### PR TITLE
[release/v7.6.6] Localized file check-in by OneLocBuild Task: Build definition ID 13420: Build ID 2674492

### DIFF
--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/cs/CimCmdletStrings.cs.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/cs/CimCmdletStrings.cs.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>Operace{0} byla dokončena.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Vytvořit CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Odstranit CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Vytvořit výčet přidružených instancí CimInstances</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Výčet CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Výčet CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>Získat CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>Získat CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Vyvolat CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>Upravit CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Dotaz na CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>Přihlásit k odběru CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Proveďte operaci {0} s následujícími parametry: {1}.</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>Parametr {0} nelze použít společně s parametrem {1}.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Nepodařilo se najít objekt CimSession s hodnotou {0} = {1}.</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>V zadané třídě {0} se nepodařilo najít následující vlastnosti: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>Nepodařilo se změnit vlastnost {0} objektu {1}, která je jen pro čtení.</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Popis stavu platby</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Operaci nelze provést, protože cesta se zástupnými znaky {0} nebyla přeložena na soubor.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Typ ověřování {0} není bez přihlašovacích údajů platný. Bez přihlašovacích údajů jsou povoleny pouze následující typy ověřování: {1}, {2}, {3} nebo {4}.</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>Ve třídě {1} se nepodařilo najít metodu {0}.</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>Ve třídě {2} se nepodařilo najít parametr {0} v metodě {1}.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Neplatná operace. Aktuální rutina již má vytvořenou operaci.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>Argument {0} obsahuje znaky, které nejsou v parametru {1} povoleny. Zadejte platný argument a pak příkaz spusťte znovu.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Operaci nelze provést, protože cesta byla přeložena na více než jeden soubor. Tento příkaz nemůže pracovat s více soubory.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>Argument {0} nemůže mít hodnotu null.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>Objekt proxy CimSession již provádí operaci.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Soubor nejde otevřít, protože aktuální poskytovatel ({0}) nemůže otevřít soubor.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Do vstupního objektu {1} nelze přidat vlastnost {0}. Schéma třídy neobsahuje tuto vlastnost.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Název sady parametrů se nepodařilo přeložit.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/es/CimCmdletStrings.es.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/es/CimCmdletStrings.es.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>Operación "{0}" completada.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Creación de CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Eliminar CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Enumerar CimInstances asociadas</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Enumerar CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Enumerar CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>Obtener CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>Obtener CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Invocar CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>Modificar CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Instancias CimInstances de consulta</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>Suscribir CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Realice la operación "{0}" con los siguientes parámetros, "{1}".</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>El parámetro "{0}" no se puede usar con el parámetro "{1}".</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>No se pudo encontrar CimSession con el especificado {0} = {1}</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>No se encontraron las siguientes propiedades en la clase dada {0}: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>No se pudo modificar la propiedad de solo lectura "{0}" del objeto "{1}".</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Descripción del estado predeterminado.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>No se puede realizar la operación porque la ruta de acceso comodín {0} no se resolvió en un archivo.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>El tipo de autenticación "{0}" no es válido sin credenciales. Solo se permiten los siguientes tipos de autenticación sin credenciales, "{1}", "{2}", "{3}" o "{4}".</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>No se encuentra el método "{0}" en la clase "{1}".</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>No se encuentra el parámetro "{0}" en el método "{1}" de la clase "{2}".</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Operación no válida. El cmdlet actual ya tiene una operación creada.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>El argumento "{0}" contiene caracteres no permitidos en el parámetro "{1}". Proporcione un argumento que sea válido e intente el comando de nuevo.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>No se puede realizar la operación porque la ruta de acceso se resolvió en más de un archivo. Este comando no puede funcionar en varios archivos.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>El argumento "{0}" no puede ser null.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>El objeto proxy CimSession ya tiene una operación en curso.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>No se puede abrir el archivo porque el proveedor actual ({0}) no puede abrir un archivo.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>No se puede agregar la propiedad "{0}" al objeto de entrada "{1}". El esquema de clase no contiene la propiedad.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>No se puede resolver el nombre del conjunto de parámetros.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/fr/CimCmdletStrings.fr.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/fr/CimCmdletStrings.fr.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>L’opération « {0} » est effectuée.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Créer une CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Supprimer une CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Énumérer les CimInstances associées</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Énumérer les CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Énumérer les CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>Obtenir CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>Obtenir CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Appeler CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
     <value>Modify CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Interroger les CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>S’abonner à une CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Exécutez l’opération « {0} » avec les paramètres suivants : « {1} ».</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>Le paramètre « {0} » ne peut pas être utilisé avec le paramètre « {1} ».</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Nous ne pouvons pas trouver CimSession avec le {0} = {1} donné</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>Nous n’avons pas pu trouver les propriétés suivantes dans la classe donnée {0} : {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>Nous n’avons pas pu modifier la propriété en lecture seule « {0} » de l’objet « {1} ».</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Description de l’état par défaut.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Nous ne pouvons pas effectuer l’opération, car le chemin d’accès contenant des caractères génériques {0} n’a pas été résolu en un fichier.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Le type d’authentification « {0} » n’est pas valide sans informations d’identification. Seuls les types d’authentification suivants sont autorisés sans informations d’identification : « {1} », « {2} », « {3} » ou « {4} ».</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>Nous ne pouvons pas trouver la méthode « {0} » dans la classe « {1} ».</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>Nous ne pouvons pas trouver le paramètre « {0} » dans la méthode « {1} » de la classe « {2} ».</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Opération non valide. Une opération a déjà été créée pour la cmdlet actuelle.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>L’argument « {0} » contient des caractères qui ne sont pas autorisés dans le paramètre « {1} ». Indiquez un argument valide, puis réexécutez la commande.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Nous ne pouvons pas effectuer l’opération, car le chemin d’accès a été résolu en plusieurs fichiers. Cette commande ne peut pas s’exécuter sur plusieurs fichiers.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>L’argument « {0} » ne peut pas avoir une valeur nulle.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>Un objet proxy CimSession a déjà une opération en cours.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Nous ne pouvons ouvrir aucun fichier, car le fournisseur actuel ({0}) ne peut pas les ouvrir.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Nous ne pouvons pas ajouter la propriété « {0} » à l’objet d’entrée « {1} ». Le schéma de classe ne contient pas la propriété.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Nous ne pouvons pas résoudre le nom du jeu de paramètres.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/it/CimCmdletStrings.it.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/it/CimCmdletStrings.it.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>Operazione ''{0}'' completata.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Crea CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Eliminare CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Enumerare CimInstance associate</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Enumerare CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Enumera CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>Ottenere CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>Ottenere CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Richiama CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>Modifica CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Chiedi a CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>Sottoscrivi CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Eseguire l'operazione ''{0}'' con i parametri seguenti, ''{1}''.</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>Non è possibile utilizzare il parametro ''{0}'' con il parametro ''{1}''.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Non è possibile trovare CimSession con il {0} specificato = {1}</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>Non è possibile trovare le proprietà seguenti nella classe specificata {0}: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>Non è possibile modificare la proprietà di sola lettura ''{0}'' dell'oggetto ''{1}''.</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Descrizione dello stato predefinito.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Non è possibile eseguire l'operazione perché il percorso con caratteri jolly {0} non si è risolto in un file.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Il tipo di autenticazione ''{0}'' non è valido senza credenziali. Sono consentiti solo i tipi di autenticazione seguenti senza credenziali, ''{1}'', ''{2}'', ''{3}'' o ''{4}''.</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>Non è possibile trovare il metodo ''{0}'' nella classe ''{1}''.</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>Non è possibile trovare il parametro ''{0}'' nel metodo ''{1}'' della classe ''{2}''.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Operazione non valida. Per il cmdlet corrente è già stata creata un'operazione.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>L'argomento ''{0}'' contiene caratteri non consentiti nel parametro ''{1}''. Specificare un argomento valido, quindi riprovare.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Non è possibile eseguire l'operazione perché il percorso è stato risolto in più di un file. Questo comando non può operare su più file.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>L'argomento ''{0}'' non può essere Null.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>L'oggetto proxy CimSession ha già un'operazione in corso.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Non è possibile aprire il file perché il provider corrente ({0}) non riesce ad aprire un file.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Non è possibile aggiungere la proprietà ''{0}'' all'oggetto di input ''{1}''. Lo schema della classe non contiene la proprietà.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Non è possibile risolvere il nome del set di parametri.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/ja/CimCmdletStrings.ja.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/ja/CimCmdletStrings.ja.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>操作 '{0}' が完了しました。</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>CimInstance の作成</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>CimInstance の削除</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>関連付けられた CimInstance の列挙</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>CimClasses の列挙</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>CimInstance の列挙</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>CimClass の取得</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>CimInstance の取得</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>CimMethod の呼び出し</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>CimInstance の変更</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>CimInstance に対してクエリを実行</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>CimIndication のサブスクライブ</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>次のパラメーターを使用して操作 '{0}' を実行します: '{1}'。</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>パラメーター '{0}' は、パラメーター '{1}' と共に使用することはできません。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>指定された {0} = {1} の CimSession が見つかりませんでした</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>指定されたクラス {0} に次のプロパティが見つかりませんでした: {1}。</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>オブジェクト '{1}' の読み取り専用プロパティ '{0}' を変更できませんでした。</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>既定の状態の説明。</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>ワイルドカード パス {0} がファイルに解決されなかったため、操作を実行できません。</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>認証の種類 '{0}' は、資格情報がないと無効です。資格情報なしで使用できるのは次の認証の種類のみです: '{1}'、'{2}'、'{3}'、または '{4}'。</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>クラス '{1}' にメソッド '{0}' が見つかりません。</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>クラス '{2}' のメソッド '{1}' にパラメーター '{0}' が見つかりません。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>無効な操作です。現在のコマンドレットには、既に操作が作成されています。</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>引数 '{0}' には、パラメーター '{1}' で使用できない文字が含まれています。有効な引数を指定して、コマンドを再試行してください。</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>パスが複数のファイルに解決されたため、操作を実行できません。このコマンドは、複数のファイルに対して操作することはできません。</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>引数 '{0}' を null 値にすることはできません。</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>CimSession プロキシ オブジェクトでは、既に操作が処理中です。</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>現在のプロバイダー ({0}) がファイルを開くことができないため、ファイルを開けません。</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>プロパティ '{0}' を入力オブジェクト '{1}' に追加できません。クラス スキーマにプロパティが含まれていません。</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>パラメーター セット名を解決できません。</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/pl/CimCmdletStrings.pl.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/pl/CimCmdletStrings.pl.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>Operacja „{0}” została ukończona.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Utwórz wystąpienie CimInstances</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Usuń CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Wyliczanie skojarzonych elementów CimInstances</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Wylicz klasy typu CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Wyliczanie elementów CimInstance</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>Pobierz CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>Pobierz CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Wywołaj metodę CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>Modyfikacja obiektu CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Zapytanie do tabeli CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>Subskrybuj element CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Wykonaj operację „{0}” z następującymi parametrami: „{1}”.</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>Parametru „{0}” nie można użyć z parametrem „{1}”.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Nie można odnaleźć elementu CimSession o podanym parametrze {0} = {1}</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>Nie można odnaleźć następujących właściwości z danej klasy {0}: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>Nie można zmodyfikować właściwości tylko do odczytu „{0}” obiektu „{1}”.</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Opis domyślnego statusu.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Nie można wykonać operacji, ponieważ ścieżka {0} symbolu wieloznacznego nie została rozpoznana jako plik.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Typ uwierzytelniania „{0}” jest nieprawidłowy bez poświadczeń. Tylko następujący typ uwierzytelniania jest dozwolony bez poświadczeń, „{1}”, „{2}”, „{3}” lub „{4}”.</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>Nie można odnaleźć metody „{0}” w klasie „{1}”.</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>Nie można odnaleźć parametru „{0}” w metodzie „{1}” klasy „{2}”.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Nieprawidłowa operacja. Bieżące polecenie cmdlet ma już utworzoną operację.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>Argument „{0}” zawiera znaki niedozwolone w parametrze „{1}”. Podaj prawidłowy argument, a następnie spróbuj ponownie wykonać polecenie.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Nie można wykonać operacji, ponieważ ścieżka wskazuje na więcej niż jeden plik. To polecenie nie może działać na wielu plikach.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>Argument „{0}” nie może być null.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>W obiekcie proxy CimSession już trwa operacja.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Nie można otworzyć pliku, ponieważ bieżący dostawca ({0}) nie może otworzyć pliku.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Nie można dodać właściwości „{0}” do obiektu wejściowego „{1}”. Schemat klasy nie zawiera właściwości.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Nie można rozpoznać nazwy zestawu parametrów.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/ru/CimCmdletStrings.ru.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/ru/CimCmdletStrings.ru.resx
@@ -118,23 +118,23 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>Операция "{0}" завершена.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>Создать CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>Удалить CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>Перечислить связанные CimInstances</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>Перечислить CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>Перечислить CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
     <value>Get CimClass</value>
@@ -143,86 +143,86 @@
     <value>Get CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>Вызвать CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>Изменить CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>Запрос CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>Подписаться на CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>Выполните операцию "{0}" со следующими параметрами: "{1}".</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>Параметр "{0}" нельзя использовать с параметром "{1}".</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Не удалось найти CimSession с заданным условием {0} = {1}</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>Не удалось найти следующие свойства в указанном классе {0}: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>Не удалось изменить доступное только для чтения свойство "{0}" объекта "{1}".</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Описание статуса по умолчанию.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Не удается выполнить операцию, так как путь с подстановочными знаками {0} не сопоставлен с файлом.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Тип проверки подлинности "{0}" недействителен без учетных данных. Без указания учетных данных допускаются только следующие типы проверки подлинности: "{1}", "{2}", "{3}" или "{4}".</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>Не удается найти метод "{0}" в классе "{1}".</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>Не удается найти параметр "{0}" в методе "{1}" класса "{2}".</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Недействительная операция. Для текущего командлета уже создана операция.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>Аргумент "{0}" содержит символы, недопустимые в параметре "{1}". Укажите допустимый аргумент, а затем повторите выполнение команды.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Операция не может быть выполнена, так как путь указывает более чем на один файл. Эта команда не может выполняться с несколькими файлами.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>Аргумент "{0}" не может иметь значение "null".</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>Для объекта-прокси CimSession уже выполняется операция.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Не удалось открыть файл, поскольку текущий поставщик ({0}) не может открывать файлы.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Не удается добавить свойство "{0}" во входной объект "{1}". Схема класса не содержит это свойство.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Не удалось сопоставить имя набора параметров.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/tr/CimCmdletStrings.tr.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/tr/CimCmdletStrings.tr.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>İşlem '{0}' tamamlandı.</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>CimInstance Oluştur</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>CimInstance'ı Sil</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>İlişkili CimInstance'ları Numaralandır</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>CimClass'ları Numaralandır</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>CimInstance'ları Numaralandır</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>CimClass'ı Al</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>CimInstance'ı Al</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>CimMethod Çağır</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>CimInstance'ı Değiştir</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>CimInstance'ları Sorgula</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>CimIndication'a Abone Ol</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>'{0}' işlemini aşağıdaki parametrelerle gerçekleştirin: '{1}'.</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>'{0}' parametresi, '{1}' parametresiyle kullanılamaz.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>Verilen {0} = {1} için CimSession bulunamadı</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>Verilen {0} sınıfında aşağıdaki özellikler bulunamadı: {1}.</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>'{1}' nesnesinin salt okunur özelliği '{0}' değiştirilemedi.</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>Varsayılan durum açıklaması.</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Joker karakter yolu {0} bir dosyaya çözümlenemediği için işlem gerçekleştirilemiyor.</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>Kimlik bilgisi olmadan '{0}' kimlik doğrulama türü geçersizdir. Kimlik bilgisi olmadan yalnızca '{1}', '{2}', '{3}' veya '{4}' kimlik doğrulama türlerine izin verilir.</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>'{1}' sınıfında '{0}' yöntemi bulunamadı.</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>'{2}' sınıfının '{1}' yönteminde '{0}' parametresi bulunamadı.</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>Geçersiz işlem. Geçerli cmdlet için zaten bir işlem oluşturulmuş.</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>'{0}' bağımsız değişkeni, '{1}' parametresinde izin verilmeyen karakterler içeriyor. Geçerli bir bağımsız değişken girin ve sonra komutu yeniden deneyin.</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Yol birden fazla dosyaya çözümlendiği için işlem gerçekleştirilemiyor. Bu komut birden fazla dosya üzerinde çalışamaz.</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>Bağımsız değişken '{0}' null olamaz.</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>CimSession ara sunucu nesnesinde zaten devam eden bir işlem var.</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Geçerli sağlayıcı ({0}) bir dosya açamadığı için dosya açılamıyor.</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>Giriş nesnesi '{1}' için '{0}' özelliği eklenemedi. Sınıf şeması özelliği içermiyor.</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>Parametre kümesi adı çözümlenemedi.</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/zh-Hans/CimCmdletStrings.zh-Hans.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/zh-Hans/CimCmdletStrings.zh-Hans.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>操作 '{0}' 完成。</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>创建 CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>删除 CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>枚举关联的 CimInstances</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>枚举 CimClass</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>枚举 CimInstance</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>获取 CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>获取 CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>调用 CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>修改 CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>查询 CimInstance</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>订阅 CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>使用以下参数执行操作 '{0}'，'{1}'。</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>参数“{0}”不能与参数“{1}”一起使用。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>找不到具有给定 {0} = {1}的 CimSession</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>无法从给定类 {0}中找到以下属性： {1}。</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>无法修改对象 '{0}' 的只读属性 '{1}'。</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>默认状态说明。</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>无法执行操作，因为通配符路径 {0} 未解析为文件。</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>如果没有凭据，身份验证类型 '{0}' 无效。没有凭据时，仅允许以下身份验证类型：'{1}'、'{2}'、'{3}' 或 '{4}'。</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>无法在类“{0}”中找到方法“{1}”。</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>在类 '{0}' 的方法 '{1}' 中找不到参数 '{2}'。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>无效的操作。当前 cmdlet 已有正在创建的操作。</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>参数 '{0}' 包含参数 '{1}' 中不允许的字符。提供有效的参数，然后重试该命令。</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>无法执行操作，因为路径解析为多个文件。此命令无法对多个文件执行操作。</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>参数 “{0}” 不能为 null。</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>CimSession 代理对象已在执行操作。</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>无法打开文件，因为当前提供程序({0})无法打开文件。</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>无法将属性 '{0}' 添加到输入对象 '{1}'。类架构不包含该属性。</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>无法解析参数集名称。</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/zh-Hant/CimCmdletStrings.zh-Hant.resx
+++ b/src/Microsoft.Management.Infrastructure.CimCmdlets/resources/zh-Hant/CimCmdletStrings.zh-Hant.resx
@@ -118,111 +118,111 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimOperationCompleted" xml:space="preserve">
-    <value>Operation '{0}' complete.</value>
+    <value>已完成作業 '{0}'。</value>
     <comment>{0} is a placeholder for operation name. (i.e, GetCimInstance)</comment>
   </data>
   <data name="CimOperationNameCreateInstance" xml:space="preserve">
-    <value>Create CimInstance</value>
+    <value>建立 CimInstance</value>
   </data>
   <data name="CimOperationNameDeleteInstance" xml:space="preserve">
-    <value>Delete CimInstance</value>
+    <value>刪除 CimInstance</value>
   </data>
   <data name="CimOperationNameEnumerateAssociatedInstances" xml:space="preserve">
-    <value>Enumerate Associated CimInstances</value>
+    <value>列舉關聯的 CimInstances</value>
   </data>
   <data name="CimOperationNameEnumerateClasses" xml:space="preserve">
-    <value>Enumerate CimClasses</value>
+    <value>列舉 CimClasses</value>
   </data>
   <data name="CimOperationNameEnumerateInstances" xml:space="preserve">
-    <value>Enumerate CimInstances</value>
+    <value>列舉 CimInstances</value>
   </data>
   <data name="CimOperationNameGetClass" xml:space="preserve">
-    <value>Get CimClass</value>
+    <value>取得 CimClass</value>
   </data>
   <data name="CimOperationNameGetInstance" xml:space="preserve">
-    <value>Get CimInstance</value>
+    <value>取得 CimInstance</value>
   </data>
   <data name="CimOperationNameInvokeMethod" xml:space="preserve">
-    <value>Invoke CimMethod</value>
+    <value>叫用 CimMethod</value>
   </data>
   <data name="CimOperationNameModifyInstance" xml:space="preserve">
-    <value>Modify CimInstance</value>
+    <value>修改 CimInstance</value>
   </data>
   <data name="CimOperationNameQueryInstances" xml:space="preserve">
-    <value>Query CimInstances</value>
+    <value>查詢 CimInstances</value>
   </data>
   <data name="CimOperationNameSubscribeIndication" xml:space="preserve">
-    <value>Subscribe CimIndication</value>
+    <value>訂閱 CimIndication</value>
   </data>
   <data name="CimOperationStart" xml:space="preserve">
-    <value>Perform operation '{0}' with following parameters, '{1}'.</value>
+    <value>使用下列參數執行作業 '{0}': '{1}'。</value>
     <comment>{0} is a placeholder for operation name; {1} is a placeholder for parameters value</comment>
   </data>
   <data name="ConflictParameterWasSet" xml:space="preserve">
-    <value>Parameter '{0}' cannot be used with the parameter '{1}'.</value>
+    <value>參數 '{0}' 不可搭配參數 '{1}' 使用。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for another parameter name;</comment>
   </data>
   <data name="CouldNotFindCimsessionObject" xml:space="preserve">
-    <value>Could not find CimSession with the given {0} = {1}</value>
+    <value>找不到具有指定 {0} = {1} 的 CimSession</value>
     <comment>{0} is a placeholder for property name; {1} is a placeholder for property value.</comment>
   </data>
   <data name="CouldNotFindPropertyFromGivenClass" xml:space="preserve">
-    <value>Could not find the following properties from the given class {0}: {1}.</value>
+    <value>在指定的類別 {0} 中找不到下列屬性: {1}。</value>
     <comment>{0} is a placeholder for class name; {1} is a placeholder for list of property names.</comment>
   </data>
   <data name="CouldNotModifyReadonlyProperty" xml:space="preserve">
-    <value>Could not modify readonly property '{0}' of object '{1}'.</value>
+    <value>無法修改物件 '{1}' 的唯讀屬性 '{0}'。</value>
     <comment>{0} is a placeholder for propertyname; {1} is a placeholder for object string.</comment>
   </data>
   <data name="DefaultStatusDescription" xml:space="preserve">
-    <value>Default status description.</value>
+    <value>預設狀態描述。</value>
     <comment>N/A</comment>
   </data>
   <data name="DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>因為萬用字元路徑 {0} 未解析為檔案，所以無法執行作業。</value>
     <comment>{0} is a placeholder for a path</comment>
   </data>
   <data name="InvalidAuthenticationTypeWithNullCredential" xml:space="preserve">
-    <value>Authentication type '{0}' is invalid without credential. Only following authentication type are allowed without credential, '{1}', '{2}', '{3}', or '{4}'.</value>
+    <value>沒有認證時，驗證類型 '{0}' 無效。僅以下驗證類型允許在沒有認證的情況下使用: '{1}'、'{2}'、'{3}' 或 '{4}'。</value>
     <comment>{0} is a placeholder for authentication type. {1}-{4} are placeholders for authentication types.</comment>
   </data>
   <data name="InvalidMethod" xml:space="preserve">
-    <value>Can not find method '{0}' in class '{1}'.</value>
+    <value>在類別 '{1}' 中找不到方法 '{0}'。</value>
     <comment>{0} is a placeholder for method name. {1} is a placeholders for class name.</comment>
   </data>
   <data name="InvalidMethodParameter" xml:space="preserve">
-    <value>Can not find Parameter '{0}' in method '{1}' of class '{2}'.</value>
+    <value>在類別 '{2}' 的方法 '{1}' 中找不到參數 '{0}'。</value>
     <comment>{0} is a placeholder for parameter name; {1} is a placeholder for method name; {2} is a placeholder for class name.</comment>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Invalid operation. Current cmdlet already have operation created.</value>
+    <value>作業無效。目前的 Cmdlet 已建立作業。</value>
     <comment>N/A</comment>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>Argument '{0}' contains characters that are not allowed in parameter '{1}'. Supply an argument that is valid and then try the command again.</value>
+    <value>引數 '{0}' 包含參數 '{1}' 中不允許的字元。請提供有效類型的引數，然後再次嘗試執行命令。</value>
     <comment>{0} stand for argument value, {1} stand for parameter name.</comment>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>因為路徑已解析為多個檔案，所以無法執行作業。此命令無法針對多個檔案執行。</value>
   </data>
   <data name="NullArgument" xml:space="preserve">
-    <value>Argument '{0}' can not be null.</value>
+    <value>引數 '{0}' 不可為 null。</value>
     <comment>N/A</comment>
   </data>
   <data name="OperationInProgress" xml:space="preserve">
-    <value>CimSession proxy object already have operation in progress.</value>
+    <value>CimSession Proxy 物件已有進行中的作業。</value>
     <comment>N/A</comment>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>因為目前的提供者 ({0}) 無法開啟檔案，所以無法開啟檔案。</value>
     <comment>{0} is a placeholder for PowerShell filesystem-like provider name (i.e. registry provider)</comment>
   </data>
   <data name="UnableToAddPropertyToInstance" xml:space="preserve">
-    <value>Unable to add property '{0}' to input object '{1}'. The class schema does not contain the property.</value>
+    <value>無法將屬性 '{0}' 新增至輸入物件 '{1}'。類別結構描述不包含屬性。</value>
     <comment>{0} stand for property name, {1} stand for cim instance path.</comment>
   </data>
   <data name="UnableToResolveParameterSetName" xml:space="preserve">
-    <value>Unable to resolve the parameter set name.</value>
+    <value>無法解析參數集名稱。</value>
     <comment>N/A</comment>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/cs/public.GraphicalHostResources.cs.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/cs/public.GraphicalHostResources.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="OutGridViewWindowObjectName" xml:space="preserve">
-    <value>OutGridViewWindow Object</value>
+    <value>Objekt OutGridViewWindow</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/cs/public.HelpWindowResources.cs.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/cs/public.HelpWindowResources.cs.resx
@@ -121,7 +121,7 @@
     <value>Zrušit</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Rozlišovat malá a velká písmena</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,64 +131,64 @@
     <value>Popis</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Příklady</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Najít:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Oddíly nápovědy</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>Nápověda pro {0}</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Vstupy</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Metody</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Další</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Nenašly se žádné shody</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Poznámky</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 shoda</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Výstupy</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Jsou podporovány zástupné znaky?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Výchozí hodnota</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Přijmout vstup z kanálu?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>Pozice?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Požadováno?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Parametry</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Předchozí</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Vlastnosti</value>
@@ -197,34 +197,34 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Poznámky</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Možnosti hledání</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Nastavení</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>Počet shod: {0}</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>Synopse</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Syntaxe</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Nápověda pro {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Celá slova</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
-    <value>{0}%</value>
+    <value>{0} %</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
-    <value>Zoom</value>
+    <value>Přiblížit</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/cs/public.ShowCommandResources.cs.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/cs/public.ShowCommandResources.cs.resx
@@ -118,41 +118,41 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActionButtons_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Zrušit</value>
   </data>
   <data name="ActionButtons_Button_Copy" xml:space="preserve">
-    <value>Co_py</value>
+    <value>Ko_pírovat</value>
   </data>
   <data name="ActionButtons_Button_Run" xml:space="preserve">
-    <value>_Run</value>
+    <value>_Spustit</value>
   </data>
   <data name="All" xml:space="preserve">
     <value>Vše</value>
   </data>
   <data name="AllModulesControl_Label_Modules" xml:space="preserve">
-    <value>Modules:</value>
+    <value>Moduly:</value>
   </data>
   <data name="CmdletControl_Button_GetHelp" xml:space="preserve">
     <value> ? </value>
   </data>
   <data name="CmdletControl_Button_ToolTip_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Nápověda</value>
   </data>
   <data name="CmdletControl_Header_CommonParameters" xml:space="preserve">
-    <value>Common Parameters</value>
+    <value>Společné parametry</value>
   </data>
   <data name="CmdletControl_Header_Errors" xml:space="preserve">
-    <value>Errors</value>
+    <value>Chyby</value>
   </data>
   <data name="DetailsParameterTitleFormat" xml:space="preserve">
-    <value>Parameters for "{0}":</value>
+    <value>Parametry pro {0}:</value>
   </data>
   <data name="CmdletTooltipFormat" xml:space="preserve">
-    <value>Name: {0}
-Module: {1} ({2})</value>
+    <value>Název: {0}
+Modul: {1} ({2})</value>
   </data>
   <data name="EndProcessingErrorMessage" xml:space="preserve">
-    <value>The following errors occurred running the command:
+    <value>Při spuštění příkazu došlo k následujícím chybám:
 {0}</value>
   </data>
   <data name="MandatoryLabelSegment" xml:space="preserve">
@@ -168,7 +168,7 @@ Module: {1} ({2})</value>
     <comment>This is a label for a control, hence the colon. {0} is a parameter name</comment>
   </data>
   <data name="ShowModuleControl_Label_Name" xml:space="preserve">
-    <value>Name:</value>
+    <value>Název:</value>
   </data>
   <data name="ActionButtons_Button_Ok" xml:space="preserve">
     <value>OK</value>
@@ -177,22 +177,22 @@ Module: {1} ({2})</value>
     <value>...</value>
   </data>
   <data name="CommandNameAutomationName" xml:space="preserve">
-    <value>Command Name</value>
+    <value>Název příkazu</value>
   </data>
   <data name="ModulesAutomationName" xml:space="preserve">
-    <value>Modules</value>
+    <value>Moduly</value>
   </data>
   <data name="NoModuleName" xml:space="preserve">
-    <value>&lt;No module name&gt;</value>
+    <value>&lt;Žádný název modulu&gt;</value>
   </data>
   <data name="SelectMultipleValuesForParameterFormat" xml:space="preserve">
-    <value>Select multiple values for "{0}"</value>
+    <value>Vyberte více hodnot pro {0}.</value>
   </data>
   <data name="CanReceiveValueFromPipeline" xml:space="preserve">
-    <value>Can receive value from pipeline</value>
+    <value>Může přijímat hodnotu z kanálu</value>
   </data>
   <data name="CommonToAllParameterSets" xml:space="preserve">
-    <value>Common to all parameter sets</value>
+    <value>Společné pro všechny sady parametrů</value>
   </data>
   <data name="Mandatory" xml:space="preserve">
     <value>Povinné</value>
@@ -201,39 +201,39 @@ Module: {1} ({2})</value>
     <value>Volitelné</value>
   </data>
   <data name="PositionFormat" xml:space="preserve">
-    <value>Position: {0}</value>
+    <value>Pozice: {0}</value>
   </data>
   <data name="TypeFormat" xml:space="preserve">
-    <value>Type: {0}</value>
+    <value>Typ: {0}</value>
   </data>
   <data name="Imported" xml:space="preserve">
-    <value>Imported</value>
+    <value>Importováno</value>
   </data>
   <data name="NotImported" xml:space="preserve">
-    <value>Not Imported</value>
+    <value>Nenaimportováno</value>
   </data>
   <data name="ImportModuleButtonText" xml:space="preserve">
-    <value>Show Details</value>
+    <value>Zobrazit podrobnosti</value>
   </data>
   <data name="ImportModuleFailedFormat" xml:space="preserve">
-    <value>Failed to import the module required by command "{0}". Module name: "{1}". Error message: "{2}".</value>
+    <value>Nepodařilo se naimportovat modul požadovaný příkazem {0}. Název modulu: {1} Chybová zpráva: „{2}“.</value>
   </data>
   <data name="NotImportedFormat" xml:space="preserve">
-    <value>To import the "{0}" module and its cmdlets, including "{1}", click {2}.</value>
+    <value>Chcete-li importovat modul {0} a jeho rutiny, včetně {1}, klikněte na {2}.</value>
   </data>
   <data name="ShowCommandError" xml:space="preserve">
-    <value>Show Command - Error</value>
+    <value>Zobrazit příkaz – chyba</value>
   </data>
   <data name="PleaseWaitMessage" xml:space="preserve">
-    <value>Please Wait...</value>
+    <value>Počkejte prosím...</value>
   </data>
   <data name="ShowModuleControl_RefreshButton" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Aktualizovat</value>
   </data>
   <data name="NoParameters" xml:space="preserve">
-    <value>There are no parameters.</value>
+    <value>Neexistují žádné parametry.</value>
   </data>
   <data name="RefreshShowCommandTooltipFormat" xml:space="preserve">
-    <value>Click after using "{0}" to see the new commands</value>
+    <value>Po použití {0} kliknutím zobrazte nové příkazy.</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/de/public.HelpWindowResources.de.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/de/public.HelpWindowResources.de.resx
@@ -121,7 +121,7 @@
     <value>Abbrechen</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Groß-/Kleinschreibung beachten</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,64 +131,64 @@
     <value>Beschreibung</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Beispiele</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Suchen:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Hilfeabschnitte</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>Hilfe zu {0}</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Eingaben</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Methoden</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Weiter</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Keine Übereinstimmungen gefunden</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Notizen</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 Übereinstimmung</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Ausgaben</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Platzhalterzeichen akzeptieren?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Standardwert</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Pipelineeingabe akzeptieren?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
     <value>Position?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Erforderlich?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Parameter</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Zurück</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Eigenschaften</value>
@@ -197,16 +197,16 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Hinweise</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Suchoptionen</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Einstellungen</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} Übereinstimmungen</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
     <value>Synopsis</value>
@@ -215,14 +215,14 @@
     <value>Syntax</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Hilfe für {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Ganzes Wort</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
-    <value>{0}%</value>
+    <value>{0} %</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
     <value>Zoom</value>

--- a/src/Microsoft.Management.UI.Internal/resources/es/public.HelpWindowResources.es.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/es/public.HelpWindowResources.es.resx
@@ -121,7 +121,7 @@
     <value>Cancelar</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Coincidir mayúsculas y minúsculas</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,64 +131,64 @@
     <value>Descripción</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Ejemplos</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Buscar:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Secciones de ayuda</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>{0} Ayuda </value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Entradas</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Métodos</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Siguiente</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>No se encontraron coincidencias</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Notas</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>Aceptar</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 coincidencia</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Salidas</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>¿Aceptar caracteres comodín?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Valor predeterminado</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>¿Aceptar la entrada de la canalización?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>¿Posición?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>¿Obligatorio?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Parámetros</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Anterior</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Propiedades</value>
@@ -197,32 +197,32 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Comentarios</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Opciones de búsqueda</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Configuración</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} coincidencias</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>Sinopsis</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Sintaxis</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Ayuda para {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Palabra completa</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
-    <value>{0}%</value>
+    <value>{0} %</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
     <value>Zoom</value>

--- a/src/Microsoft.Management.UI.Internal/resources/es/public.ShowCommandResources.es.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/es/public.ShowCommandResources.es.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActionButtons_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Cancelar</value>
   </data>
   <data name="ActionButtons_Button_Copy" xml:space="preserve">
-    <value>Co_py</value>
+    <value>Co_piar</value>
   </data>
   <data name="ActionButtons_Button_Run" xml:space="preserve">
     <value>_Run</value>
@@ -130,29 +130,29 @@
     <value>Todas</value>
   </data>
   <data name="AllModulesControl_Label_Modules" xml:space="preserve">
-    <value>Modules:</value>
+    <value>Módulos:</value>
   </data>
   <data name="CmdletControl_Button_GetHelp" xml:space="preserve">
     <value> ? </value>
   </data>
   <data name="CmdletControl_Button_ToolTip_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Ayuda</value>
   </data>
   <data name="CmdletControl_Header_CommonParameters" xml:space="preserve">
-    <value>Common Parameters</value>
+    <value>Parámetros comunes</value>
   </data>
   <data name="CmdletControl_Header_Errors" xml:space="preserve">
-    <value>Errors</value>
+    <value>Errores</value>
   </data>
   <data name="DetailsParameterTitleFormat" xml:space="preserve">
-    <value>Parameters for "{0}":</value>
+    <value>Parámetros para "{0}":</value>
   </data>
   <data name="CmdletTooltipFormat" xml:space="preserve">
-    <value>Name: {0}
-Module: {1} ({2})</value>
+    <value>Nombre: {0}
+Módulo: {1} ({2})</value>
   </data>
   <data name="EndProcessingErrorMessage" xml:space="preserve">
-    <value>The following errors occurred running the command:
+    <value>Se produjeron los siguientes errores al ejecutar el comando:
 {0}</value>
   </data>
   <data name="MandatoryLabelSegment" xml:space="preserve">
@@ -168,31 +168,31 @@ Module: {1} ({2})</value>
     <comment>This is a label for a control, hence the colon. {0} is a parameter name</comment>
   </data>
   <data name="ShowModuleControl_Label_Name" xml:space="preserve">
-    <value>Name:</value>
+    <value>Nombre:</value>
   </data>
   <data name="ActionButtons_Button_Ok" xml:space="preserve">
-    <value>OK</value>
+    <value>Aceptar</value>
   </data>
   <data name="MultiParameter_Button_Browse" xml:space="preserve">
     <value>...</value>
   </data>
   <data name="CommandNameAutomationName" xml:space="preserve">
-    <value>Command Name</value>
+    <value>Nombre de comando</value>
   </data>
   <data name="ModulesAutomationName" xml:space="preserve">
-    <value>Modules</value>
+    <value>Módulos</value>
   </data>
   <data name="NoModuleName" xml:space="preserve">
-    <value>&lt;No module name&gt;</value>
+    <value>&lt;No hay nombre de módulo&gt;</value>
   </data>
   <data name="SelectMultipleValuesForParameterFormat" xml:space="preserve">
-    <value>Select multiple values for "{0}"</value>
+    <value>Seleccionar varios valores para "{0}"</value>
   </data>
   <data name="CanReceiveValueFromPipeline" xml:space="preserve">
-    <value>Can receive value from pipeline</value>
+    <value>Puede recibir valor de la canalización</value>
   </data>
   <data name="CommonToAllParameterSets" xml:space="preserve">
-    <value>Common to all parameter sets</value>
+    <value>Común a todos los conjuntos de parámetros</value>
   </data>
   <data name="Mandatory" xml:space="preserve">
     <value>Obligatorio</value>
@@ -201,39 +201,39 @@ Module: {1} ({2})</value>
     <value>Opcional</value>
   </data>
   <data name="PositionFormat" xml:space="preserve">
-    <value>Position: {0}</value>
+    <value>Posición: {0}</value>
   </data>
   <data name="TypeFormat" xml:space="preserve">
-    <value>Type: {0}</value>
+    <value>Tipo: {0}</value>
   </data>
   <data name="Imported" xml:space="preserve">
-    <value>Imported</value>
+    <value>Importado</value>
   </data>
   <data name="NotImported" xml:space="preserve">
-    <value>Not Imported</value>
+    <value>Sin importar</value>
   </data>
   <data name="ImportModuleButtonText" xml:space="preserve">
-    <value>Show Details</value>
+    <value>Mostrar detalles</value>
   </data>
   <data name="ImportModuleFailedFormat" xml:space="preserve">
-    <value>Failed to import the module required by command "{0}". Module name: "{1}". Error message: "{2}".</value>
+    <value>No se pudo importar el módulo requerido por el comando "{0}". Nombre del módulo: "{1}". Mensaje de error: "{2}".</value>
   </data>
   <data name="NotImportedFormat" xml:space="preserve">
-    <value>To import the "{0}" module and its cmdlets, including "{1}", click {2}.</value>
+    <value>Para importar el módulo "{0}" y sus cmdlets, incluido "{1}", haga clic en {2}.</value>
   </data>
   <data name="ShowCommandError" xml:space="preserve">
-    <value>Show Command - Error</value>
+    <value>Mostrar comando: error</value>
   </data>
   <data name="PleaseWaitMessage" xml:space="preserve">
-    <value>Please Wait...</value>
+    <value>Espere...</value>
   </data>
   <data name="ShowModuleControl_RefreshButton" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Actualizar</value>
   </data>
   <data name="NoParameters" xml:space="preserve">
-    <value>There are no parameters.</value>
+    <value>No hay ningún parámetro.</value>
   </data>
   <data name="RefreshShowCommandTooltipFormat" xml:space="preserve">
-    <value>Click after using "{0}" to see the new commands</value>
+    <value>Haga clic después de usar "{0}" para ver los nuevos comandos</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/fr/public.HelpWindowResources.fr.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/fr/public.HelpWindowResources.fr.resx
@@ -121,7 +121,7 @@
     <value>Annuler</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Respecter la casse</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,31 +131,31 @@
     <value>Description</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Exemples</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Rechercher :</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Sections d’aide</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>Aide de {0}</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Entrées</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Méthodes</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Suivant</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Aucune correspondance n’a été trouvée</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
     <value>Notes</value>
@@ -164,31 +164,31 @@
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 correspondance</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Sorties</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Accepter les caractères génériques ?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Valeur par défaut</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Accepter l'entrée de pipeline ?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>Position ?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Obligatoire ?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Paramètres</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Précédent</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Propriétés</value>
@@ -197,32 +197,32 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Remarques</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Options de recherche</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Paramètres</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} correspondances</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
     <value>Synopsis</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Syntaxe</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Aide pour {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Mot entier</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
-    <value>{0}%</value>
+    <value>{0} %</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
     <value>Zoom</value>

--- a/src/Microsoft.Management.UI.Internal/resources/it/public.HelpWindowResources.it.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/it/public.HelpWindowResources.it.resx
@@ -121,7 +121,7 @@
     <value>Annulla</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Corrispondenza maiuscole/minuscole</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,95 +131,95 @@
     <value>Descrizione</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Esempi</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Trova:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Sezioni della Guida</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>Guida di {0}</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Input</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Metodi</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Avanti</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Nessuna corrispondenza trovata</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Note</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 corrispondenza</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Output</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Accettare caratteri jolly?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Valore predefinito</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Accettare input da pipeline?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>Posizione?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Obbligatorio?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Parametri</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Precedente</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Proprietà</value>
   </data>
   <data name="RelatedLinksTitle" xml:space="preserve">
-    <value>RelatedLinks</value>
+    <value>Collegamenti correlati</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Note</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Opzioni di ricerca</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Impostazioni</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} corrispondenze</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>Sinossi</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Sintassi</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Guida per {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Parola intera</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
     <value>{0}%</value>

--- a/src/Microsoft.Management.UI.Internal/resources/ja/public.HelpWindowResources.ja.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/ja/public.HelpWindowResources.ja.resx
@@ -121,7 +121,7 @@
     <value>キャンセル</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>大文字と小文字を区別</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,64 +131,64 @@
     <value>説明</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>例</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>検索(_F):</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>ヘルプ セクション</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>{0} ヘルプ</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>入力</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>メソッド</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>次へ(_N)</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>一致するものが見つかりません</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>注意</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 件の一致</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>出力</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>ワイルドカード文字の受け入れ?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>既定値</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>パイプライン入力の受け入れ?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>位置?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>必須?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>パラメーター</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>前へ(_P)</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>プロパティ</value>
@@ -197,34 +197,34 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>注釈</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>検索オプション</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>設定</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} 件の一致</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>概要</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>構文</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>{0} のヘルプ</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>単語全体</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
     <value>{0}%</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
-    <value>Zoom</value>
+    <value>ズーム</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/ko/public.InvariantResources.ko.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/ko/public.InvariantResources.ko.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotModified" xml:space="preserve">
-    <value>{0} cannot be modified directly, use {1} instead.</value>
+    <value>{0}은(는) 직접 수정할 수 없습니다. 대신 {1}을(를) 사용하세요.</value>
   </data>
   <data name="Columns" xml:space="preserve">
     <value>열</value>
@@ -140,9 +140,9 @@
     <comment>The format string that is used by the InnerList in the case where a whole number type is used. The {0} will be the column value.</comment>
   </data>
   <data name="NotSupportAddingToItems" xml:space="preserve">
-    <value>{0} does not support adding to the Items collection, use {1} instead.</value>
+    <value>{0}은(는) 항목 컬렉션에 대한 추가를 지원하지 않습니다. 대신 {1}을(를) 사용하세요.</value>
   </data>
   <data name="ViewSetWithType" xml:space="preserve">
-    <value>If View is set to a {0}, it should have the type {1}.</value>
+    <value>보기가 {0}(으)로 설정된 경우 {1} 유형이어야 합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/ko/public.XamlLocalizableResources.ko.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/ko/public.XamlLocalizableResources.ko.resx
@@ -118,66 +118,66 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AutoResXGen_ColumnPicker_AutomationPropertiesName_49" xml:space="preserve">
-    <value>Available Columns</value>
+    <value>사용 가능한 열</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_AutomationPropertiesName_75" xml:space="preserve">
-    <value>Add</value>
+    <value>추가</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_AutomationPropertiesName_86" xml:space="preserve">
-    <value>Remove</value>
+    <value>제거</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_AutomationPropertiesName_104" xml:space="preserve">
-    <value>Selected Columns</value>
+    <value>선택한 열</value>
   </data>
   <data name="AutoResXGen_BackForwardHistory_AutomationPropertiesName_613" xml:space="preserve">
-    <value>Back</value>
+    <value>뒤로</value>
     <comment>Localizable AutomationName for control that is used by accessibility screen readers.</comment>
   </data>
   <data name="AutoResXGen_BackForwardHistory_AutomationPropertiesName_619" xml:space="preserve">
-    <value>Forward</value>
+    <value>전달</value>
     <comment>Localizable AutomationName for control that is used by accessibility screen readers.</comment>
   </data>
   <data name="AutoResXGen_BreadcrumbItem_Text_144" xml:space="preserve">
-    <value>Find in this column</value>
+    <value>이 열에서 찾기</value>
     <comment>Background text shown in the search box.</comment>
   </data>
   <data name="AutoResXGen_DesignerStyleResources_Tooltip_148" xml:space="preserve">
-    <value>Expand</value>
+    <value>펼치기</value>
   </data>
   <data name="AutoResXGen_ListOrganizer_AutomationPropertiesName_95" xml:space="preserve">
-    <value>Name</value>
+    <value>이름</value>
   </data>
   <data name="AutoResXGen_ManagementList_Text_602" xml:space="preserve">
-    <value>New Query</value>
+    <value>새 쿼리</value>
   </data>
   <data name="AutoResXGen_TaskPane_Text_74" xml:space="preserve">
-    <value>Tasks</value>
+    <value>작업</value>
     <comment>This is the title string for the Task Pane.</comment>
   </data>
   <data name="AutoResXGen_Tile_AutomationPropertiesName_674" xml:space="preserve">
-    <value>Tasks</value>
+    <value>작업</value>
     <comment>AutomationProperties.Name of a SeparatedList.</comment>
   </data>
   <data name="AutoResXGen_WaitingRing_AutomationPropertiesName_74" xml:space="preserve">
-    <value>Indeterminate Progress Icon</value>
+    <value>확정되지 않은 진행률 아이콘</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Text_124" xml:space="preserve">
-    <value>Add criteria</value>
+    <value>조건 추가</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Text_166" xml:space="preserve">
-    <value>Overwrite the existing query or type a different name to save a new query. Each query consists of criteria, sorting, and column customizations.</value>
+    <value>기존 쿼리를 덮어쓰거나 다른 이름을 입력하여 새 쿼리를 저장하세요. 각 쿼리는 조건, 정렬, 열 사용자 지정으로 구성됩니다.</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Content_186" xml:space="preserve">
-    <value>Ok</value>
+    <value>확인</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Content_196" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="AutoResXGen_ManagementList2_AutomationPropertiesName_314" xml:space="preserve">
-    <value>Click to save a search query</value>
+    <value>검색 쿼리를 저장하려면 클릭하십시오.</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_42" xml:space="preserve">
-    <value>Available columns</value>
+    <value>사용 가능한 열</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_73" xml:space="preserve">
     <value>&gt;&gt;</value>
@@ -188,104 +188,104 @@
     <comment>The contents of a button which indicates that items will move from the right column to left column</comment>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_127" xml:space="preserve">
-    <value>Move up</value>
+    <value>위로 이동</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_134" xml:space="preserve">
-    <value>Move down</value>
+    <value>아래로 이동</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_189" xml:space="preserve">
-    <value>OK</value>
+    <value>확인</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_199" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_5" xml:space="preserve">
-    <value>Select columns</value>
+    <value>열 선택</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Tooltip_76" xml:space="preserve">
-    <value>Move selected column to list of visible columns</value>
+    <value>선택한 열을 표시되는 열 목록으로 이동</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Tooltip_84" xml:space="preserve">
-    <value>Move selected column to list of hidden columns</value>
+    <value>선택한 열을 숨겨진 열 목록으로 이동</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Text_142" xml:space="preserve">
-    <value>This column may not be removed.</value>
+    <value>이 열은 제거할 수 없습니다.</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Text_152" xml:space="preserve">
-    <value>The list must always display at least one column.</value>
+    <value>목록에 열을 하나 이상 표시해야 합니다.</value>
   </data>
   <data name="AutoResXGen_ColumnPicker_Content_93" xml:space="preserve">
-    <value>Selected columns</value>
+    <value>선택한 열</value>
   </data>
   <data name="ColumnsExplorer_Column_FindTextBox_BackgroundText" xml:space="preserve">
-    <value>Find in this column</value>
+    <value>이 열에서 찾기</value>
   </data>
   <data name="AutoResXGen_DesignerStyleResources_ToolTip_97" xml:space="preserve">
-    <value>Expand</value>
+    <value>펼치기</value>
   </data>
   <data name="AutoResXGen_ManagementList2_ToolTip_104" xml:space="preserve">
-    <value>Click to clear all filter criteria.</value>
+    <value>모든 필터 조건을 지우려면 클릭하십시오.</value>
   </data>
   <data name="AutoResXGen_ManagementList2_ToolTip_132" xml:space="preserve">
-    <value>Click to add search criteria.</value>
+    <value>검색 조건을 추가하려면 클릭하십시오.</value>
   </data>
   <data name="AutoResXGen_ManagementList2_ToolTip_32" xml:space="preserve">
-    <value>Click to expand search criteria.</value>
+    <value>검색 조건을 확장하려면 클릭하십시오.</value>
   </data>
   <data name="AutoResXGen_ManagementList2_NoItemsText_50" xml:space="preserve">
-    <value>There are currently no saved queries.</value>
+    <value>저장된 쿼리가 현재 없습니다.</value>
   </data>
   <data name="AutoResXGen_ManagementList2_AutomationPropertiesName_52" xml:space="preserve">
-    <value>Queries</value>
+    <value>쿼리</value>
   </data>
   <data name="AutoResXGen_ListOrganizer_AutomationPropertiesName_47" xml:space="preserve">
-    <value>Delete</value>
+    <value>삭제</value>
   </data>
   <data name="AutoResXGen_ListOrganizer_AutomationPropertiesName_72" xml:space="preserve">
-    <value>Rename</value>
+    <value>이름 바꾸기</value>
   </data>
   <data name="FilterRule_AccessibleName" xml:space="preserve">
-    <value>{0} rule</value>
+    <value>{0} 규칙</value>
     <comment>The text representation of a rule in the filter panel, displayed to accessibility clients. {0} will be the name of the rule.</comment>
   </data>
   <data name="AutoResXGen_AddFilterRulePicker_Content_214" xml:space="preserve">
-    <value>Add</value>
+    <value>추가</value>
   </data>
   <data name="AutoResXGen_AddFilterRulePicker_Content_223" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="AutoResXGen_AddFilterRulePicker_AutomationPropertiesName_293" xml:space="preserve">
-    <value>Add Filter Criteria</value>
+    <value>필터 조건 추가</value>
   </data>
   <data name="AutoResXGen_FilterRulePanel_AutomationPropertiesName_199" xml:space="preserve">
-    <value>Value</value>
+    <value>값</value>
     <comment>The name for text input fields</comment>
   </data>
   <data name="AutoResXGen_FilterRulePanel_BackgroundText_200" xml:space="preserve">
     <value>&lt;Empty&gt;</value>
   </data>
   <data name="AutoResXGen_FilterRulePanel_AutomationPropertiesName_257" xml:space="preserve">
-    <value>Rules</value>
+    <value>규칙</value>
     <comment>The name of the panel which contains the filter rules</comment>
   </data>
   <data name="AutoResXGen_ManagementList_AutomationPropertiesName_302" xml:space="preserve">
-    <value>Delete</value>
+    <value>삭제</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Content_19" xml:space="preserve">
-    <value>Query</value>
+    <value>쿼리</value>
   </data>
   <data name="AutoResXGen_ManagementList2_Content_33" xml:space="preserve">
-    <value>Queries</value>
+    <value>쿼리</value>
   </data>
   <data name="AutoResXGen_SearchBox_AutomationPropertiesName_75" xml:space="preserve">
-    <value>Search</value>
+    <value>검색</value>
   </data>
   <data name="ManagementListTitle_ListStatus_FilterApplied" xml:space="preserve">
-    <value>({0} of {1})</value>
+    <value>({0}/{1}개)</value>
     <comment>The text displayed in the management list title when the list has a filter applied. {0} will be the number of items shown in the list. {1} will be the total number of items in the list before filtering.</comment>
   </data>
   <data name="ManagementListTitle_ListStatus_FilterInProgress" xml:space="preserve">
-    <value>Searching...</value>
+    <value>검색 중...</value>
     <comment>The text displayed in the management list title when the list is processing a filter.</comment>
   </data>
   <data name="ManagementListTitle_ListStatus_FilterNotApplied" xml:space="preserve">
@@ -293,122 +293,122 @@
     <comment>The text displayed in the management list title when the list does not have a filter applied. {0} will be the number of items shown in the list.</comment>
   </data>
   <data name="AutoResXGen_BreadcrumbItem_AutomationPropertiesName_142" xml:space="preserve">
-    <value>Filter</value>
+    <value>필터</value>
     <comment>Localizable AutomationName for control that is used by accessibility screen readers.</comment>
   </data>
   <data name="ColumnsExplorer_Column_FindTextBox_AutomationName" xml:space="preserve">
-    <value>Filter</value>
+    <value>필터</value>
   </data>
   <data name="AutoResXGen_AddFilterRulePicker_AutomationPropertiesName_157" xml:space="preserve">
-    <value>Shortcut Rules</value>
+    <value>바로 가기 규칙</value>
     <comment>The name used to indicate custom filter rules which are specific to a particular application.</comment>
   </data>
   <data name="AutoResXGen_AddFilterRulePicker_AutomationPropertiesName_180" xml:space="preserve">
-    <value>Columns Rules</value>
+    <value>열 규칙</value>
     <comment>The name used to indicate filter rules that are based upon the properties of the items in the list.</comment>
   </data>
   <data name="ManagementList_SortGlyph_Ascending_AutomationName" xml:space="preserve">
-    <value>Sort Glyph</value>
+    <value>문자 모양 정렬</value>
   </data>
   <data name="ManagementList_SortGlyph_Descending_AutomationName" xml:space="preserve">
-    <value>Sort Glyph</value>
+    <value>문자 모양 정렬</value>
   </data>
   <data name="AutoResXGen_DesignerStyleResources_ToolTip_119" xml:space="preserve">
-    <value>Collapse</value>
+    <value>접기</value>
   </data>
   <data name="AutoResXGen_DesignerStyleResources_ToolTip_160" xml:space="preserve">
-    <value>Collapse</value>
+    <value>접기</value>
   </data>
   <data name="InnerList_GridViewColumnHeader_ItemStatus_Ascending" xml:space="preserve">
-    <value>Sorted ascending</value>
+    <value>오름차순 정렬</value>
     <comment>The text used for the accessible ItemStatus property when a column is sorted ascending.</comment>
   </data>
   <data name="InnerList_GridViewColumnHeader_ItemStatus_Descending" xml:space="preserve">
-    <value>Sorted descending</value>
+    <value>내림차순 정렬</value>
     <comment>The text used for the accessible ItemStatus property when a column is sorted descending.</comment>
   </data>
   <data name="CollapsingTabControl_ExpandButton_AutomationName" xml:space="preserve">
-    <value>Collapse</value>
+    <value>접기</value>
   </data>
   <data name="CollapsingTabControl_CollapseButton_AutomationName" xml:space="preserve">
-    <value>Expand</value>
+    <value>펼치기</value>
   </data>
   <data name="AutoResXGen_ManagementList_TextBlock_83" xml:space="preserve">
-    <value>Search</value>
+    <value>검색</value>
   </data>
   <data name="AutoResXGen_ManagementList_TextBlock_106" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="AutoResXGen_ManagementList_TextBlock_129" xml:space="preserve">
-    <value>Clear All</value>
+    <value>모두 선택 취소</value>
   </data>
   <data name="AutoResXGen_ManagementList_AutomationPropertiesName_395" xml:space="preserve">
-    <value>Clear All</value>
+    <value>모두 선택 취소</value>
   </data>
   <data name="AutoResXGen_SearchBox_AutomationPropertiesName_85" xml:space="preserve">
-    <value>Clear Search Text</value>
+    <value>검색 텍스트 지우기</value>
   </data>
   <data name="AutoResXGen_TaskPane_AutomationPropertiesName_133" xml:space="preserve">
-    <value>Tasks</value>
+    <value>작업</value>
   </data>
   <data name="ManagementList_StartFilterButton_AutomationName" xml:space="preserve">
-    <value>Search</value>
+    <value>검색</value>
     <comment>The accessible name of the Search button in the filter panel.</comment>
   </data>
   <data name="ManagementList_StopFilterButton_AutomationName" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
     <comment>The accessible name of the Stop Search button in the filter panel.</comment>
   </data>
   <data name="ManagementList_ToggleFilterPanelButton_AutomationName" xml:space="preserve">
-    <value>Expand or Collapse Filter Panel</value>
+    <value>필터 창 확장 또는 축소</value>
     <comment>The accessible name of the button that expands/collapses the filter panel.</comment>
   </data>
   <data name="ManagementList_SearchBox_BackgroundText_Live" xml:space="preserve">
-    <value>Filter</value>
+    <value>필터</value>
     <comment>The background text of the list's search box when filtering is immediate.</comment>
   </data>
   <data name="AutoResXGen_ManagementList_ToolTip_314" xml:space="preserve">
-    <value>Click to display saved search queries.</value>
+    <value>저장된 검색 쿼리를 표시하려면 클릭하십시오.</value>
   </data>
   <data name="AutoResXGen_ManagementList_Text_392" xml:space="preserve">
-    <value>Filter applied.</value>
+    <value>필터가 적용되었습니다.</value>
   </data>
   <data name="FilterRulePanel_LogicalOperatorText_FirstHeader" xml:space="preserve">
-    <value>and</value>
+    <value>및</value>
     <comment>The first header operator indicates that it is the first item in the list of filter rules. The AND value is used to indicate that it is and'ed with the above SearchBox.</comment>
   </data>
   <data name="FilterRulePanel_LogicalOperatorText_Header" xml:space="preserve">
-    <value>and</value>
+    <value>및</value>
     <comment>The header operator indicates that it is the first item in a group of filter rules which are the same. The AND value is used to indicate that it is and'ed with the other groups in the panel.</comment>
   </data>
   <data name="FilterRulePanel_LogicalOperatorText_Item" xml:space="preserve">
-    <value>or</value>
+    <value>또는</value>
     <comment>The Item operator indicates that it is NOT the first item in a group of filter rules which are the same. The OR value is used to indicate that it is or'ed with the other items in the same group.</comment>
   </data>
   <data name="ManagementList_NoMatchesFound_Message" xml:space="preserve">
-    <value>No matches found.</value>
+    <value>일치 항목이 없습니다.</value>
     <comment>The text displayed in the ManagementList when the filter has been applied but matching items were found.</comment>
   </data>
   <data name="CollapsingTabControl_CollapseButton_ToolTip" xml:space="preserve">
-    <value>Collapse</value>
+    <value>접기</value>
   </data>
   <data name="CollapsingTabControl_ExpandButton_ToolTip" xml:space="preserve">
-    <value>Expand</value>
+    <value>펼치기</value>
   </data>
   <data name="NavigationList_ShownChildrenButton_ToolTip" xml:space="preserve">
-    <value>Show Children</value>
+    <value>하위 항목 표시</value>
   </data>
   <data name="NavigationList_ShownChildrenButton_AutomationName" xml:space="preserve">
-    <value>Show Children</value>
+    <value>하위 항목 표시</value>
   </data>
   <data name="ManagementListTitle_Title_WithViewName" xml:space="preserve">
     <value>{0}: {1}</value>
     <comment>The format string used for the ManagementList title when query has been applied. For example, "Users: My Fancy Query"</comment>
   </data>
   <data name="OutGridView_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>취소</value>
   </data>
   <data name="OutGridView_Button_OK" xml:space="preserve">
-    <value>OK</value>
+    <value>확인</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/pl/public.HelpWindowResources.pl.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/pl/public.HelpWindowResources.pl.resx
@@ -121,74 +121,74 @@
     <value>Anuluj</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Dopasuj wielkość liter</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
-    <value>CommonParameters</value>
+    <value>Typowe parametry</value>
     <comment>Name of a group of parameters common to all cmdlets</comment>
   </data>
   <data name="DescriptionTitle" xml:space="preserve">
     <value>Opis</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Przykłady</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Znajdź:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Sekcje Pomocy</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>{0} — Pomoc</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Dane wejściowe</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Metody</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Dalej</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Nie znaleziono dopasowań</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Notatki</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>OK</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 dopasowanie</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Dane wyjściowe</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Akceptować symbole wieloznaczne?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Wartość domyślna</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Zaakceptować dane wejściowe potoku?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>Lokalizacja?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Wymagany?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Parametry</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Wstecz</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Właściwości</value>
@@ -197,34 +197,34 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Uwagi</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Opcje wyszukiwania</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Ustawienia</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} dopasowań</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
     <value>Synopsis</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Składnia</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Pomoc dotycząca {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Całe słowo</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
     <value>{0}%</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
-    <value>Zoom</value>
+    <value>Powiększanie</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/pl/public.ShowCommandResources.pl.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/pl/public.ShowCommandResources.pl.resx
@@ -118,41 +118,41 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActionButtons_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>Anuluj</value>
   </data>
   <data name="ActionButtons_Button_Copy" xml:space="preserve">
-    <value>Co_py</value>
+    <value>Ko_piuj</value>
   </data>
   <data name="ActionButtons_Button_Run" xml:space="preserve">
-    <value>_Run</value>
+    <value>_Uruchom</value>
   </data>
   <data name="All" xml:space="preserve">
     <value>Wszystko</value>
   </data>
   <data name="AllModulesControl_Label_Modules" xml:space="preserve">
-    <value>Modules:</value>
+    <value>Moduły:</value>
   </data>
   <data name="CmdletControl_Button_GetHelp" xml:space="preserve">
     <value> ? </value>
   </data>
   <data name="CmdletControl_Button_ToolTip_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Pomoc</value>
   </data>
   <data name="CmdletControl_Header_CommonParameters" xml:space="preserve">
-    <value>Common Parameters</value>
+    <value>Typowe parametry</value>
   </data>
   <data name="CmdletControl_Header_Errors" xml:space="preserve">
-    <value>Errors</value>
+    <value>Błędy</value>
   </data>
   <data name="DetailsParameterTitleFormat" xml:space="preserve">
-    <value>Parameters for "{0}":</value>
+    <value>Parametry dla „{0}”:</value>
   </data>
   <data name="CmdletTooltipFormat" xml:space="preserve">
-    <value>Name: {0}
-Module: {1} ({2})</value>
+    <value>Nazwa: {0}
+Moduł: {1} ({2})</value>
   </data>
   <data name="EndProcessingErrorMessage" xml:space="preserve">
-    <value>The following errors occurred running the command:
+    <value>Podczas uruchamiania polecenia wystąpiły następujące błędy:
 {0}</value>
   </data>
   <data name="MandatoryLabelSegment" xml:space="preserve">
@@ -168,7 +168,7 @@ Module: {1} ({2})</value>
     <comment>This is a label for a control, hence the colon. {0} is a parameter name</comment>
   </data>
   <data name="ShowModuleControl_Label_Name" xml:space="preserve">
-    <value>Name:</value>
+    <value>Nazwa:</value>
   </data>
   <data name="ActionButtons_Button_Ok" xml:space="preserve">
     <value>OK</value>
@@ -177,22 +177,22 @@ Module: {1} ({2})</value>
     <value>...</value>
   </data>
   <data name="CommandNameAutomationName" xml:space="preserve">
-    <value>Command Name</value>
+    <value>Nazwa polecenia</value>
   </data>
   <data name="ModulesAutomationName" xml:space="preserve">
-    <value>Modules</value>
+    <value>Moduły</value>
   </data>
   <data name="NoModuleName" xml:space="preserve">
     <value>&lt;No module name&gt;</value>
   </data>
   <data name="SelectMultipleValuesForParameterFormat" xml:space="preserve">
-    <value>Select multiple values for "{0}"</value>
+    <value>Wybierz wiele wartości dla „{0}”</value>
   </data>
   <data name="CanReceiveValueFromPipeline" xml:space="preserve">
-    <value>Can receive value from pipeline</value>
+    <value>Może odbierać wartość z potoku</value>
   </data>
   <data name="CommonToAllParameterSets" xml:space="preserve">
-    <value>Common to all parameter sets</value>
+    <value>Wspólne dla wszystkich zestawów parametrów</value>
   </data>
   <data name="Mandatory" xml:space="preserve">
     <value>Obowiązkowe</value>
@@ -201,39 +201,39 @@ Module: {1} ({2})</value>
     <value>Opcjonalne</value>
   </data>
   <data name="PositionFormat" xml:space="preserve">
-    <value>Position: {0}</value>
+    <value>Pozycja: {0}</value>
   </data>
   <data name="TypeFormat" xml:space="preserve">
-    <value>Type: {0}</value>
+    <value>Typ: {0}</value>
   </data>
   <data name="Imported" xml:space="preserve">
-    <value>Imported</value>
+    <value>Zaimportowano</value>
   </data>
   <data name="NotImported" xml:space="preserve">
-    <value>Not Imported</value>
+    <value>Nie zaimportowano</value>
   </data>
   <data name="ImportModuleButtonText" xml:space="preserve">
-    <value>Show Details</value>
+    <value>Pokaż szczegóły</value>
   </data>
   <data name="ImportModuleFailedFormat" xml:space="preserve">
-    <value>Failed to import the module required by command "{0}". Module name: "{1}". Error message: "{2}".</value>
+    <value>Nie można zaimportować modułu wymaganego przez polecenie „{0}”. Nazwa modułu: „{1}”. Komunikat o błędzie: „{2}”.</value>
   </data>
   <data name="NotImportedFormat" xml:space="preserve">
-    <value>To import the "{0}" module and its cmdlets, including "{1}", click {2}.</value>
+    <value>Aby zaimportować moduł „{0}” i jego polecenia cmdlet, w tym „{1}”, kliknij pozycję {2}.</value>
   </data>
   <data name="ShowCommandError" xml:space="preserve">
-    <value>Show Command - Error</value>
+    <value>Pokaż polecenie – błąd</value>
   </data>
   <data name="PleaseWaitMessage" xml:space="preserve">
-    <value>Please Wait...</value>
+    <value>Czekaj...</value>
   </data>
   <data name="ShowModuleControl_RefreshButton" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Odśwież</value>
   </data>
   <data name="NoParameters" xml:space="preserve">
-    <value>There are no parameters.</value>
+    <value>Brak parametrów.</value>
   </data>
   <data name="RefreshShowCommandTooltipFormat" xml:space="preserve">
-    <value>Click after using "{0}" to see the new commands</value>
+    <value>Kliknij po użyciu znaku „{0}”, aby wyświetlić nowe polecenia</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/ru/public.HelpWindowResources.ru.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/ru/public.HelpWindowResources.ru.resx
@@ -121,74 +121,74 @@
     <value>Отмена</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>Учитывать регистр</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
-    <value>CommonParameters</value>
+    <value>Общие параметры</value>
     <comment>Name of a group of parameters common to all cmdlets</comment>
   </data>
   <data name="DescriptionTitle" xml:space="preserve">
     <value>Описание</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>Примеры</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>_Найти:</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>Разделы справки</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>{0}: справка</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>Входные данные</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>Методы</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>_Далее</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>Совпадений не найдено</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>Заметки</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>ОК</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 совпадение</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>Выходные данные</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>Принимать символы-шаблоны?</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>Значение по умолчанию</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>Принимать входные данные конвейера?</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>Позиция?</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>Обязательно?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>Параметры</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>_Назад</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>Свойства</value>
@@ -197,34 +197,34 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>Примечания</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>Параметры поиска</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>Параметры</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>Совпадения: {0}</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>Описание</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>Синтаксис</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>Справка для {0}</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>Слово целиком</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
-    <value>{0}%</value>
+    <value>{0} %</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
-    <value>Zoom</value>
+    <value>Масштаб</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/tr/public.ShowCommandResources.tr.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/tr/public.ShowCommandResources.tr.resx
@@ -118,41 +118,41 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActionButtons_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>İptal</value>
   </data>
   <data name="ActionButtons_Button_Copy" xml:space="preserve">
-    <value>Co_py</value>
+    <value>Kop_yala</value>
   </data>
   <data name="ActionButtons_Button_Run" xml:space="preserve">
-    <value>_Run</value>
+    <value>_Çalıştır</value>
   </data>
   <data name="All" xml:space="preserve">
     <value>Tümü</value>
   </data>
   <data name="AllModulesControl_Label_Modules" xml:space="preserve">
-    <value>Modules:</value>
+    <value>Modüller:</value>
   </data>
   <data name="CmdletControl_Button_GetHelp" xml:space="preserve">
     <value> ? </value>
   </data>
   <data name="CmdletControl_Button_ToolTip_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>Yardım</value>
   </data>
   <data name="CmdletControl_Header_CommonParameters" xml:space="preserve">
-    <value>Common Parameters</value>
+    <value>Ortak Parametreler</value>
   </data>
   <data name="CmdletControl_Header_Errors" xml:space="preserve">
-    <value>Errors</value>
+    <value>Hatalar</value>
   </data>
   <data name="DetailsParameterTitleFormat" xml:space="preserve">
-    <value>Parameters for "{0}":</value>
+    <value>"{0}" parametreleri:</value>
   </data>
   <data name="CmdletTooltipFormat" xml:space="preserve">
-    <value>Name: {0}
-Module: {1} ({2})</value>
+    <value>Ad: {0}
+Modül: {1} ({2})</value>
   </data>
   <data name="EndProcessingErrorMessage" xml:space="preserve">
-    <value>The following errors occurred running the command:
+    <value>Komut çalıştırılırken aşağıdaki hatalar oluştu:
 {0}</value>
   </data>
   <data name="MandatoryLabelSegment" xml:space="preserve">
@@ -168,31 +168,31 @@ Module: {1} ({2})</value>
     <comment>This is a label for a control, hence the colon. {0} is a parameter name</comment>
   </data>
   <data name="ShowModuleControl_Label_Name" xml:space="preserve">
-    <value>Name:</value>
+    <value>Ad:</value>
   </data>
   <data name="ActionButtons_Button_Ok" xml:space="preserve">
-    <value>OK</value>
+    <value>Tamam</value>
   </data>
   <data name="MultiParameter_Button_Browse" xml:space="preserve">
     <value>...</value>
   </data>
   <data name="CommandNameAutomationName" xml:space="preserve">
-    <value>Command Name</value>
+    <value>Komut Adı</value>
   </data>
   <data name="ModulesAutomationName" xml:space="preserve">
-    <value>Modules</value>
+    <value>Modüller</value>
   </data>
   <data name="NoModuleName" xml:space="preserve">
-    <value>&lt;No module name&gt;</value>
+    <value>&lt;Modül adı yok&gt;</value>
   </data>
   <data name="SelectMultipleValuesForParameterFormat" xml:space="preserve">
-    <value>Select multiple values for "{0}"</value>
+    <value>"{0}" için birden çok değer seçin</value>
   </data>
   <data name="CanReceiveValueFromPipeline" xml:space="preserve">
-    <value>Can receive value from pipeline</value>
+    <value>İşlem hattından değer alabilir</value>
   </data>
   <data name="CommonToAllParameterSets" xml:space="preserve">
-    <value>Common to all parameter sets</value>
+    <value>Tüm parametre kümeleri için ortak</value>
   </data>
   <data name="Mandatory" xml:space="preserve">
     <value>Zorunlu</value>
@@ -201,39 +201,39 @@ Module: {1} ({2})</value>
     <value>İsteğe bağlı</value>
   </data>
   <data name="PositionFormat" xml:space="preserve">
-    <value>Position: {0}</value>
+    <value>Konum: {0}</value>
   </data>
   <data name="TypeFormat" xml:space="preserve">
-    <value>Type: {0}</value>
+    <value>Tür: {0}</value>
   </data>
   <data name="Imported" xml:space="preserve">
-    <value>Imported</value>
+    <value>İçeri aktarıldı</value>
   </data>
   <data name="NotImported" xml:space="preserve">
-    <value>Not Imported</value>
+    <value>İçeri Aktarılmadı</value>
   </data>
   <data name="ImportModuleButtonText" xml:space="preserve">
-    <value>Show Details</value>
+    <value>Ayrıntıları Göster</value>
   </data>
   <data name="ImportModuleFailedFormat" xml:space="preserve">
-    <value>Failed to import the module required by command "{0}". Module name: "{1}". Error message: "{2}".</value>
+    <value>"{0}" komutu için gereken modül içeri aktarılamadı. Modül adı: "{1}". Hata iletisi: "{2}".</value>
   </data>
   <data name="NotImportedFormat" xml:space="preserve">
-    <value>To import the "{0}" module and its cmdlets, including "{1}", click {2}.</value>
+    <value>"{0}" modülünü ve "{1}" dahil cmdlet'lerini içeri aktarmak için {2} seçeneğine tıklayın.</value>
   </data>
   <data name="ShowCommandError" xml:space="preserve">
-    <value>Show Command - Error</value>
+    <value>Komutu Göster - Hata</value>
   </data>
   <data name="PleaseWaitMessage" xml:space="preserve">
-    <value>Please Wait...</value>
+    <value>Lütfen Bekleyin...</value>
   </data>
   <data name="ShowModuleControl_RefreshButton" xml:space="preserve">
-    <value>Refresh</value>
+    <value>Yenile</value>
   </data>
   <data name="NoParameters" xml:space="preserve">
-    <value>There are no parameters.</value>
+    <value>Parametre yok.</value>
   </data>
   <data name="RefreshShowCommandTooltipFormat" xml:space="preserve">
-    <value>Click after using "{0}" to see the new commands</value>
+    <value>Yeni komutları görmek için "{0}" kullandıktan sonra tıklayın</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/zh-Hant/public.HelpWindowResources.zh-Hant.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/zh-Hant/public.HelpWindowResources.zh-Hant.resx
@@ -121,7 +121,7 @@
     <value>取消</value>
   </data>
   <data name="CaseSensitiveTitle" xml:space="preserve">
-    <value>Match Case</value>
+    <value>區分大小寫</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>CommonParameters</value>
@@ -131,64 +131,64 @@
     <value>描述</value>
   </data>
   <data name="ExamplesTitle" xml:space="preserve">
-    <value>Examples</value>
+    <value>範例</value>
   </data>
   <data name="FindText" xml:space="preserve">
-    <value>_Find:</value>
+    <value>尋找(_F):</value>
   </data>
   <data name="HelpSectionsTitle" xml:space="preserve">
-    <value>Help Sections</value>
+    <value>說明區段</value>
   </data>
   <data name="HelpTitleFormat" xml:space="preserve">
-    <value>{0} Help</value>
+    <value>{0} 說明</value>
   </data>
   <data name="InputsTitle" xml:space="preserve">
-    <value>Inputs</value>
+    <value>輸入</value>
   </data>
   <data name="LinkTextFormat" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="MethodsTitle" xml:space="preserve">
-    <value>Methods</value>
+    <value>方法</value>
   </data>
   <data name="NextText" xml:space="preserve">
-    <value>_Next</value>
+    <value>下一步(_N)</value>
   </data>
   <data name="NoMatches" xml:space="preserve">
-    <value>No matches found</value>
+    <value>找不到相符的項目</value>
   </data>
   <data name="NotesTitle" xml:space="preserve">
-    <value>Notes</value>
+    <value>備註</value>
   </data>
   <data name="OKText" xml:space="preserve">
     <value>確定</value>
   </data>
   <data name="OneMatch" xml:space="preserve">
-    <value>1 match</value>
+    <value>1 個相符項目</value>
   </data>
   <data name="OutputsTitle" xml:space="preserve">
-    <value>Outputs</value>
+    <value>輸出</value>
   </data>
   <data name="ParameterAcceptWildcard" xml:space="preserve">
-    <value>Accept wildcard characters?</value>
+    <value>接受萬用字元？</value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value</value>
+    <value>預設值</value>
   </data>
   <data name="ParameterPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?</value>
+    <value>接受管線輸入？</value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?</value>
+    <value>位置？</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?</value>
+    <value>是否為必要?</value>
   </data>
   <data name="ParametersTitle" xml:space="preserve">
-    <value>Parameters</value>
+    <value>參數</value>
   </data>
   <data name="PreviousText" xml:space="preserve">
-    <value>_Previous</value>
+    <value>上一步(_P)</value>
   </data>
   <data name="PropertiesTitle" xml:space="preserve">
     <value>屬性</value>
@@ -197,34 +197,34 @@
     <value>RelatedLinks</value>
   </data>
   <data name="RemarksTitle" xml:space="preserve">
-    <value>Remarks</value>
+    <value>備註</value>
   </data>
   <data name="SearchOptionsTitle" xml:space="preserve">
-    <value>Search Options</value>
+    <value>搜尋選項</value>
   </data>
   <data name="SettingsText" xml:space="preserve">
     <value>設定</value>
   </data>
   <data name="SomeMatchesFormat" xml:space="preserve">
-    <value>{0} matches</value>
+    <value>{0} 個相符項目</value>
   </data>
   <data name="SynopsisTitle" xml:space="preserve">
-    <value>Synopsis</value>
+    <value>概要</value>
   </data>
   <data name="SyntaxTitle" xml:space="preserve">
-    <value>Syntax</value>
+    <value>語法</value>
   </data>
   <data name="Title" xml:space="preserve">
-    <value>Help for {0}</value>
+    <value>{0} 的說明</value>
     <comment>{0} is the name of a cmdlet</comment>
   </data>
   <data name="WholeWordTitle" xml:space="preserve">
-    <value>Whole Word</value>
+    <value>全字拼寫須相符</value>
   </data>
   <data name="ZoomLabelTextFormat" xml:space="preserve">
     <value>{0}%</value>
   </data>
   <data name="ZoomSlider" xml:space="preserve">
-    <value>Zoom</value>
+    <value>縮放</value>
   </data>
 </root>

--- a/src/Microsoft.Management.UI.Internal/resources/zh-Hant/public.ShowCommandResources.zh-Hant.resx
+++ b/src/Microsoft.Management.UI.Internal/resources/zh-Hant/public.ShowCommandResources.zh-Hant.resx
@@ -118,41 +118,41 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ActionButtons_Button_Cancel" xml:space="preserve">
-    <value>Cancel</value>
+    <value>取消</value>
   </data>
   <data name="ActionButtons_Button_Copy" xml:space="preserve">
-    <value>Co_py</value>
+    <value>複製(_P)</value>
   </data>
   <data name="ActionButtons_Button_Run" xml:space="preserve">
-    <value>_Run</value>
+    <value>執行(_R)</value>
   </data>
   <data name="All" xml:space="preserve">
     <value>全部</value>
   </data>
   <data name="AllModulesControl_Label_Modules" xml:space="preserve">
-    <value>Modules:</value>
+    <value>模組:</value>
   </data>
   <data name="CmdletControl_Button_GetHelp" xml:space="preserve">
-    <value> ? </value>
+    <value> ？</value>
   </data>
   <data name="CmdletControl_Button_ToolTip_Help" xml:space="preserve">
-    <value>Help</value>
+    <value>說明</value>
   </data>
   <data name="CmdletControl_Header_CommonParameters" xml:space="preserve">
-    <value>Common Parameters</value>
+    <value>一般參數</value>
   </data>
   <data name="CmdletControl_Header_Errors" xml:space="preserve">
-    <value>Errors</value>
+    <value>錯誤</value>
   </data>
   <data name="DetailsParameterTitleFormat" xml:space="preserve">
-    <value>Parameters for "{0}":</value>
+    <value>"{0}" 的參數:</value>
   </data>
   <data name="CmdletTooltipFormat" xml:space="preserve">
-    <value>Name: {0}
-Module: {1} ({2})</value>
+    <value>名稱: {0}
+模組: {1} ({2})</value>
   </data>
   <data name="EndProcessingErrorMessage" xml:space="preserve">
-    <value>The following errors occurred running the command:
+    <value>執行命令時發生下列錯誤: 
 {0}</value>
   </data>
   <data name="MandatoryLabelSegment" xml:space="preserve">
@@ -168,31 +168,31 @@ Module: {1} ({2})</value>
     <comment>This is a label for a control, hence the colon. {0} is a parameter name</comment>
   </data>
   <data name="ShowModuleControl_Label_Name" xml:space="preserve">
-    <value>Name:</value>
+    <value>名稱:</value>
   </data>
   <data name="ActionButtons_Button_Ok" xml:space="preserve">
-    <value>OK</value>
+    <value>確定</value>
   </data>
   <data name="MultiParameter_Button_Browse" xml:space="preserve">
     <value>...</value>
   </data>
   <data name="CommandNameAutomationName" xml:space="preserve">
-    <value>Command Name</value>
+    <value>命令名稱</value>
   </data>
   <data name="ModulesAutomationName" xml:space="preserve">
-    <value>Modules</value>
+    <value>模組</value>
   </data>
   <data name="NoModuleName" xml:space="preserve">
-    <value>&lt;No module name&gt;</value>
+    <value>&lt;無模組名稱&gt;</value>
   </data>
   <data name="SelectMultipleValuesForParameterFormat" xml:space="preserve">
-    <value>Select multiple values for "{0}"</value>
+    <value>選取 “{0}” 的多個值</value>
   </data>
   <data name="CanReceiveValueFromPipeline" xml:space="preserve">
-    <value>Can receive value from pipeline</value>
+    <value>可從管線接收值</value>
   </data>
   <data name="CommonToAllParameterSets" xml:space="preserve">
-    <value>Common to all parameter sets</value>
+    <value>通用於所有參數集合</value>
   </data>
   <data name="Mandatory" xml:space="preserve">
     <value>強制</value>
@@ -201,39 +201,39 @@ Module: {1} ({2})</value>
     <value>選擇性</value>
   </data>
   <data name="PositionFormat" xml:space="preserve">
-    <value>Position: {0}</value>
+    <value>位置: {0}</value>
   </data>
   <data name="TypeFormat" xml:space="preserve">
-    <value>Type: {0}</value>
+    <value>類型: {0}</value>
   </data>
   <data name="Imported" xml:space="preserve">
-    <value>Imported</value>
+    <value>已匯入</value>
   </data>
   <data name="NotImported" xml:space="preserve">
-    <value>Not Imported</value>
+    <value>尚未匯入</value>
   </data>
   <data name="ImportModuleButtonText" xml:space="preserve">
-    <value>Show Details</value>
+    <value>顯示詳細資料</value>
   </data>
   <data name="ImportModuleFailedFormat" xml:space="preserve">
-    <value>Failed to import the module required by command "{0}". Module name: "{1}". Error message: "{2}".</value>
+    <value>無法匯入命令 “{0}” 所需的模組。模組名稱: "{1}"。錯誤訊息: "{2}"。</value>
   </data>
   <data name="NotImportedFormat" xml:space="preserve">
-    <value>To import the "{0}" module and its cmdlets, including "{1}", click {2}.</value>
+    <value>若要匯入 “{0}” 模組及其 Cmdlet (包括"{1}")，請按一下 {2}。</value>
   </data>
   <data name="ShowCommandError" xml:space="preserve">
-    <value>Show Command - Error</value>
+    <value>顯示命令 - 錯誤</value>
   </data>
   <data name="PleaseWaitMessage" xml:space="preserve">
-    <value>Please Wait...</value>
+    <value>請稍候...</value>
   </data>
   <data name="ShowModuleControl_RefreshButton" xml:space="preserve">
-    <value>Refresh</value>
+    <value>重新整理</value>
   </data>
   <data name="NoParameters" xml:space="preserve">
-    <value>There are no parameters.</value>
+    <value>沒有參數。</value>
   </data>
   <data name="RefreshShowCommandTooltipFormat" xml:space="preserve">
-    <value>Click after using "{0}" to see the new commands</value>
+    <value>在使用 "{0}" 來查看新命令之後按一下</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Diagnostics/resources/ko/GetEventResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Diagnostics/resources/ko/GetEventResources.ko.resx
@@ -118,198 +118,198 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CounterNotALogFile" xml:space="preserve">
-    <value>The {0} file does not have the expected file name extension. Specify only .blg, .csv, or .tsv files when you use the Path parameter.</value>
+    <value>{0} 파일에 필요한 파일 이름 확장명이 없습니다. Path 매개 변수를 사용할 때는 .blg, .csv 또는 .tsv 파일만 지정하세요.</value>
   </data>
   <data name="CounterApiError" xml:space="preserve">
-    <value>Internal performance counter API call failed. Error: {0:x8}.</value>
+    <value>내부 성능 카운터 API 호출에 실패했습니다. 오류: {0:x8}.</value>
   </data>
   <data name="LogProviderOrPathNeeded" xml:space="preserve">
-    <value>You must specify at least one Log, Provider or Path key-value pair.</value>
+    <value>하나 이상의 Log, Provider 또는 Path 키-값 쌍을 지정해야 합니다.</value>
   </data>
   <data name="NoMatchingProvidersFound" xml:space="preserve">
-    <value>There is not an event provider on the {0} computer that matches "{1}".</value>
+    <value>{0} 컴퓨터에 "{1}"와(과) 일치하는 이벤트 공급자가 없습니다.</value>
   </data>
   <data name="NullNotAllowedInHashtable" xml:space="preserve">
-    <value>A null value was encountered in the {0} hash table key. Null values are not permitted.</value>
+    <value>{0} 해시 테이블 키에 null 값이 있습니다. null 값은 허용되지 않습니다.</value>
   </data>
   <data name="QueryTrace" xml:space="preserve">
-    <value>Constructed structured query:
+    <value>다음 구조화된 쿼리를 생성했습니다. 
 {0}.</value>
   </data>
   <data name="ProviderLogLink" xml:space="preserve">
-    <value>The {0} provider writes events to the {1} log.</value>
+    <value>{0} 공급자는 {1} 로그에 이벤트를 씁니다.</value>
   </data>
   <data name="CounterInvalidDateRange" xml:space="preserve">
-    <value>The value of the StartTime parameter must be less than the value of the EndTime parameter.</value>
+    <value>StartTime 매개 변수 값은 EndTime 매개 변수 값보다 작아야 합니다.</value>
   </data>
   <data name="NoMatchingLogsFound" xml:space="preserve">
-    <value>There is not an event log on the {0} computer that matches "{1}".</value>
+    <value>{0} 컴퓨터에 "{1}"와(과) 일치하는 이벤트 로그가 없습니다.</value>
   </data>
   <data name="Vendor" xml:space="preserve">
     <value>Microsoft</value>
   </data>
   <data name="CounterCircularNoMaxSize" xml:space="preserve">
-    <value>The Circular parameter will be ignored unless the MaxSize parameter is also specified.</value>
+    <value>MaxSize 매개 변수도 지정하지 않으면 Circular 매개 변수는 무시됩니다.</value>
   </data>
   <data name="FileOpenFailed" xml:space="preserve">
-    <value>Unable to open the {0} file for writing.</value>
+    <value>쓰기용으로 {0} 파일을 열 수 없습니다.</value>
   </data>
   <data name="KeywordLongExpected" xml:space="preserve">
-    <value>Invalid value '{0}' specified for keyword.</value>
+    <value>키워드에 대해 값 '{0}'이(가) 잘못 지정되었습니다.</value>
   </data>
   <data name="CounterExportSampleNotInInitialSet" xml:space="preserve">
-    <value>The {0} performance counter cannot be exported to the {1} file because it was not part of the first sample set.</value>
+    <value>첫 번째 샘플 집합의 일부가 아니므로 {0} 성능 카운터를 {1} 파일로 내보낼 수 없습니다.</value>
   </data>
   <data name="NoMatchingEventsFound" xml:space="preserve">
-    <value>No events were found that match the specified selection criteria.</value>
+    <value>지정한 선택 조건과 일치하는 이벤트를 찾을 수 없습니다.</value>
   </data>
   <data name="CounterPathTranslationFailed" xml:space="preserve">
-    <value>The default values for this command failed. Error: {0:x8}.</value>
+    <value>이 명령의 기본값을 적용하지 못했습니다. 오류: {0:x8}.</value>
   </data>
   <data name="CounterNoMixedLogTypes" xml:space="preserve">
-    <value>You cannot import different types of performance log files in the same command.  Specify only one type of file in the Path parameter.</value>
+    <value>같은 명령에서 서로 다른 형식의 성능 로그 파일을 가져올 수 없습니다.  Path 매개 변수에는 한 가지 형식의 파일만 지정하세요.</value>
   </data>
   <data name="NotAFileSystemPath" xml:space="preserve">
-    <value>The {0} path does not appear to be a valid log file path. Specify a valid file system path.</value>
+    <value>{0} 경로가 올바른 로그 파일 경로가 아닌 것 같습니다. 올바른 파일 시스템 경로를 지정하세요.</value>
   </data>
   <data name="EventIdNotSpecified" xml:space="preserve">
-    <value>A valid Event Id must be specified.</value>
+    <value>유효한 이벤트 ID를 지정해야 합니다.</value>
   </data>
   <data name="ProviderMetadataUnavailable" xml:space="preserve">
-    <value>Could not retrieve information about the {0} provider. Error: {1}.</value>
+    <value>{0} 제공자에 대한 정보를 검색할 수 없습니다. 오류: {1}.</value>
   </data>
   <data name="SpecifyOldestForLog" xml:space="preserve">
-    <value>The {0} event log can be read only in the forward chronological order because it is an analytical or a debug log. To see events from the {0} event log, use the Oldest parameter in the command.</value>
+    <value>{0} 이벤트 로그는 분석 또는 디버그 로그이므로 앞으로의 시간 순서로만 읽을 수 있습니다. {0} 이벤트 로그의 이벤트를 보려면 명령에서 Oldest 매개 변수를 사용하세요.</value>
   </data>
   <data name="ExportDestPathAmbiguous" xml:space="preserve">
-    <value>The following export destination path is ambiguous: {0}.</value>
+    <value>다음 내보내기 대상 경로가 모호합니다. {0}</value>
   </data>
   <data name="CounterPathIsInvalid" xml:space="preserve">
-    <value>The {0} performance counter path is not valid.</value>
+    <value>{0} 성능 카운터 경로가 유효하지 않습니다.</value>
   </data>
   <data name="CounterSampleDataInvalid" xml:space="preserve">
-    <value>The data in one of the performance counter samples is not valid. View the Status property for each PerformanceCounterSample object to make sure it contains valid data.</value>
+    <value>성능 카운터 샘플 중 하나의 데이터가 올바르지 않습니다. 각 PerformanceCounterSample 개체의 Status 속성을 열어 유효한 데이터가 포함되어 있는지 확인하세요.</value>
   </data>
   <data name="PayloadMismatch" xml:space="preserve">
-    <value>Provided payload does not match with the template that was defined for event id {0}.
-The defined template is following:
+    <value>제공된 페이로드가 이벤트 ID {0}에 대해 정의된 템플릿과 일치하지 않습니다.
+정의된 템플릿은 다음과 같습니다. 
 {1}</value>
   </data>
   <data name="NoMatchingCounterSetsFound" xml:space="preserve">
-    <value>Cannot find any performance counter sets on the {0} computer that match the following: {1}.</value>
+    <value>{0} 컴퓨터에서 다음과 일치하는 성능 카운터 집합을 찾을 수 없습니다. {1}.</value>
   </data>
   <data name="CounterPathsInFilesInvalid" xml:space="preserve">
-    <value>No valid counter paths were found in the files.</value>
+    <value>파일에서 유효한 카운터 경로를 찾을 수 없습니다.</value>
   </data>
   <data name="FileCreateFailed" xml:space="preserve">
-    <value>Unable to create the {0} file. Verify that the path is valid.</value>
+    <value>{0} 파일을 만들 수 없습니다. 경로가 올바른지 확인하세요.</value>
   </data>
   <data name="NoCounterSetsOnComputer" xml:space="preserve">
-    <value>Could not find any performance counter sets on the {0} computer: error {1:x8}. Verify that the {0} computer exists, that it is discoverable, and that you have sufficient privileges to view performance counter data on that computer.</value>
+    <value>{0} 컴퓨터에서 성능 카운터 집합을 찾을 수 없습니다. 오류 {1:x8}. {0} 컴퓨터가 있는지, 검색 가능한지, 그리고 해당 컴퓨터에서 성능 카운터 데이터를 볼 수 있는 권한이 충분한지 확인하세요.</value>
   </data>
   <data name="IncorrectEventId" xml:space="preserve">
-    <value>Event cannot be written because there are no events defined with id {0} for the provider {1}.  Please correct the event id and try again.</value>
+    <value>공급자 {1}에 대해 ID {0}(으)로 정의된 이벤트가 없으므로 이벤트를 쓸 수 없습니다.  오류를 수정하고 다시 시도하세요.</value>
   </data>
   <data name="InvalidContext" xml:space="preserve">
-    <value>The {0} Context key-value is not a valid SID or NT account name.</value>
+    <value>{0} Context 키-값이 올바른 SID 또는 NT 계정 이름이 아닙니다.</value>
   </data>
   <data name="IncorrectEventVersion" xml:space="preserve">
-    <value>Event cannot be written because the specified version {0} for event {1} is not defined for the provider {2}.  Please correct the version and try again.</value>
+    <value>이벤트 {1}에 대해 지정한 버전 {0}이(가) 공급자 {2}에 대해 정의되어 있지 않아 이벤트를 쓸 수 없습니다.  버전을 수정하고 다시 시도하세요.</value>
   </data>
   <data name="Counter32FileLimit" xml:space="preserve">
-    <value>You cannot import more than 32 .blg counter log files in each command.</value>
+    <value>각 명령에서 .blg 카운터 로그 파일을 32개 이상 가져올 수 없습니다.</value>
   </data>
   <data name="SpecifiedProvidersDontWriteToLog" xml:space="preserve">
-    <value>The specified providers do not write events to the {0} log. This log will be ignored.</value>
+    <value>지정된 공급자는 {0} 로그에 이벤트를 쓰지 않습니다. 이 로그는 무시됩니다.</value>
   </data>
   <data name="InvalidSIDFormat" xml:space="preserve">
-    <value>The following value is not in a valid security identifier (SID) format: {0}. Enter a valid SID, such as S-1-5-32-544.</value>
+    <value>다음 값은 유효한 보안 식별자(SID) 형식이 아닙니다. {0} 유효한 SID를 입력하세요(예: S-1-5-32-544).</value>
   </data>
   <data name="NoProviderFound" xml:space="preserve">
-    <value>No provider found with name {0}.</value>
+    <value>이름이 {0}인 공급자를 찾을 수 없습니다.</value>
   </data>
   <data name="CounterSetEnumAccessDenied" xml:space="preserve">
-    <value>Cannot retrieve information about the {0} performance counter set because access was denied.</value>
+    <value>액세스가 거부되어 {0} 성능 카운터 집합에 대한 정보를 검색할 수 없습니다.</value>
   </data>
   <data name="VersionNotSpecified" xml:space="preserve">
-    <value>Event cannot be written because multiple events with id {0} have been defined for provider {1}.  Please provide a version for the event and try again.</value>
+    <value>공급자 {0}에 대해 ID {1}이(가) 여러 개 정의되어 있어 이벤트를 쓸 수 없습니다.  이벤트의 버전을 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="SpecifyOldestForEtlEvt" xml:space="preserve">
-    <value>The {0} event log file can be read only in the forward chronological order because it is an .etl or an .evt file. To see events from the {0} event log, use the Oldest parameter in the command.</value>
+    <value>{0} 이벤트 로그 파일은 .etl 또는 .evt 파일이므로 앞으로의 시간 순서로만 읽을 수 있습니다. {0} 이벤트 로그의 이벤트를 보려면 명령에서 Oldest 매개 변수를 사용하세요.</value>
   </data>
   <data name="ProviderNotSpecified" xml:space="preserve">
-    <value>Provider name must be specified.</value>
+    <value>제공자 이름을 지정해야 합니다.</value>
   </data>
   <data name="NotALogFile" xml:space="preserve">
-    <value>The {0} file does not appear to be a valid log file. Specify only .evtx, .etl, or .evt files as values of the Path parameter.</value>
+    <value>{0} 파일이 올바른 로그 파일이 아닌 것 같습니다. Path 매개 변수 값으로는 .evtx, .etl 또는 .evt 파일만 지정하세요.</value>
   </data>
   <data name="CounterPathInvalidOrNotInFile" xml:space="preserve">
-    <value>The {0} performance counter path is either not valid or it is not present in the following files: {1}.</value>
+    <value>{0} 성능 카운터 경로가 유효하지 않거나 다음 파일에 없습니다. {1}.</value>
   </data>
   <data name="Timestamp" xml:space="preserve">
     <value>타임스탬프</value>
   </data>
   <data name="DateTimeExpected" xml:space="preserve">
-    <value>The following value is not in a valid DateTime format: {0}.</value>
+    <value>다음 값은 올바른 DateTime 형식이 아닙니다. {0}.</value>
   </data>
   <data name="LogInfoUnavailable" xml:space="preserve">
-    <value>To access the '{0}' log start PowerShell with elevated user rights.  Error: {1}</value>
+    <value>'{0}' 로그에 액세스하려면 상승된 사용자 권한으로 PowerShell을 시작하세요.  오류: {1}</value>
   </data>
   <data name="LogInfoNoAccess" xml:space="preserve">
-    <value>Access denied for log: '{0}'.</value>
+    <value>로그 액세스가 거부됨: {0}</value>
   </data>
   <data name="SuggestElevation" xml:space="preserve">
-    <value>Launch PowerShell with elevated user rights.</value>
+    <value>상승된 사용자 권한으로 PowerShell을 시작합니다.</value>
   </data>
   <data name="NoEventMessage" xml:space="preserve">
-    <value>Cannot retrieve event message text.</value>
+    <value>이벤트 메시지 텍스트를 검색할 수 없습니다.</value>
   </data>
   <data name="CounterFileExists" xml:space="preserve">
-    <value>The {0} file already exists. To overwrite this file, use the Force parameter in the Export-Counter command.</value>
+    <value>{0} 파일이 이미 있습니다. 이 파일을 덮어쓰려면 Export-Counter 명령에서 Force 매개 변수를 사용하세요.</value>
   </data>
   <data name="CounterContinuousOrMaxSamples" xml:space="preserve">
-    <value>The Continuous parameter and the MaxSamples parameter cannot be used in the same command.</value>
+    <value>Continuous 매개 변수와 MaxSamples 매개 변수는 같은 명령에서 함께 사용할 수 없습니다.</value>
   </data>
   <data name="ExportCtrWin7Required" xml:space="preserve">
-    <value>This cmdlet can be run only on Microsoft Windows 7 and above.</value>
+    <value>이 cmdlet은 Microsoft Windows 7 이상에서만 실행할 수 있습니다.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>This PowerShell snap-in contains Windows Eventing and Performance Counter cmdlets.</value>
+    <value>이 PowerShell 스냅인에는 Windows 이벤트 및 성능 카운터 cmdlet이 포함되어 있습니다.</value>
   </data>
   <data name="NoMatchingCounterSetsInFile" xml:space="preserve">
-    <value>Cannot find any performance counter sets in the {0} files that match the following: {1}.</value>
+    <value>{0} 파일에서 다음과 일치하는 성능 카운터 집합을 찾을 수 없습니다. {1}</value>
   </data>
   <data name="LogsAndProvidersDontOverlap" xml:space="preserve">
-    <value>The specified providers do not write events to any of the specified logs.</value>
+    <value>지정된 공급자는 지정된 로그에 이벤트를 쓰지 않습니다.</value>
   </data>
   <data name="CookedValues" xml:space="preserve">
-    <value>Cooked Values</value>
+    <value>가공된 값</value>
   </data>
   <data name="Counter1FileLimit" xml:space="preserve">
-    <value>You cannot import more than one comma-separated (.csv) or tab-separated (.tsv) performance counter file in each command.</value>
+    <value>각 명령에서 쉼표로 구분된(.csv) 또는 탭으로 구분된(.tsv) 성능 카운터 파일을 두 개 이상 가져올 수 없습니다.</value>
   </data>
   <data name="LogCountLimitExceeded" xml:space="preserve">
-    <value>Log count ({0}) is exceeded Windows Event Log API limit ({1}). Adjust filter to return less log names.</value>
+    <value>로그 수({0})가 Windows 이벤트 로그 API 제한({1})을 초과했습니다. 더 적은 로그 이름을 반환하도록 필터를 조정하세요.</value>
   </data>
   <data name="ListLogParamHelp" xml:space="preserve">
-    <value>Specifies the event logs. Wildcards are permitted.</value>
+    <value>이벤트 로그를 지정합니다. 와일드카드를 사용할 수 있습니다.</value>
   </data>
   <data name="GetLogParamHelp" xml:space="preserve">
-    <value>Specifies the event logs that this cmdlet gets events from. Wildcards are permitted.</value>
+    <value>이 cmdlet이 이벤트를 가져오는 이벤트 로그를 지정합니다. 와일드카드를 사용할 수 있습니다.</value>
   </data>
   <data name="ListProviderParamHelp" xml:space="preserve">
-    <value>Specifies the event log providers that this cmdlet gets.</value>
+    <value>이 cmdlet이 가져오는 이벤트 로그 공급자를 지정합니다.</value>
   </data>
   <data name="GetProviderParamHelp" xml:space="preserve">
-    <value>Specifies the event log providers from which this cmdlet gets events.</value>
+    <value>이 cmdlet이 이벤트를 가져오는 이벤트 로그 공급자를 지정합니다.</value>
   </data>
   <data name="PathParamHelp" xml:space="preserve">
-    <value>Specifies the path to the event log files that this cmdlet gets events from.</value>
+    <value>이 cmdlet이 이벤트를 가져오는 이벤트 로그 파일의 경로를 지정합니다.</value>
   </data>
   <data name="MaxEventsParamHelp" xml:space="preserve">
-    <value>Specifies the maximum number of events that are returned.</value>
+    <value>반환되는 최대 이벤트 수를 지정합니다.</value>
   </data>
   <data name="ComputerNameParamHelp" xml:space="preserve">
-    <value>Specifies the name of the computer from which this cmdlet gets data.</value>
+    <value>이 cmdlet이 데이터를 가져오는 컴퓨터의 이름을 지정합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/cs/ComputerInfoResources.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/cs/ComputerInfoResources.cs.resx
@@ -118,27 +118,27 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="LoadingOperationSystemInfo" xml:space="preserve">
-    <value>Loading operating system information</value>
+    <value>Načítají se informace o operačním systému.</value>
   </data>
   <data name="LoadingHotPatchInfo" xml:space="preserve">
-    <value>Loading hot-patch information</value>
+    <value>Načítají se informace o aktualizacích instalovatelných bez restartování.</value>
   </data>
   <data name="LoadingRegistryInfo" xml:space="preserve">
-    <value>Loading registry information</value>
+    <value>Načítají se informace o registru.</value>
   </data>
   <data name="LoadingBiosInfo" xml:space="preserve">
-    <value>Loading BIOS information</value>
+    <value>Načítají se informace o systému BIOS.</value>
   </data>
   <data name="LoadingMotherboardInfo" xml:space="preserve">
-    <value>Loading motherboard information</value>
+    <value>Načítají se informace o základní desce.</value>
   </data>
   <data name="LoadingComputerInfo" xml:space="preserve">
-    <value>Loading Computer information</value>
+    <value>Načítají se informace o počítači.</value>
   </data>
   <data name="LoadingProcessorInfo" xml:space="preserve">
-    <value>Loading processor information</value>
+    <value>Načítají se informace o procesoru.</value>
   </data>
   <data name="LoadingNetworkAdapterInfo" xml:space="preserve">
-    <value>Loading network adapter information</value>
+    <value>Načítají se informace o síťovém adaptéru.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/cs/HotFixResources.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/cs/HotFixResources.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>V počítači {0} nelze najít požadovanou opravu hotfix. Ověřte vstup a spusťte příkaz znovu.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/cs/TestPathResources.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/cs/TestPathResources.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PathIsNullOrEmptyCollection" xml:space="preserve">
-    <value>The provided Path argument was null or an empty collection.</value>
+    <value>Zadaný argument Path měl hodnotu null nebo představoval prázdnou kolekci.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/de/HotFixResources.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/de/HotFixResources.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>Der angeforderte Hotfix wurde auf dem Computer „{0}“ nicht gefunden. Überprüfen Sie die Eingabe, und führen Sie den Befehl erneut aus.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/de/NavigationResources.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/de/NavigationResources.de.resx
@@ -118,75 +118,75 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeleteHasChildrenPrompt" xml:space="preserve">
-    <value>The specified path is a container that has child items. Do you want to delete this container and its child items?</value>
+    <value>Der angegebene Pfad ist ein Container mit untergeordneten Elementen. Möchten Sie diesen Container und seine untergeordneten Elemente löschen?</value>
   </data>
   <data name="DeletePrompt" xml:space="preserve">
-    <value>Do you want to delete the specified item?</value>
+    <value>Möchten Sie das angegebene Element löschen?</value>
   </data>
   <data name="CopyToExistingPrompt" xml:space="preserve">
-    <value>Cannot copy because the specified destination already exists. Do you want to overwrite the existing content?</value>
+    <value>Kann nicht kopiert werden, da das angegebene Ziel bereits vorhanden ist. Möchten Sie den vorhandenen Inhalt überschreiben?</value>
   </data>
   <data name="NewDriveConfirmAction" xml:space="preserve">
-    <value>New drive</value>
+    <value>Neues Laufwerk</value>
   </data>
   <data name="NewDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Name: {0} Anbieter: {1} Stamm: {2}</value>
   </data>
   <data name="RemoveDriveConfirmAction" xml:space="preserve">
-    <value>Remove Drive</value>
+    <value>Laufwerk entfernen</value>
   </data>
   <data name="RemoveDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Name: {0} Anbieter: {1} Stamm: {2}</value>
   </data>
   <data name="RemoveDriveInUse" xml:space="preserve">
-    <value>Cannot remove drive '{0}' because it is in use.</value>
+    <value>Das Laufwerk „{0}“ kann nicht entfernt werden, da es verwendet wird.</value>
   </data>
   <data name="RemoveItemWithChildren" xml:space="preserve">
-    <value>The item at {0} has children and the Recurse parameter was not specified. If you continue, all children will be removed with the item. Are you sure you want to continue?</value>
+    <value>Das Element hat {0} untergeordnete Elemente und der Recurse-Parameter wurde nicht angegeben. Wenn Sie fortfahren, werden alle untergeordneten Elemente mit dem Element entfernt. Sind Sie sicher, dass Sie den Vorgang fortsetzen?</value>
   </data>
   <data name="RemoveItemInUse" xml:space="preserve">
-    <value>Cannot remove the item at '{0}' because it is in use.</value>
+    <value>Das Element unter „{0}“ kann nicht entfernt werden, da es verwendet wird.</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist, or has been filtered by the -Include or -Exclude parameter.</value>
+    <value>Ein Objekt am angegebenen Pfad {0} ist nicht vorhanden oder wurde mit dem -Include- oder -Exclude-Parameter gefiltert.</value>
   </data>
   <data name="SetContentAction" xml:space="preserve">
-    <value>Set Content</value>
+    <value>Inhalt festlegen</value>
   </data>
   <data name="SetContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Pfad: {0}</value>
   </data>
   <data name="AddContentAction" xml:space="preserve">
-    <value>Add Content</value>
+    <value>Inhalt hinzufügen</value>
   </data>
   <data name="AddContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Pfad: {0}</value>
   </data>
   <data name="MoveItemDoesntExist" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' does not exist.</value>
+    <value>Das Element kann nicht verschoben werden, da das Element unter „{0}“ nicht vorhanden ist.</value>
   </data>
   <data name="MoveItemInUse" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' is in use.</value>
+    <value>Das Element kann nicht verschoben werden, da das Element unter „{0}“ verwendet wird.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>Cannot rename because item at '{0}' does not exist.</value>
+    <value>Kann nicht umbenannt werden, da das Element unter „{0}“ nicht vorhanden ist.</value>
   </data>
   <data name="RenamedItemInUse" xml:space="preserve">
-    <value>Cannot rename the item at '{0}' because it is in use.</value>
+    <value>Das Element kann nicht unter „{0}“ umbenannt werden, da es verwendet wird.</value>
   </data>
   <data name="ParsePathFormatError" xml:space="preserve">
-    <value>Cannot parse path because path '{0}' does not have a qualifier specified.</value>
+    <value>Der Pfad kann nicht analysiert werden, da für den Pfad „{0}“ kein Qualifizierer angegeben ist.</value>
   </data>
   <data name="CreateAction" xml:space="preserve">
-    <value>Begin</value>
+    <value>Beginn</value>
   </data>
   <data name="RollbackAction" xml:space="preserve">
     <value>Rollback</value>
   </data>
   <data name="CommitAction" xml:space="preserve">
-    <value>Commit</value>
+    <value>Committen</value>
   </data>
   <data name="TransactionResource" xml:space="preserve">
-    <value>Current transaction</value>
+    <value>Aktuelle Transaktion</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/de/ProcessResources.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/de/ProcessResources.de.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>Es wurde kein Prozess mit dem Namen „{0}“ gefunden. Überprüfen Sie den Prozessnamen, und rufen Sie das Cmdlet erneut auf.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>Es wurde kein Prozess mit dem Namen „{0}“ gefunden. Führen Sie den Befehl mit -Id aus, um nach der ID der Prozesse zu suchen.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>Dieser Befehl kann nicht ausgeführt werden, da der Debugger nicht an den Prozess „{0} ({1})“ angefügt werden kann. Geben Sie einen anderen Prozess an, und führen Sie den Befehl aus.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>Es wurde kein Prozess mit der Prozess-ID „{1}“ gefunden.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>Der Prozess „{0} ({1})“ kann aufgrund des folgenden Fehlers nicht beendet werden: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>Die Module des Prozesses „{0}“ können nicht aufgelistet werden.</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>Die Dateiversionsinformationen des Prozesses „{0}“ können nicht aufgezählt werden.</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>Die Module und die Dateiversionsinformationen des Prozesses „{0}“ können nicht aufgezählt werden.</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>Möchten Sie den Stop-Process-Vorgang für das folgende Element ausführen: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>Der angegebene Pfad ist keine gültige win32-Anwendung. Wiederholen Sie den Vorgang mit UseShellExecute.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>Dieser Befehl hat den Vorgang von „{0} ({1})“ aufgrund des folgenden Fehlers beendet: {2}.</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Dieser Befehl kann nicht ausgeführt werden, da Umleitungsparameter nicht zusammen mit dem Parameter UseShellExecute verwendet werden können.</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>Ausnahme beim Abrufen von „Modules“ oder „FileVersion“: „This feature is not supported for remote computers.“.</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>Dieser Befehl kann den Debugger nicht an den Prozess anfügen, da „{0}“ kein Standarddebugger verfügbar ist.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>Dieser Befehl hat den Vorgang beendet, da er nicht auf den Prozess „System Idle“ (System im Leerlauf) warten kann. Geben Sie einen anderen Prozess an, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>Dieser Befehl hat den Vorgang beendet, da er nicht auf sich selbst warten kann. Geben Sie einen anderen Prozess an, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>Dieser Befehl hat den Vorgang beendet, da der Prozess „{0} ({1})“ nicht innerhalb der angegebenen Zeitüberschreitung beendet wurde.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>Dieser Befehl kann aufgrund des folgenden Fehlers nicht ausgeführt werden: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>Dieser Befehl kann nicht ausgeführt werden, da die Eingabe „{0}“ keine gültige Anwendung ist.  Geben Sie eine gültige Anwendung an, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>Dieser Befehl kann nicht ausgeführt werden, da der Parameter „{0}“ einen ungültigen Wert hat oder nicht mit diesem Befehl verwendet werden kann. Geben Sie eine gültige Eingabe ein, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>Dieser Befehl kann nicht ausgeführt werden, da „{0}“ und „{1}“ identisch sind. Geben Sie unterschiedliche Eingaben an, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>Dieser Befehl kann nicht vollständig ausgeführt werden, da das System nicht alle erforderlichen Informationen finden kann.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>Beim Abrufen des neuen Prozesshandles ist ein Fehler aufgetreten: „{0}“. Das ausgegebene Process-Objekt verfügt möglicherweise über einige Eigenschaften und Methoden, die nicht ordnungsgemäß funktionieren.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>Dieser Befehl kann aufgrund des Fehlers 1783 nicht ausgeführt werden. Eine mögliche Ursache für diesen Fehler ist die Verwendung des nicht vorhandenen Benutzers „{0}“. Geben Sie einen gültigen Benutzer an, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>Fehler beim Hinzufügen von „{0}“ zum Netzwerk: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>Fehler beim Entfernen von „{0}“ aus dem Netzwerk: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>Fehler beim Umbenennen von „{0}“: {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>Die Parameter „{0}“ und „{1}“ können nicht gleichzeitig festgelegt werden.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>Der Prozess „{0} ({1})“ kann aufgrund des folgenden Fehlers nicht debuggen werden: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>Der Benutzer besitzt keinen Zugriff auf die angeforderten Informationen.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>Der angegebene Parameter ist ungültig.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>Der Benutzer verfügt nicht über ausreichende Berechtigungen.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>Unbekannter Fehler.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>Der angegebene Pfad ist nicht vorhanden.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>Der Parameter „{0}“ wird für das Cmdlet „{1}“ in dieser Windows-Edition nicht unterstützt.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>Der Parameter „{0}“ wird für das Cmdlet „{1}“ in dieser PowerShell-Edition nicht unterstützt.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/de/TestPathResources.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/de/TestPathResources.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PathIsNullOrEmptyCollection" xml:space="preserve">
-    <value>The provided Path argument was null or an empty collection.</value>
+    <value>Das angegebene Path-Argument war Null oder eine leere Auflistung.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/es/HotFixResources.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/es/HotFixResources.es.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>No se encuentra la revisión solicitada en el equipo ''{0}. Compruebe la entrada y vuelva a ejecutar el comando.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/es/ProcessResources.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/es/ProcessResources.es.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>No se encuentra un proceso con el nombre "{0}". Compruebe el nombre del proceso y vuelva a llamar al cmdlet.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>No se encuentra un proceso con el nombre "{0}". Intente ejecutar con -Id para buscar por id. de procesos.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>Este comando no se puede ejecutar porque el depurador no se puede asociar al proceso "{0} ({1})". Especifique otro proceso y ejecute el comando.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>No se encuentra ningún proceso con el identificador de proceso {1}.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>No se puede detener el proceso "{0} ({1})" debido al siguiente error: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>No se pueden enumerar los módulos del proceso "{0}".</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>No se puede enumerar la información de versión del archivo del proceso "{0}".</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>No se pueden enumerar los módulos ni la información de versión del archivo del proceso "{0}".</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>¿Está seguro de que desea realizar la operación Stop-Process en el siguiente elemento: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>La ruta de acceso especificada no es una aplicación win32 válida. Vuelva a intentarlo con UseShellExecute.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>Este comando detuvo la operación de "{0} ({1})" debido al siguiente error: {2}.</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>No se puede ejecutar este comando porque no se pueden usar parámetros de redirección con el parámetro UseShellExecute</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>Excepción al obtener "Modules" o "FileVersion": "Esta característica no se admite para equipos remotos".</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>Este comando no puede asociar el depurador al proceso porque {0} no hay ningún depurador predeterminado disponible.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>Este comando detuvo la operación porque no puede esperar en el proceso "Inactiva del sistema". Especifique otro proceso y vuelva a ejecutar el comando.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>Este comando detuvo la operación porque no puede esperar por sí mismo. Especifique otro proceso y vuelva a ejecutar el comando.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>Este comando detuvo la operación porque el proceso "{0} ({1})" no se detuvo en el tiempo de espera especificado.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>Este comando no se puede ejecutar debido al error: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>No se puede ejecutar este comando porque la entrada "{0}" no es una aplicación válida.  Proporcione una aplicación válida y vuelva a ejecutar el comando.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>Este comando no se puede ejecutar porque el parámetro "{0}" tiene un valor que no es válido o no se puede usar con este comando. Proporcione una entrada válida y vuelva a ejecutar el comando.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>No se puede ejecutar este comando porque "{0}" y "{1}" son iguales. Proporcione entradas diferentes y vuelva a ejecutar el comando.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>Este comando no se puede ejecutar completamente porque el sistema no encuentra toda la información necesaria.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>No se pudo recuperar el nuevo identificador de proceso: "{0}". El objeto Process generado puede tener algunas propiedades y métodos que no funcionan correctamente.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>Este comando no se puede ejecutar debido al error 1783. La posible causa de este error puede ser el uso de un usuario no existente "{0}". Proporcione un usuario válido y vuelva a ejecutar el comando.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>Error al agregar "{0}" a la red: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>Error al quitar "{0}" de la red: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>Error al cambiar el nombre de "{0}": {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>Los parámetros "{0}" y "{1}" no se pueden especificar al mismo tiempo.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>No se puede depurar el proceso "{0} ({1})" debido al siguiente error: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>El usuario no tiene acceso a la información pedida.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>El parámetro especificado no es válido.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>El usuario no tiene privilegios suficientes.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>Error desconocido.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>La ruta especificada no existe.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>El parámetro "{0}" no es compatible con el cmdlet "{1}" en esta edición de Windows.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>El parámetro "{0}" no es compatible con el cmdlet "{1}" en esta edición de PowerShell.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/fr/TimeZoneResources.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/fr/TimeZoneResources.fr.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>Nous ne pouvons pas définir le fuseau horaire local, car le nom « {0} » correspond à plusieurs entrées.</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>Le nom de fuseau horaire « {0} » est introuvable sur l’ordinateur local.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/it/HotFixResources.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/it/HotFixResources.it.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>Non è possibile trovare l'hotfix richiesto nel computer ''{0}''. Verificare l'input ed eseguire di nuovo il comando.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/it/ProcessResources.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/it/ProcessResources.it.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>Non è possibile trovare un processo denominato "{0}". Verificare il nome del processo e chiamare di nuovo il cmdlet.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>Non è possibile trovare un processo denominato "{0}". Provare a eseguire con -Id per cercare in base all'ID dei processi.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>Non è possibile eseguire questo comando perché il debugger non può essere collegato al processo "{0} ({1})". Specificare un altro processo ed eseguire il comando.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>Non è possibile trovare un processo con l'identificatore del processo {1}.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>Non è possibile arrestare il processo "{0} ({1})" a causa dell'errore seguente: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>Non è possibile enumerare i moduli del processo "{0}".</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>Non è possibile enumerare le informazioni sulla versione del file del processo "{0}".</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>Non è possibile enumerare i moduli e le informazioni sulla versione del file del processo "{0}".</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>Eseguire l'operazione Stop-Process sull'elemento seguente: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>Il percorso specificato non è un'applicazione win32 valida. Riprovare con UseShellExecute.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>Questo comando ha interrotto l'esecuzione di "{0} ({1})" a causa dell'errore seguente: {2}.</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Questo comando non può essere eseguito perché non è possibile usare i parametri di reindirizzamento con il parametro UseShellExecute</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>Eccezione durante il recupero di "Modules" o "FileVersion": "Questa funzionalità non è supportata per i computer remoti".</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>Questo comando non può collegare il debugger al processo a causa di {0} perché non è disponibile alcun debugger predefinito.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>Questo comando ha interrotto l'esecuzione perché non può attendere il processo 'System Idle'. Specificare un altro processo ed eseguire di nuovo il comando.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>Questo comando ha interrotto l'esecuzione perché non può attendere se stesso. Specificare un altro processo ed eseguire di nuovo il comando.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>Questo comando ha interrotto l'esecuzione perché il processo "{0} ({1})" non è arrestato nel timeout specificato.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>Non è possibile eseguire questo comando a causa dell'errore: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>Non è possibile eseguire questo comando perché l'input "{0}" non è un'applicazione valida.  Specificare un'applicazione valida ed eseguire di nuovo il comando.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>Non è possibile eseguire questo comando perché il parametro "{0}" ha un valore non valido o non può essere usato con questo comando. Specificare un input valido ed eseguire di nuovo il comando.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>Non è possibile eseguire questo comando perché "{0}" e "{1}" sono uguali. Assegnare input diversi ed eseguire di nuovo il comando.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>Non è possibile eseguire completamente questo comando perché il sistema non è in grado di trovare tutte le informazioni necessarie.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>Non è possibile recuperare il nuovo handle di processo: "{0}". È possibile che alcune proprietà e metodi dell'oggetto Process restituito non funzionino correttamente.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>Questo comando non può essere eseguito a causa dell'errore 1783. Una possibile causa dell'errore può essere l'uso di un utente inesistente "{0}". Specificare un utente valido ed eseguire di nuovo il comando.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>Errore durante l'aggiunta di '{0}' alla rete: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>Errore durante la rimozione di '{0}' dalla rete: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>Errore durante la ridenominazione di '{0}': {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>Non è possibile specificare "{0}" e "{1}" contemporaneamente.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>Non è possibile eseguire il debug del processo "{0} ({1})" a causa dell'errore seguente: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>L'utente non ha accesso alle informazioni richieste.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>Il parametro specificato non è valido.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>L'utente non dispone di privilegi sufficienti.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>Errore sconosciuto.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>Il percorso specificato non esiste.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>Il parametro '{0}' non è supportato per il cmdlet '{1}' in questa edizione di Windows.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>Il parametro '{0}' non è supportato per il cmdlet '{1}' in questa edizione di PowerShell.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/it/TestConnectionResources.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/it/TestConnectionResources.it.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoPingResult" xml:space="preserve">
-    <value>Testing connection to computer '{0}' failed: {1}</value>
+    <value>Il test della connessione al computer '{0}' non è riuscito: {1}</value>
   </data>
   <data name="CannotResolveTargetName" xml:space="preserve">
-    <value>Cannot resolve the target name.</value>
+    <value>Non è possibile risolvere il nome della destinazione.</value>
   </data>
   <data name="TargetAddressAbsent" xml:space="preserve">
-    <value>Target IPv4/IPv6 address absent.</value>
+    <value>Indirizzo IPv4/IPv6 di destinazione assente.</value>
   </data>
   <data name="MaxHopsExceeded" xml:space="preserve">
-    <value>Cannot complete traceroute to destination '{0}': Number of hops required to reach host exceeds MaxHops ({1}).</value>
+    <value>Non è possibile completare il traceroute alla destinazione '{0}': il numero di hop necessari per raggiungere l'host supera il valore MaxHops ({1}).</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ja/HotFixResources.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ja/HotFixResources.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>'{0}' コンピューターに要求された修正プログラムが見つかりません。入力を確認し、コマンドをもう一度実行してください。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ja/ProcessResources.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ja/ProcessResources.ja.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>"{0}" という名前のプロセスが見つかりません。プロセス名を確認し、コマンドレットをもう一度呼び出してください。</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>"{0}" という名前のプロセスが見つかりません。プロセスの ID で検索するには、-Id を指定して実行してみてください。</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>デバッガーをプロセス "{0} ({1})" にアタッチできないため、このコマンドを実行できません。別のプロセスを指定して、コマンドを実行してください。</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>プロセス識別子が {1} のプロセスが見つかりません。</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>次のエラーにより、プロセス "{0} ({1})" を停止できません: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>"{0}" プロセスのモジュールを列挙できません。</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>"{0}" プロセスのファイル バージョン情報を列挙できません。</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>"{0}" プロセスのモジュールとファイル バージョン情報を列挙できません。</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>次の項目に対して Stop-Process 操作を実行しますか: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>指定されたパスは、有効な win32 アプリケーションではありません。UseShellExecute を使用して、もう一度お試しください。</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>このコマンドは、次のエラーにより、"{0} ({1})" の操作を停止しました: {2}。</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Redirection パラメーターは UseShellExecute パラメーターと共に使用できないため、このコマンドを実行できません</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>"Modules" または "FileVersion" の取得で例外が発生しました: "この機能はリモート コンピューターではサポートされていません。"。</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>既定のデバッガーがないため、{0} により、このコマンドはデバッガーをプロセスにアタッチできません。</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>このコマンドは、'システム アイドル' 状態のプロセスで待機できないため、操作を停止しました。別のプロセスを指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>このコマンドは、それ自体を待機できないため、操作を停止しました。別のプロセスを指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>このコマンドは、指定されたタイムアウト時間内にプロセス "{0} ({1})" が停止しなかったため、操作を停止しました。</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>次のエラーにより、このコマンドを実行できません: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>入力 "{0}" が有効なアプリケーションではないため、このコマンドを実行できません。 有効なアプリケーションを指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>パラメーター "{0}" の値が無効であるか、このコマンドでは使用できないため、このコマンドを実行できません。有効な入力を指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>"{0}" と "{1}" が同じであるため、このコマンドを実行できません。異なる入力を指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>システムが必要なすべての情報を見つけられないため、このコマンドを完全に実行できません。</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>新しいプロセス ハンドルを取得できませんでした: "{0}"。出力された Process オブジェクトには、正しく動作しないプロパティやメソッドが含まれている可能性があります。</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>エラー 1783 のため、このコマンドを実行できません。このエラーの原因として、存在しないユーザー "{0}" の使用が考えられます。有効なユーザーを指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>ネットワークへの '{0}' の追加でエラーが発生しました: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>ネットワークからの '{0}' の削除でエラーが発生しました: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>'{0}' の名前の変更でエラーが発生しました: {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>パラメーター "{0}" と "{1}" を同時に指定することはできません。</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>次のエラーにより、プロセス "{0} ({1})" をデバッグできません: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>ユーザーには、要求された情報へのアクセス権がありません。</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>指定されたパラメーターは無効です。</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>ユーザーには十分な権限がありません。</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>不明なエラーです。</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>指定されたパスが存在しない。</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>パラメーター '{0}' は、このエディションの Windows のコマンドレット '{1}' ではサポートされていません。</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>パラメーター '{0}' は、このエディションの PowerShell のコマンドレット '{1}' ではサポートされていません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ja/TestPathResources.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ja/TestPathResources.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PathIsNullOrEmptyCollection" xml:space="preserve">
-    <value>The provided Path argument was null or an empty collection.</value>
+    <value>指定された Path 引数が null 値または空のコレクションでした。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ja/TimeZoneResources.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ja/TimeZoneResources.ja.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>名前 '{0}' は複数のエントリに解決されるため、ローカル タイム ゾーンを設定できません。</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>ローカル コンピューターにタイム ゾーン名 '{0}' が見つかりませんでした。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ko/CmdletizationResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ko/CmdletizationResources.ko.resx
@@ -118,54 +118,54 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CimJob_InvalidClassName" xml:space="preserve">
-    <value>Cannot find the {0} class on the {1} CIM server.  Verify the value of the ClassName xml attribute in Cmdlet Definition XML and retry. Valid class name example: ROOT\cimv2\Win32_Process.</value>
+    <value>{1} CIM 서버에서 {0} 클래스를 찾을 수 없습니다.  Cmdlet Definition XML에서 ClassName xml 특성의 값을 확인하고 다시 시도하세요. 유효한 클래스 이름 예: ROOT\cimv2\Win32_Process.</value>
     <comment>{StrContains="ClassName"} {StrContains="ROOT\cimv2\Win32_Process"}
 {0} is a placeholder for a name of a (potentially misspelled) CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".</comment>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="CimJob_MethodDescription" xml:space="preserve">
-    <value>CIM method {1} on the {0} CIM object</value>
+    <value>{0}CIM 개체의 CIM 메서드 {1}</value>
     <comment>{0} is a placeholder for a CIM path. Example: \\SERVER1\ROOT\cimv2:Win32_Process.Handle="11828"
 {1} is a placeholder for a CIM method name. Example: Create</comment>
   </data>
   <data name="CimJob_GenericCimFailure" xml:space="preserve">
-    <value>Failed to run {1}.  {0}</value>
+    <value>{1}을(를)실행하지 못했습니다.  {0}</value>
     <comment>{0} is a placeholder for a generic CIM failure.  Example: 'Invalid namespace' or '9'
 {1} is a placeholder for a description of CIM operation.  This most likely comes from CimJob_MethodDescription or CimJob_QueryDescription</comment>
   </data>
   <data name="CimJob_VerboseExecutionMessage" xml:space="preserve">
-    <value>Running the following operation: {0}.</value>
+    <value>다음 작업을 실행하는 중입니다. {0}</value>
     <comment>{0} is a placeholder for a description of CIM operation.  This most likely comes from CimJob_MethodDescription or CimJob_QueryDescription</comment>
   </data>
   <data name="SessionBasedWrapper_ShouldProcessVsJobConflict" xml:space="preserve">
-    <value>CIM cmdlets do not support the {0} parameter together with the AsJob parameter.  Remove one of these parameters and retry.</value>
+    <value>CIM cmdlet은 {0} 매개 변수와 AsJob 매개 변수를 함께 지원하지 않습니다.  이 매개 변수들 중 하나를 제거하고 다시 시도하세요.</value>
     <comment>{StrContains="AsJob"}
 {0} is a placeholder for 'WhatIf' or 'Confirm' cmdlet parameters</comment>
   </data>
   <data name="CimJob_SafeQueryDescription" xml:space="preserve">
-    <value>CIM query for instances of the {0} class on the {1} CIM server: {2}</value>
+    <value>{1} CIM 서버의 {0} 클래스 인스턴스에 대한 CIM 쿼리: {2}</value>
     <comment>{0} is a placeholder for a name of a CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".</comment>
   </data>
   <data name="CimJob_ErrorCodeFromMethod" xml:space="preserve">
-    <value>The CIM method returned the following error code: {0}</value>
+    <value>CIM 메서드가 다음 오류 코드를 반환했습니다. {0}</value>
     <comment>{0} is a placeholder for an error code returned from a CIM method.  Example: 123</comment>
   </data>
   <data name="CimJob_SafeMethodDescription" xml:space="preserve">
-    <value>The {2} CIM method exposed by the {0} class on the {1} CIM server</value>
+    <value>{1} CIM 서버의 {0} 클래스에서 노출하는 {2} CIM 메서드</value>
     <comment>{0} is a placeholder for a name of a CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".
 {2} is a placeholder for a CIM method name. Example: Create</comment>
   </data>
   <data name="CimConversion_CimIntrinsicValue" xml:space="preserve">
-    <value>CIM intrinsic type</value>
+    <value>CIM 내장 형식</value>
   </data>
   <data name="CimConversion_WqlQuery" xml:space="preserve">
-    <value>WQL literal</value>
+    <value>WQL 리터럴</value>
   </data>
   <data name="CimJob_InvalidOutputParameterName" xml:space="preserve">
-    <value>Cannot find the {2} output parameter of the {1} method of the {0} CIM object.  Verify the value of the ParameterName attribute in Cmdlet Definition XML and retry.</value>
+    <value>{0} CIM 개체의 {1} 메서드에 대한 {2} 출력 매개 변수를 찾을 수 없습니다.  Cmdlet Definition XML에서 ParameterName 특성의 값을 확인하고 다시 시도하세요.</value>
     <comment>{StrContains="ParameterName"}
 {0} is a placeholder for a CIM path. Example: \\SERVER1\ROOT\cimv2:Win32_Process.Handle="11828"
 {1} is a placeholder for a name of a (potentially misspelled) CIM method.  Example: "Terminate".
@@ -173,45 +173,45 @@
 </comment>
   </data>
   <data name="CimJob_NotFound_ComplexCase" xml:space="preserve">
-    <value>No matching {1} objects found by {0}. Verify query parameters and retry.</value>
+    <value>{0}을(를) 통해 일치하는 {1} 개체를 찾을 수 없습니다. 쿼리 매개 변수를 확인하고 다시 시도하세요.</value>
   </data>
   <data name="CimJob_NotFound_SimpleGranularCase_Equality" xml:space="preserve">
-    <value>No {2} objects found with property '{0}' equal to '{1}'.  Verify the value of the property and retry.</value>
+    <value>속성 '{0}'이(가) '{1}'와(과) 같은 {2} 개체를 찾을 수 없습니다.  속성 값을 확인하고 다시 시도하세요.</value>
   </data>
   <data name="CimJob_MismatchedTypeOfPropertyReturnedByQuery" xml:space="preserve">
-    <value>Type of {0} property ({1}) doesn't match the CIM type ({2}) associated with the type declared in Cmdlet Definition XML.</value>
+    <value>Cmdlet Definition XML에 선언된 형식과 연결된 CIM 형식({2})이 {0} 속성({1})의 형식과 일치하지 않습니다.</value>
   </data>
   <data name="CimJob_SafeAssociationDescription" xml:space="preserve">
-    <value>CIM query for enumerating associated instance of the {0} class on the {1} CIM server</value>
+    <value>{1} CIM 서버의 {0} 클래스에 대한 연결된 인스턴스를 열거하는 CIM 쿼리</value>
     <comment>{0} is a placeholder for a name of a CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".</comment>
   </data>
   <data name="CimJob_AssociationDescription" xml:space="preserve">
-    <value>CIM query for enumerating instances of the {0} class on the {1} CIM server, that are associated with the following instance: {2}</value>
+    <value>다음 인스턴스와 연결된{1} CIM 서버의 {0} 클래스 인스턴스를 열거하는 CIM 쿼리입니다. {2}</value>
     <comment>{0} is a placeholder for a name of a CIM class.  Example: "Win32_Process".
 {1} is a placeholder for a server name.  Example: "localhost".
 {2} is a placeholder for a string describing a CimInstance.  Example: "Win32_Process[Handle=123]".</comment>
   </data>
   <data name="CimJob_SleepAndRetryVerboseMessage" xml:space="preserve">
-    <value>The {0} command cannot complete, because the {1} server is currently busy.  The command will be automatically resumed in {2:f2} seconds.</value>
+    <value>{1} 서버가 현재 사용 중이므로 {0} 명령을 완료할 수 없습니다.  명령은 {2:f2}초 후에 자동으로 다시 시작됩니다.</value>
     <comment>{0} is a placeholder for a command name.  Example: "Get-NetAdapter"
 {1} is a placeholder for a computer name.  Example: "localhost"
 {2} is a placeholder for a number of seconds.  Example: 1.23</comment>
   </data>
   <data name="CimJob_BrokenSession" xml:space="preserve">
-    <value>Cannot connect to CIM server. {0}</value>
+    <value>CIM 서버에 연결할 수 없습니다. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message.</comment>
   </data>
   <data name="CimCmdletAdapter_DebugInquire" xml:space="preserve">
-    <value>The cmdlet does not fully support the Inquire action for debug messages.  Cmdlet operation will continue during the prompt.  Select a different action preference via -Debug switch or $DebugPreference variable, and try again.</value>
+    <value>cmdlet은 디버그 메시지에 대한 Inquire 동작을 완전히 지원하지 않습니다.  프롬프트 중에도 cmdlet 작업은 계속됩니다.  -Debug 스위치 또는 $DebugPreference 변수를 통해 다른 동작 기본 설정을 선택하고 다시 시도하세요.</value>
     <comment>{StrContains="Debug"} {StrContains="DebugPreference"} {StrContains="Inquire"}</comment>
   </data>
   <data name="CimCmdletAdapter_WarningInquire" xml:space="preserve">
-    <value>The cmdlet does not fully support the Inquire action for warnings.  Cmdlet operation will continue during the prompt.  Select a different action preference via -WarningAction parameter or $WarningPreference variable, and try again.</value>
+    <value>cmdlet은 경고에 대한 Inquire 동작을 완전히 지원하지 않습니다.  프롬프트 중에도 cmdlet 작업은 계속됩니다.  -WarningAction 매개 변수 또는 $WarningPreference 변수를 통해 다른 동작 기본 설정을 선택하고 다시 시도하세요.</value>
     <comment>{StrContains="WarningAction"} {StrContains="WarningPreference"} {StrContains="Inquire"}</comment>
   </data>
   <data name="CimCmdletAdapter_WarningStop" xml:space="preserve">
-    <value>The cmdlet does not fully support the Stop action for warnings.  Cmdlet operation will be stopped with a delay.  Select a different action preference via -WarningAction parameter or $WarningPreference variable, and try again.</value>
+    <value>cmdlet은 경고에 대한 Stop 동작을 완전히 지원하지 않습니다.  cmdlet 작업은 지연 후 중지됩니다.  -WarningAction 매개 변수 또는 $WarningPreference 변수를 통해 다른 동작 기본 설정을 선택하고 다시 시도하세요.</value>
     <comment>{StrContains="WarningAction"} {StrContains="WarningPreference"} {StrContains="Stop"}</comment>
   </data>
   <data name="CimJob_ComputerNameConcatenationTemplate" xml:space="preserve">
@@ -220,11 +220,11 @@
 {1} is a placeholder for the original message.  Example: "Deleting managed resource"</comment>
   </data>
   <data name="CimCmdletAdapter_RemoteDcomDoesntSupportExtendedSemantics" xml:space="preserve">
-    <value>{0}: A CimSession to the CIM server uses the DCOM protocol, which does not support the {1} switch.</value>
+    <value>{0}: CimSession이 CIM 서버에 연결할 때 DCOM 프로토콜을 사용합니다. 이 프로토콜은 {1} 스위치를 지원하지 않습니다.</value>
     <comment>{0} is a placeholder for a name of a computer
 {1} is a placeholder for 'Confirm' or 'WhatIf'</comment>
   </data>
   <data name="CimJob_NotFound_SimpleGranularCase_Wildcard" xml:space="preserve">
-    <value>No {2} objects found with property '{0}' matching '{1}'.  Verify the value of the property and retry.</value>
+    <value>속성 '{0}'이(가) '{1}'와(과) 일치하는 {2} 개체를 찾을 수 없습니다.  속성 값을 확인하고 다시 시도하세요.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ko/HotFixResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ko/HotFixResources.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>'{0}' 컴퓨터에서 요청한 핫픽스를 찾을 수 없습니다. 입력을 확인한 다음 명령을 다시 실행하세요.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ko/ProcessResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ko/ProcessResources.ko.resx
@@ -118,117 +118,117 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>"{0}" 이름의 프로세스를 찾을 수 없습니다. 프로세스 이름을 확인한 다음 cmdlet을 다시 호출하세요.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>"{0}" 이름의 프로세스를 찾을 수 없습니다. 프로세스 ID로 검색하려면 -Id를 사용해 보세요.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>디버거를 "{0} ({1})" 프로세스에 연결할 수 없어서 이 명령을 실행할 수 없습니다. 다른 프로세스를 지정한 다음 명령을 다시 실행하세요.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>프로세스 식별자가 {1}인 프로세스를 찾을 수 없습니다.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>다음 오류로 인해 "{0} ({1})" 프로세스를 중지할 수 없습니다. {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
-    <value>{0} ({1})</value>
+    <value>{0}({1})</value>
   </data>
   <data name="StartProcessTarget" xml:space="preserve">
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>"{0}" 프로세스의 모듈을 열거할 수 없습니다.</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>"{0}" 프로세스의 파일 버전 정보를 열거할 수 없습니다.</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>"{0}" 프로세스의 모듈 및 파일 버전 정보를 열거할 수 없습니다.</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>{0}({1}) 항목에 대해 Stop-Process 작업을 수행하시겠습니까?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>지정한 경로는 올바른 Win32 응용 프로그램이 아닙니다. UseShellExecute를 사용하여 다시 시도하세요.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>다음 오류로 인해 이 명령이 "{0} ({1})" 작업을 중지했습니다. {2}</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Redirection 매개 변수는 UseShellExecute 매개 변수와 함께 사용할 수 없어서 이 명령을 실행할 수 없습니다.</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>"Modules" 또는 "FileVersion"을 가져오는 중 예외가 발생했습니다. "이 기능은 원격 컴퓨터에서 지원되지 않습니다."</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>기본 디버거를 사용할 수 없어서 이 명령은 {0} 때문에 프로세스에 디버거를 연결할 수 없습니다.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>"시스템 유휴 상태" 프로세스를 기다릴 수 없어서 이 명령이 중지되었습니다. 다른 프로세스를 지정하고 명령을 다시 실행하세요.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>자기 자신은 기다릴 수 없어서 이 명령이 중지되었습니다. 다른 프로세스를 지정하고 명령을 다시 실행하세요.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>"{0} ({1})" 프로세스가 지정된 제한 시간 안에 중지되지 않아서 이 명령이 중지되었습니다.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>오류 때문에 이 명령을 실행할 수 없습니다. {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>입력한 "{0}"이(가) 올바른 응용 프로그램이 아니므로 이 명령을 실행할 수 없습니다.  올바른 응용 프로그램을 지정한 다음 명령을 다시 실행하세요.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>매개 변수 "{0}"에 올바르지 않은 값이 있거나 이 명령과 함께 사용할 수 없어서 이 명령을 실행할 수 없습니다. 올바른 입력을 제공한 다음 명령을 다시 실행하세요.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>"{0}"과(와) "{1}"이(가) 같아서 이 명령을 실행할 수 없습니다. 다른 입력을 제공한 다음 명령을 다시 실행하세요.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>이 명령은 필요한 정보를 모두 찾을 수 없어서 완전히 실행할 수 없습니다.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>새 프로세스 핸들을 가져오지 못했습니다. "{0}". 출력된 Process 개체의 일부 속성과 메서드는 제대로 작동하지 않을 수 있습니다.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>오류 1783 때문에 이 명령을 실행할 수 없습니다. 이 오류의 원인은 존재하지 않는 사용자 "{0}"을(를) 사용하는 것일 수 있습니다. 올바른 사용자를 지정하고 명령을 다시 실행하세요.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>네트워크에 '{0}'을(를) 추가하는 동안 오류가 발생했습니다. {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>네트워크에서 '{0}'을(를) 제거하는 동안 오류가 발생했습니다. {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>‘{0}’의 이름을 바꾸는 동안 오류 발생: {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>매개 변수 "{0}" 및 "{1}"을(를) 동시에 지정할 수 없습니다.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>다음 오류로 인해 "{0} ({1})" 프로세스를 디버그할 수 없습니다. {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>사용자는 요청한 정보에 대한 액세스 권한이 없습니다.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>지정한 매개 변수가 잘못되었습니다.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>사용자에게 권한이 충분하지 않습니다.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>알 수 없는 오류가 발생했습니다.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>지정한 경로가 없습니다.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>'{0}' 매개 변수는 이 Windows 버전의 cmdlet '{1}'에서 지원되지 않습니다.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>'{0}' 매개 변수는 이 PowerShell 버전의 cmdlet '{1}'에서 지원되지 않습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ko/TestConnectionResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ko/TestConnectionResources.ko.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoPingResult" xml:space="preserve">
-    <value>Testing connection to computer '{0}' failed: {1}</value>
+    <value>컴퓨터 '{0}'에 대한 연결 테스트에 실패했습니다. {1}</value>
   </data>
   <data name="CannotResolveTargetName" xml:space="preserve">
-    <value>Cannot resolve the target name.</value>
+    <value>대상 이름을 확인할 수 없습니다.</value>
   </data>
   <data name="TargetAddressAbsent" xml:space="preserve">
-    <value>Target IPv4/IPv6 address absent.</value>
+    <value>대상 IPv4/IPv6 주소가 없습니다.</value>
   </data>
   <data name="MaxHopsExceeded" xml:space="preserve">
-    <value>Cannot complete traceroute to destination '{0}': Number of hops required to reach host exceeds MaxHops ({1}).</value>
+    <value>대상 '{0}'에 대한 경로 추적을 완료할 수 없습니다. 호스트에 도달하는 데 필요한 홉 수가 MaxHops({1})를 초과합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ko/TimeZoneResources.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ko/TimeZoneResources.ko.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>이름 '{0}'이(가) 여러 항목으로 확인되므로 로컬 표준 시간대를 설정할 수 없습니다.</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>로컬 컴퓨터에서 '{0}' 표준 시간대 이름을 찾을 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/pl/HotFixResources.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/pl/HotFixResources.pl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>Nie można odnaleźć żądanej poprawki na komputerze „{0}”. Sprawdź dane wejściowe i ponownie uruchom polecenie.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/pl/NavigationResources.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/pl/NavigationResources.pl.resx
@@ -118,75 +118,75 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeleteHasChildrenPrompt" xml:space="preserve">
-    <value>The specified path is a container that has child items. Do you want to delete this container and its child items?</value>
+    <value>Określona ścieżka jest kontenerem zawierającym elementy podrzędne. Czy chcesz usunąć ten kontener i jego elementy podrzędne?</value>
   </data>
   <data name="DeletePrompt" xml:space="preserve">
-    <value>Do you want to delete the specified item?</value>
+    <value>Czy chcesz usunąć określony element?</value>
   </data>
   <data name="CopyToExistingPrompt" xml:space="preserve">
-    <value>Cannot copy because the specified destination already exists. Do you want to overwrite the existing content?</value>
+    <value>Nie można skopiować, ponieważ określone miejsce docelowe już istnieje. Czy chcesz zastąpić istniejącą zawartość?</value>
   </data>
   <data name="NewDriveConfirmAction" xml:space="preserve">
-    <value>New drive</value>
+    <value>Nowy dysk</value>
   </data>
   <data name="NewDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Nazwa: {0} Dostawca: {1} Katalog główny: {2}</value>
   </data>
   <data name="RemoveDriveConfirmAction" xml:space="preserve">
-    <value>Remove Drive</value>
+    <value>Usuń dysk</value>
   </data>
   <data name="RemoveDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Nazwa: {0} Dostawca: {1} Katalog główny: {2}</value>
   </data>
   <data name="RemoveDriveInUse" xml:space="preserve">
-    <value>Cannot remove drive '{0}' because it is in use.</value>
+    <value>Nie można usunąć dysku „{0}”, ponieważ jest używany.</value>
   </data>
   <data name="RemoveItemWithChildren" xml:space="preserve">
-    <value>The item at {0} has children and the Recurse parameter was not specified. If you continue, all children will be removed with the item. Are you sure you want to continue?</value>
+    <value>Element {0} ma elementy podrzędne, a parametr Recurse nie został określony. Jeśli będziesz kontynuować, wszystkie elementy podrzędne zostaną usunięte wraz z elementem. Czy na pewno chcesz kontynuować?</value>
   </data>
   <data name="RemoveItemInUse" xml:space="preserve">
-    <value>Cannot remove the item at '{0}' because it is in use.</value>
+    <value>Nie można usunąć elementu w lokalizacji „{0}”, ponieważ jest on używany.</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist, or has been filtered by the -Include or -Exclude parameter.</value>
+    <value>Obiekt w określonej ścieżce {0} nie istnieje lub został przefiltrowany za pomocą parametru -Include lub -Exclude.</value>
   </data>
   <data name="SetContentAction" xml:space="preserve">
-    <value>Set Content</value>
+    <value>Ustaw zawartość</value>
   </data>
   <data name="SetContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Ścieżka: {0}</value>
   </data>
   <data name="AddContentAction" xml:space="preserve">
-    <value>Add Content</value>
+    <value>Dodaj zawartość</value>
   </data>
   <data name="AddContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Ścieżka: {0}</value>
   </data>
   <data name="MoveItemDoesntExist" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' does not exist.</value>
+    <value>Nie można przenieść elementu, ponieważ element w lokalizacji „{0}” nie istnieje.</value>
   </data>
   <data name="MoveItemInUse" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' is in use.</value>
+    <value>Nie można przenieść elementu, ponieważ element w „{0}” jest w użyciu.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>Cannot rename because item at '{0}' does not exist.</value>
+    <value>Nie można zmienić nazwy, ponieważ element w lokalizacji „{0}” nie istnieje.</value>
   </data>
   <data name="RenamedItemInUse" xml:space="preserve">
-    <value>Cannot rename the item at '{0}' because it is in use.</value>
+    <value>Nie można zmienić nazwy elementu w „{0}”, ponieważ jest on używany.</value>
   </data>
   <data name="ParsePathFormatError" xml:space="preserve">
-    <value>Cannot parse path because path '{0}' does not have a qualifier specified.</value>
+    <value>Nie można przeanalizować ścieżki, ponieważ ścieżka „{0}” nie ma określonego kwalifikatora.</value>
   </data>
   <data name="CreateAction" xml:space="preserve">
-    <value>Begin</value>
+    <value>Początek</value>
   </data>
   <data name="RollbackAction" xml:space="preserve">
-    <value>Rollback</value>
+    <value>Wycofaj</value>
   </data>
   <data name="CommitAction" xml:space="preserve">
-    <value>Commit</value>
+    <value>Zatwierdź</value>
   </data>
   <data name="TransactionResource" xml:space="preserve">
-    <value>Current transaction</value>
+    <value>Bieżąca transakcja</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/pl/ProcessResources.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/pl/ProcessResources.pl.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>Nie można odnaleźć procesu o nazwie „{0}”. Sprawdź nazwę procesu i ponownie wywołaj polecenie cmdlet.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>Nie można odnaleźć procesu o nazwie „{0}”. Spróbuj uruchomić polecenie z identyfikatorem -Id, aby wyszukać według identyfikatora procesów.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>Nie można uruchomić tego polecenia, ponieważ nie można dołączyć debugera do procesu „{0} ({1})”. Określ inny proces i uruchom polecenie.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>Nie można odnaleźć procesu o identyfikatorze procesu {1}.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>Nie można zatrzymać procesu „{0} ({1})” z powodu następującego błędu: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>Nie można wyliczyć modułów procesu „{0}”.</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>Nie można wyliczyć informacji o wersji pliku procesu „{0}”.</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>Nie można wyliczyć modułów i informacji o wersji pliku procesu „{0}”.</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>Czy na pewno chcesz wykonać operację zatrzymania procesu na następującym elemencie: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>Określona ścieżka nie jest prawidłową aplikacją win32. Spróbuj ponownie za pomocą polecenia UseShellExecute.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>To polecenie zatrzymało operację „{0} ({1})” z powodu następującego błędu: {2}.</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Nie można uruchomić tego polecenia, ponieważ parametrów przekierowania nie można używać z parametrem UseShellExecute</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>Wystąpił błąd podczas pobierania elementów „Modules” lub „FileVersion”: „Ta funkcja nie jest obsługiwana na komputerach zdalnych.”.</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>To polecenie nie może dołączyć debugera do procesu z powodu {0} braku dostępnego debugera domyślnego.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>To polecenie przerwało działanie, ponieważ nie może oczekiwać na zakończenie procesu bezczynności systemu. Określ inny proces i ponownie uruchom polecenie.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>To polecenie zatrzymało operację, ponieważ nie może czekać na siebie. Określ inny proces i ponownie uruchom polecenie.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>To polecenie zatrzymało operację, ponieważ proces „{0} ({1})” nie został zatrzymany w określonym przekroczeniem limitu czasu.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>Nie można uruchomić tego polecenia z powodu błędu: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>Nie można uruchomić tego polecenia, ponieważ dane wejściowe „{0}” nie są prawidłową aplikacją.  Podaj prawidłową aplikację i ponownie uruchom polecenie.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>Nie można uruchomić tego polecenia, ponieważ parametr „{0}” ma nieprawidłową wartość lub nie może być używany z tym poleceniem. Podaj prawidłowe dane wejściowe i ponownie uruchom polecenie.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>Nie można uruchomić tego polecenia, ponieważ „{0}” i „{1}” są takie same. Podaj różne dane wejściowe i ponownie uruchom polecenie.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>To polecenie nie może zostać w pełni wykonane, ponieważ system nie może znaleźć wszystkich wymaganych informacji.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>Nie można pobrać nowego dojścia procesu: „{0}”. Wyjściowy obiekt Process może mieć pewne właściwości i metody, które nie działają prawidłowo.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>Nie można uruchomić tego polecenia z powodu błędu 1783. Możliwą przyczyną tego błędu może być użycie nieistniejącego użytkownika „{0}”. Podaj prawidłowego użytkownika i ponownie uruchom polecenie.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>Błąd podczas dodawania elementu „{0}” do sieci: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>Błąd podczas usuwania elementu „{0}” z sieci: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>Błąd podczas zmieniania nazwy „{0}”: {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>Nie można jednocześnie podać parametrów „{0}” i „{1}”.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>Nie można przeprowadzić debugowania procesu „{0} ({1})” z powodu następującego błędu: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>Użytkownik nie ma dostępu do żądanych informacji.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>Określona nazwa parametru jest nieprawidłowa.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>Użytkownik nie ma wystarczających uprawnień.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>Nieznany błąd.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
-    <value>The path specified does not exist.</value>
+    <value>Podana ścieżka nie istnieje.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>Parametr „{0}” nie jest obsługiwany przez polecenie cmdlet „{1}” w tej wersji systemu Windows.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>Parametr „{0}” nie jest obsługiwany dla polecenia cmdlet „{1}” w tej wersji programu PowerShell.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/pl/TestPathResources.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/pl/TestPathResources.pl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PathIsNullOrEmptyCollection" xml:space="preserve">
-    <value>The provided Path argument was null or an empty collection.</value>
+    <value>Podany argument Path ma wartość null lub jest pustą kolekcją.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/pl/TimeZoneResources.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/pl/TimeZoneResources.pl.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>Nie można ustawić lokalnej strefy czasowej, ponieważ nazwa „{0}” wskazuje na wiele wpisów.</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>Nie znaleziono nazwy strefy czasowej „{0}” na komputerze lokalnym.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ru/HotFixResources.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ru/HotFixResources.ru.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>Не удалось найти запрошенное исправление на компьютере "{0}". Проверьте введенные данные и запустите команду еще раз.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/ru/ProcessResources.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/ru/ProcessResources.ru.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>Не удается найти процесс "{0}". Проверьте имя процесса и вызовите командлет еще раз.</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>Не удается найти процесс "{0}". Попробуйте запустить команду с параметром -Id для поиска по идентификатору процесса.</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>Эту команду нельзя выполнить, так как отладчик не может быть присоединен к процессу "{0} ({1})". Укажите другой процесс и выполните команду.</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>Не удается найти процесс с идентификатором {1}.</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>Невозможно остановить процесс "{0} ({1})" из-за следующей ошибки: {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>Не удается перечислить модули процесса "{0}".</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>Не удается получить сведения о версии файла для процесса "{0}".</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>Не удается получить сведения о модулях и версии файла для процесса "{0}".</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>Действительно выполнить операцию Stop-Process для следующего элемента: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>Указанный путь не является действительным приложением win32. Повторите попытку, используя UseShellExecute.</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>Эта команда остановила операцию "{0} ({1})" из-за следующей ошибки: {2}.</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>Эту команду нельзя выполнить, так как параметры перенаправления нельзя использовать с параметром UseShellExecute</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>Исключение при получении "Modules" или "FileVersion": "Эта функция не поддерживается для удаленных компьютеров.".</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>Эта команда не может присоединить отладчик к процессу из-за {0}, так как отладчик по умолчанию недоступен.</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>Эта команда остановила операцию, так как не может ожидать процесса "Бездействие системы". Укажите другой процесс и выполните команду еще раз.</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>Эта команда остановила операцию, так как не может ожидать саму себя. Укажите другой процесс и выполните команду еще раз.</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>Эта команда остановила операцию, так как процесс "{0} ({1})" не был остановлен в течение указанного времени ожидания.</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>Не удается выполнить эту команду из-за ошибки: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>Эту команду нельзя выполнить, так как введенное значение "{0}" не является допустимым приложением.  Укажите допустимое приложение и выполните команду еще раз.</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>Эту команду нельзя выполнить, так как параметр "{0}" имеет недопустимое значение или не может использоваться с этой командой. Укажите допустимые входные данные и выполните команду еще раз.</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>Эту команду нельзя выполнить, так как "{0}" и "{1}" совпадают. Укажите разные входные данные и выполните команду еще раз.</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>Эту команду невозможно выполнить полностью, так как системе не удается найти всю необходимую информацию.</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>Не удалось получить новый дескриптор процесса: "{0}". У выведенного объекта Process некоторые свойства и методы могут работать неправильно.</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>Эту команду нельзя выполнить из-за ошибки 1783. Возможная причина этой ошибки — использование несуществующего пользователя "{0}". Укажите допустимого пользователя и выполните команду еще раз.</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>Ошибка при добавлении "{0}" в сеть: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>Ошибка при удалении "{0}" из сети: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>Ошибка при переименовании "{0}": {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>Параметры "{0}" и "{1}" нельзя задать одновременно.</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>Невозможно отладить процесс "{0} ({1})" из-за следующей ошибки: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>У пользователя нет доступа к запрошенной информации.</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>Указан недопустимый параметр.</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>У пользователя недостаточно прав.</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>Неизвестный сбой.</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>Указанный путь не существует.</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>Параметр "{0}" не поддерживается для командлета "{1}" в этом выпуске Windows.</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>Параметр "{0}" не поддерживается для командлета "{1}" в этом выпуске PowerShell.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/tr/NavigationResources.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/tr/NavigationResources.tr.resx
@@ -118,75 +118,75 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeleteHasChildrenPrompt" xml:space="preserve">
-    <value>The specified path is a container that has child items. Do you want to delete this container and its child items?</value>
+    <value>Belirtilen yol, alt öğeleri olan bir kapsayıcıdır. Bu kapsayıcıyı ve alt öğelerini silmek istiyor musunuz?</value>
   </data>
   <data name="DeletePrompt" xml:space="preserve">
-    <value>Do you want to delete the specified item?</value>
+    <value>Belirtilen öğeyi silmek istiyor musunuz?</value>
   </data>
   <data name="CopyToExistingPrompt" xml:space="preserve">
-    <value>Cannot copy because the specified destination already exists. Do you want to overwrite the existing content?</value>
+    <value>Belirtilen hedef zaten var olduğu için kopyalanamıyor. Var olan içeriğin üzerine yazmak istiyor musunuz?</value>
   </data>
   <data name="NewDriveConfirmAction" xml:space="preserve">
-    <value>New drive</value>
+    <value>Yeni sürücü</value>
   </data>
   <data name="NewDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Ad: {0} Sağlayıcı: {1} Kök: {2}</value>
   </data>
   <data name="RemoveDriveConfirmAction" xml:space="preserve">
-    <value>Remove Drive</value>
+    <value>Sürücüyü kaldır</value>
   </data>
   <data name="RemoveDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>Ad: {0} Sağlayıcı: {1} Kök: {2}</value>
   </data>
   <data name="RemoveDriveInUse" xml:space="preserve">
-    <value>Cannot remove drive '{0}' because it is in use.</value>
+    <value>‘{0}' sürücüsü kullanımda olduğu için kaldırılamıyor.</value>
   </data>
   <data name="RemoveItemWithChildren" xml:space="preserve">
-    <value>The item at {0} has children and the Recurse parameter was not specified. If you continue, all children will be removed with the item. Are you sure you want to continue?</value>
+    <value>{0} konumundaki öğenin alt öğeleri var ve Recurse parametresi belirtilmedi. Devam ederseniz, tüm çocuklar öğe ile birlikte kaldırılacaktır. Devam etmek istediğinizden emin misiniz?</value>
   </data>
   <data name="RemoveItemInUse" xml:space="preserve">
-    <value>Cannot remove the item at '{0}' because it is in use.</value>
+    <value>‘{0}' konumundaki öğe kullanımda olduğu için kaldırılamıyor.</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist, or has been filtered by the -Include or -Exclude parameter.</value>
+    <value>Belirtilen {0} yolundaki nesne yok veya -Include ya da -Exclude parametresi tarafından filtrelenmiş.</value>
   </data>
   <data name="SetContentAction" xml:space="preserve">
-    <value>Set Content</value>
+    <value>İçerik Ayarla</value>
   </data>
   <data name="SetContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Yol: {0}</value>
   </data>
   <data name="AddContentAction" xml:space="preserve">
-    <value>Add Content</value>
+    <value>İçerik Ekle</value>
   </data>
   <data name="AddContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>Yol: {0}</value>
   </data>
   <data name="MoveItemDoesntExist" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' does not exist.</value>
+    <value>‘{0}' konumundaki öğe bulunamadığı için öğe taşınamıyor.</value>
   </data>
   <data name="MoveItemInUse" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' is in use.</value>
+    <value>‘{0}' konumundaki öğe kullanımda olduğu için öğe taşınamıyor.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>Cannot rename because item at '{0}' does not exist.</value>
+    <value>Belirtilen konumdaki '{0}' öğesi yeniden adlandırılamıyor çünkü bu öğe yok.</value>
   </data>
   <data name="RenamedItemInUse" xml:space="preserve">
-    <value>Cannot rename the item at '{0}' because it is in use.</value>
+    <value>‘{0}' konumundaki öğe kullanımda olduğu için yeniden adlandırılamıyor.</value>
   </data>
   <data name="ParsePathFormatError" xml:space="preserve">
-    <value>Cannot parse path because path '{0}' does not have a qualifier specified.</value>
+    <value>‘{0}' yolu bir niteleyici belirtilmediği için ayrıştırılamıyor.</value>
   </data>
   <data name="CreateAction" xml:space="preserve">
-    <value>Begin</value>
+    <value>Başlat</value>
   </data>
   <data name="RollbackAction" xml:space="preserve">
-    <value>Rollback</value>
+    <value>Geri alma</value>
   </data>
   <data name="CommitAction" xml:space="preserve">
-    <value>Commit</value>
+    <value>İşle</value>
   </data>
   <data name="TransactionResource" xml:space="preserve">
-    <value>Current transaction</value>
+    <value>Geçerli işlem</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/tr/TimeZoneResources.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/tr/TimeZoneResources.tr.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>Adı '{0}' birden çok girdiye çözümlendiği için yerel saat dilimi ayarlanamıyor.</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>Yerel bilgisayarda '{0}' saat dilimi adı bulunamadı.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hans/HotFixResources.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hans/HotFixResources.zh-Hans.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>在“{0}”计算机上找不到请求的修补程序。验证输入并再次运行该命令。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hans/NavigationResources.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hans/NavigationResources.zh-Hans.resx
@@ -118,75 +118,75 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DeleteHasChildrenPrompt" xml:space="preserve">
-    <value>The specified path is a container that has child items. Do you want to delete this container and its child items?</value>
+    <value>指定的路径是一个包含子项的容器。是否要删除此容器及其子项?</value>
   </data>
   <data name="DeletePrompt" xml:space="preserve">
-    <value>Do you want to delete the specified item?</value>
+    <value>是否要删除指定项?</value>
   </data>
   <data name="CopyToExistingPrompt" xml:space="preserve">
-    <value>Cannot copy because the specified destination already exists. Do you want to overwrite the existing content?</value>
+    <value>无法复制，因为指定的目标已存在。是否要覆盖现有内容?</value>
   </data>
   <data name="NewDriveConfirmAction" xml:space="preserve">
-    <value>New drive</value>
+    <value>新驱动器</value>
   </data>
   <data name="NewDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>名称: {0} 提供程序: {1} 根目录: {2}</value>
   </data>
   <data name="RemoveDriveConfirmAction" xml:space="preserve">
-    <value>Remove Drive</value>
+    <value>移除驱动器</value>
   </data>
   <data name="RemoveDriveConfirmResourceTemplate" xml:space="preserve">
-    <value>Name: {0} Provider: {1} Root: {2}</value>
+    <value>名称: {0} 提供程序: {1} 根目录: {2}</value>
   </data>
   <data name="RemoveDriveInUse" xml:space="preserve">
-    <value>Cannot remove drive '{0}' because it is in use.</value>
+    <value>无法移除驱动器“{0}”，因为它正在使用中。</value>
   </data>
   <data name="RemoveItemWithChildren" xml:space="preserve">
-    <value>The item at {0} has children and the Recurse parameter was not specified. If you continue, all children will be removed with the item. Are you sure you want to continue?</value>
+    <value>{0} 处的项具有子项，并且未指定 Recurse 参数。如果继续，所有子项都将随该项一起移除。是否确定要继续?</value>
   </data>
   <data name="RemoveItemInUse" xml:space="preserve">
-    <value>Cannot remove the item at '{0}' because it is in use.</value>
+    <value>无法移除“{0}”处的项，因为它正在使用中。</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist, or has been filtered by the -Include or -Exclude parameter.</value>
+    <value>指定路径 {0} 处的对象不存在，或者已被 -Include 或 -Exclude 参数筛选。</value>
   </data>
   <data name="SetContentAction" xml:space="preserve">
-    <value>Set Content</value>
+    <value>设置内容</value>
   </data>
   <data name="SetContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>路径: {0}</value>
   </data>
   <data name="AddContentAction" xml:space="preserve">
-    <value>Add Content</value>
+    <value>添加内容</value>
   </data>
   <data name="AddContentTarget" xml:space="preserve">
-    <value>Path: {0}</value>
+    <value>路径: {0}</value>
   </data>
   <data name="MoveItemDoesntExist" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' does not exist.</value>
+    <value>无法移动项，因为“{0}”处的项不存在。</value>
   </data>
   <data name="MoveItemInUse" xml:space="preserve">
-    <value>Cannot move item because the item at '{0}' is in use.</value>
+    <value>无法移动项，因为“{0}”处的项正在使用中。</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>Cannot rename because item at '{0}' does not exist.</value>
+    <value>无法重命名，因为“{0}”处的项不存在。</value>
   </data>
   <data name="RenamedItemInUse" xml:space="preserve">
-    <value>Cannot rename the item at '{0}' because it is in use.</value>
+    <value>无法重命名“{0}”处的项，因为它正在使用中。</value>
   </data>
   <data name="ParsePathFormatError" xml:space="preserve">
-    <value>Cannot parse path because path '{0}' does not have a qualifier specified.</value>
+    <value>无法解析路径，因为路径“{0}”未指定限定符。</value>
   </data>
   <data name="CreateAction" xml:space="preserve">
-    <value>Begin</value>
+    <value>开始</value>
   </data>
   <data name="RollbackAction" xml:space="preserve">
-    <value>Rollback</value>
+    <value>回滚</value>
   </data>
   <data name="CommitAction" xml:space="preserve">
-    <value>Commit</value>
+    <value>提交</value>
   </data>
   <data name="TransactionResource" xml:space="preserve">
-    <value>Current transaction</value>
+    <value>当前事务</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/HotFixResources.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/HotFixResources.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoEntriesFound" xml:space="preserve">
-    <value>Cannot find the requested hotfix on the '{0}' computer. Verify the input and run the command again.</value>
+    <value>在 '{0}' 電腦上找不到要求的 Hotfix。驗證輸入，然後再次執行命令。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/ProcessResources.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/ProcessResources.zh-Hant.resx
@@ -118,19 +118,19 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoProcessFoundForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Verify the process name and call the cmdlet again.</value>
+    <value>找不到名稱為 "{0}" 的處理序。請確認處理序名稱，然後再次呼叫 Cmdlet。</value>
   </data>
   <data name="RecommendIdTagForGivenName" xml:space="preserve">
-    <value>Cannot find a process with the name "{0}". Try running with -Id to search by Id of processes.</value>
+    <value>找不到名稱為 "{0}" 的處理序。請嘗試使用 -Id 依處理序識別碼搜尋。</value>
   </data>
   <data name="NoDebuggerFound" xml:space="preserve">
-    <value>This command cannot be run because the debugger cannot be attached to the process "{0} ({1})". Specify another process and Run your command.</value>
+    <value>因為無法將偵錯工具附加到處理序 "{0} ({1})"，所以無法執行此命令。請指定其他處理序，然後執行命令。</value>
   </data>
   <data name="NoProcessFoundForGivenId" xml:space="preserve">
-    <value>Cannot find a process with the process identifier {1}.</value>
+    <value>找不到處理序識別碼為 {1} 的處理序。</value>
   </data>
   <data name="CouldNotStopProcess" xml:space="preserve">
-    <value>Cannot stop process "{0} ({1})" because of the following error: {2}</value>
+    <value>因為發生下列錯誤，無法停止處理序 "{0} ({1})": {2}</value>
   </data>
   <data name="ProcessNameForConfirmation" xml:space="preserve">
     <value>{0} ({1})</value>
@@ -139,96 +139,96 @@
     <value>{0} {1}</value>
   </data>
   <data name="CouldNotEnumerateModules" xml:space="preserve">
-    <value>Cannot enumerate the modules of the "{0}" process.</value>
+    <value>無法列舉 "{0}" 處理序的模組。</value>
   </data>
   <data name="CouldNotEnumerateFileVer" xml:space="preserve">
-    <value>Cannot enumerate the file version information of the "{0}" process.</value>
+    <value>無法列舉 "{0}" 處理序的檔案版本資訊。</value>
   </data>
   <data name="CouldNotEnumerateModuleFileVer" xml:space="preserve">
-    <value>Cannot enumerate the modules and the file version information of the "{0}" process.</value>
+    <value>無法列舉 "{0}" 處理序的模組和檔案版本資訊。</value>
   </data>
   <data name="ConfirmStopProcess" xml:space="preserve">
-    <value>Are you sure you want to perform the Stop-Process operation on the following item: {0}({1})?</value>
+    <value>您確定要在下列項目上執行 Stop-Process 作業嗎: {0}({1})?</value>
   </data>
   <data name="UseShell" xml:space="preserve">
-    <value>The specified path is not a valid win32 application. Try again with the UseShellExecute.</value>
+    <value>指定的路徑不是有效的 Win32 應用程式。請改用 UseShellExecute 再試一次。</value>
   </data>
   <data name="ProcessIsNotTerminated" xml:space="preserve">
-    <value>This command stopped operation of "{0} ({1})" because of the following error: {2}.</value>
+    <value>因為發生下列錯誤，所以此命令已停止 "{0} ({1})" 的作業: {2}。</value>
   </data>
   <data name="RedirectionParams" xml:space="preserve">
-    <value>This command cannot be run because Redirection parameters cannot be used with UseShellExecute parameter</value>
+    <value>因為 Redirection 參數無法與 UseShellExecute 參數搭配使用，所以無法執行此命令</value>
   </data>
   <data name="NoComputerNameWithFileVersion" xml:space="preserve">
-    <value>Exception getting "Modules" or "FileVersion": "This feature is not supported for remote computers.".</value>
+    <value>取得 "Modules" 或 "FileVersion" 時發生例外狀況: [此功能不支援遠端電腦。]。</value>
   </data>
   <data name="DebuggerError" xml:space="preserve">
-    <value>This command cannot attach the debugger to the process due to {0} because no default debugger is available.</value>
+    <value>因為沒有可用的預設偵錯工具，所以此命令因 {0} 無法將偵錯工具附加至處理序。</value>
   </data>
   <data name="WaitOnIdleProcess" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on 'System Idle' process. Specify another process and Run your command again.</value>
+    <value>因為此命令無法等候 'System Idle' 處理序，所以已停止作業。請指定其他處理序，然後再次執行命令。</value>
   </data>
   <data name="WaitOnItself" xml:space="preserve">
-    <value>This command stopped operation because it cannot wait on itself. Specify another process and Run your command again.</value>
+    <value>因為此命令無法等候自己完成，所以已停止作業。請指定其他處理序，然後再次執行命令。</value>
   </data>
   <data name="ProcessNotTerminated" xml:space="preserve">
-    <value>This command stopped operation because process "{0} ({1})" is not stopped in the specified time-out.</value>
+    <value>因為處理序 "{0} ({1})" 未在指定的逾時時間內停止，所以此命令已停止作業。</value>
   </data>
   <data name="InvalidStartProcess" xml:space="preserve">
-    <value>This command cannot be run due to the error: {0}</value>
+    <value>因為發生錯誤，所以無法執行此命令: {0}</value>
   </data>
   <data name="InvalidApplication" xml:space="preserve">
-    <value>This command cannot be run because the input "{0}" is not a valid Application.  Give a valid application and run your command again.</value>
+    <value>因為輸入 "{0}" 不是有效的應用程式，所以無法執行此命令。 請提供有效的應用程式，然後再次執行命令。</value>
   </data>
   <data name="InvalidInput" xml:space="preserve">
-    <value>This command cannot be run because either the parameter "{0}" has a value that is not valid or cannot be used with this command. Give a valid input and Run your command again.</value>
+    <value>因為參數 "{0}" 的值無效，或無法與此命令搭配使用，所以無法執行此命令。請提供有效的輸入，然後再次執行命令。</value>
   </data>
   <data name="DuplicateEntry" xml:space="preserve">
-    <value>This command cannot be run because "{0}" and "{1}" are same. Give different inputs and Run your command again.</value>
+    <value>因為 "{0}" 和 "{1}" 相同，所以無法執行此命令。請提供不同的輸入，然後再次執行命令。</value>
   </data>
   <data name="CannotStarttheProcess" xml:space="preserve">
-    <value>This command cannot be run completely because the system cannot find all the information required.</value>
+    <value>因為系統找不到所有必要的資訊，所以此命令無法完整執行。</value>
   </data>
   <data name="FailedToCreateProcessObject" xml:space="preserve">
-    <value>Failed to retrieve the new process handle: "{0}". The Process object outputted may have some properties and methods that do not work properly.</value>
+    <value>無法擷取新的處理序控制代碼: "{0}"。輸出的 Process 物件可能有一些屬性和方法無法正常運作。</value>
   </data>
   <data name="InvalidUserError" xml:space="preserve">
-    <value>This command cannot be run due to error 1783. The possible cause of this error can be using of a non-existing user "{0}". Please give a valid user and run your command again.</value>
+    <value>因為發生錯誤 1783，所以無法執行此命令。此錯誤的可能原因是使用了不存在的使用者 "{0}"。請提供有效的使用者，然後再次執行命令。</value>
   </data>
   <data name="JoinNetworkFailed" xml:space="preserve">
-    <value>Error adding '{0}' to the network: {1}</value>
+    <value>將 '{0}' 新增至網路時發生錯誤: {1}</value>
   </data>
   <data name="RemoveFailed" xml:space="preserve">
-    <value>Error removing '{0}' from the network: {1}</value>
+    <value>從網路移除 '{0}' 時發生錯誤: {1}</value>
   </data>
   <data name="RenameFailed" xml:space="preserve">
-    <value>Error renaming '{0}': {1}</value>
+    <value>重新命名 '{0}' 時發生錯誤: {1}</value>
   </data>
   <data name="ContradictParametersSpecified" xml:space="preserve">
-    <value>Parameters "{0}" and "{1}" cannot be specified at the same time.</value>
+    <value>不可同時指定參數 "{0}" 和 "{1}"。</value>
   </data>
   <data name="CouldNotDebugProcess" xml:space="preserve">
-    <value>Cannot debug process "{0} ({1})" because of the following error: {2}</value>
+    <value>因為發生下列錯誤，所以無法對處理序 "{0} ({1})" 進行偵錯: {2}</value>
   </data>
   <data name="AttachDebuggerReturnCode2" xml:space="preserve">
     <value>使用者沒有要求之資訊的存取權。</value>
   </data>
   <data name="AttachDebuggerReturnCode21" xml:space="preserve">
-    <value>The specified parameter is not valid.</value>
+    <value>指定的參數無效。</value>
   </data>
   <data name="AttachDebuggerReturnCode3" xml:space="preserve">
-    <value>The user does not have sufficient privilege.</value>
+    <value>使用者沒有足夠的權限。</value>
   </data>
   <data name="AttachDebuggerReturnCode8" xml:space="preserve">
-    <value>Unknown failure.</value>
+    <value>未知失敗。</value>
   </data>
   <data name="AttachDebuggerReturnCode9" xml:space="preserve">
     <value>指定的路徑不存在。</value>
   </data>
   <data name="ParameterNotSupported" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of Windows.</value>
+    <value>此版本的 Windows 不支援 cmdlet '{1}' 的參數 '{0}'。</value>
   </data>
   <data name="ParameterNotSupportedOnPSEdition" xml:space="preserve">
-    <value>The parameter '{0}' is not supported for the cmdlet '{1}' on this edition of PowerShell.</value>
+    <value>此版本的 PowerShell 不支援 cmdlet '{1}' 的參數 '{0}'。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/TestPathResources.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/TestPathResources.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PathIsNullOrEmptyCollection" xml:space="preserve">
-    <value>The provided Path argument was null or an empty collection.</value>
+    <value>提供的 Path 引數是 Null 或空的集合。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/TimeZoneResources.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Management/resources/zh-Hant/TimeZoneResources.zh-Hant.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleMatchingTimeZones" xml:space="preserve">
-    <value>Cannot set the local time zone because the name '{0}' resolves to multiple entries.</value>
+    <value>無法設定本機時區，因為名稱 '{0}' 解析為多個項目。</value>
   </data>
   <data name="TimeZoneNameNotFound" xml:space="preserve">
-    <value>The time zone name '{0}' was not found on the local computer.</value>
+    <value>在本機電腦上找不到時區名稱 '{0}'。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/ConvertHTMLStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/ConvertHTMLStrings.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetaPropertyNotFound" xml:space="preserve">
-    <value>Accepted meta properties are content-type, default-style, application-name, author, description, generator, keywords, x-ua-compatible, and viewport. The meta pair: {0} and {1} may not function correctly.</value>
+    <value>Povolené meta vlastnosti jsou content-type, default-style, application-name, author, description, generator, keywords, x-ua-compatible a viewport. Meta pár {0} a {1} nemusí fungovat správně.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/Debugger.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/Debugger.cs.resx
@@ -118,63 +118,63 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="LineLessThanOne" xml:space="preserve">
-    <value>Line cannot be less than 1.</value>
+    <value>Řádek nemůže být menší než 1.</value>
   </data>
   <data name="BreakpointIdNotFound" xml:space="preserve">
-    <value>There is no breakpoint with ID '{0}'.</value>
+    <value>Zarážka s ID {0} neexistuje.</value>
   </data>
   <data name="FileDoesNotExist" xml:space="preserve">
     <value>Soubor {0} neexistuje.</value>
   </data>
   <data name="WrongExtension" xml:space="preserve">
-    <value>Cannot set breakpoint on file '{0}'; only *.ps1 and *.psm1 files are valid.</value>
+    <value>V souboru {0} nelze nastavit zarážku. Platné jsou pouze soubory *.ps1 a *.psm1.</value>
   </data>
   <data name="RemoteDebuggerNotSupported" xml:space="preserve">
-    <value>Debugging is not supported on remote sessions.</value>
+    <value>Ladění není ve vzdálených relacích podporováno.</value>
   </data>
   <data name="CannotSetBreakpointInconsistentLanguageMode" xml:space="preserve">
-    <value>Cannot set breakpoint. The language mode for this session is incompatible with the system-wide language mode.</value>
+    <value>Nelze nastavit zarážku. Jazykový režim této relace není kompatibilní se systémovým jazykovým režimem.</value>
   </data>
   <data name="RemoteDebuggerNotSupportedInHost" xml:space="preserve">
-    <value>Breakpoints cannot be set in the remote session because remote debugging is not supported by the current host.</value>
+    <value>Zarážky nelze nastavit ve vzdálené relaci, protože aktuální hostitel nepodporuje vzdálené ladění.</value>
   </data>
   <data name="RunspaceDebuggingCannotDebugDefaultRunspace" xml:space="preserve">
-    <value>You cannot debug the default host Runspace using this cmdlet. To debug the default Runspace use the normal debugging commands from the host.</value>
+    <value>Pomocí této rutiny nelze ladit výchozí hostitelské prostředí runspace. Chcete-li ladit výchozí prostředí runspace, použijte běžné příkazy ladění hostitele.</value>
   </data>
   <data name="RunspaceDebuggingNoHostRunspaceOrDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The host has no debugger. Try debugging the Runspace inside the PowerShell console or with Visual Studio Code, both of which have built-in debuggers.</value>
+    <value>Nelze ladit prostředí runspace. Hostitel nemá ladicí program. Zkuste ladit prostředí runspace v konzole PowerShellu nebo ve Visual Studio Code, které mají integrované ladicí programy.</value>
   </data>
   <data name="RunspaceDebuggingNoHost" xml:space="preserve">
-    <value>Cannot debug Runspace. There is no host or host UI. The debugger requires a host and host UI for debugging.</value>
+    <value>Nelze ladit prostředí runspace. Hostitel nebo jeho uživatelské rozhraní nejsou k dispozici. Ladicí program vyžaduje hostitele a uživatelské rozhraní hostitele.</value>
   </data>
   <data name="RunspaceDebuggingTooManyRunspacesFound" xml:space="preserve">
-    <value>More than one Runspace was found. Only one Runspace can be debugged at a time.</value>
+    <value>Bylo nalezeno více než jedno prostředí runspace. Současně lze ladit pouze jedno prostředí runspace.</value>
   </data>
   <data name="RunspaceDebuggingEndSession" xml:space="preserve">
-    <value>To end the debugging session type the 'Detach' command at the debugger prompt, or type 'Ctrl+C' otherwise.</value>
+    <value>Chcete-li ukončit relaci ladění, zadejte na příkazovém řádku ladicího programu příkaz Detach, případně stiskněte Ctrl+C.</value>
   </data>
   <data name="RunspaceDebuggingScriptCompleted" xml:space="preserve">
-    <value>Command or script completed.</value>
+    <value>Příkaz nebo skript byl dokončen.</value>
   </data>
   <data name="RunspaceDebuggingStarted" xml:space="preserve">
-    <value>Debugging Runspace: {0}</value>
+    <value>Laděné prostředí runspace: {0}</value>
   </data>
   <data name="RunspaceOptionInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot set debug options on Runspace {0} because it is not in the Opened state.</value>
+    <value>Možnosti ladění prostředí runspace {0} nelze nastavit, protože není ve stavu Opened (Otevřeno).</value>
   </data>
   <data name="PersistDebugPreferenceFailure" xml:space="preserve">
-    <value>Failed to persist debug options for Process {0}.</value>
+    <value>Možnosti ladění pro proces {0} se nepodařilo trvale uložit.</value>
   </data>
   <data name="RunspaceOptionNoDebugger" xml:space="preserve">
-    <value>No debugger was found for Runspace {0}.</value>
+    <value>Pro prostředí runspace {0} nebyl nalezen žádný ladicí program.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceFound" xml:space="preserve">
-    <value>No Runspace was found.</value>
+    <value>Nebylo nalezeno žádné prostředí runspace.</value>
   </data>
   <data name="DebugBreakMessage" xml:space="preserve">
-    <value>Wait-Debugger called on line {0} in {1}.</value>
+    <value>Rutina Wait-Debugger byla volána na řádku {0} v {1}.</value>
   </data>
   <data name="RunspaceInstanceIdNotFound" xml:space="preserve">
-    <value>A breakpoint associated with another runspace cannot be updated because there is no runspace with instance ID '{0}'.</value>
+    <value>Zarážku přidruženou k jinému prostředí runspace nelze aktualizovat, protože neexistuje žádné prostředí runspace s ID instance {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/FormatAndOut_out_gridview.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/FormatAndOut_out_gridview.cs.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Out-GridView nepodporuje tento formát dat.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>Microsoft .NET Framework 4.5 byl nainstalován v době, kdy byla spuštěna jedna nebo více relací PowerShellu. Chcete-li použít rutinu {0}, zavřete všechna okna PowerShellu a potom otevřete nové okno PowerShellu.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>Typ</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>Hodnota</value>
@@ -133,16 +133,16 @@
     <value>Index</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>Příkaz s názvem {0} nebyl nalezen.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>Byl nalezen více než jeden příkaz s názvem {0}. Spusťte {1} bez parametrů a potom zadáním {0} vyfiltrujte výsledky.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>Do vstupní vyrovnávací paměti konzoly nelze zapisovat.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} musí být menší než {1}.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetMember.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetMember.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoObjectSpecified" xml:space="preserve">
-    <value>You must specify an object for the Get-Member cmdlet.</value>
+    <value>Pro rutinu Get-Member musíte zadat objekt.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetRandomCommandStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetRandomCommandStrings.cs.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>Hodnota maxValue musí být větší než nula.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>Minimální hodnota ({0}) nemůže být větší nebo rovna maximální hodnotě ({1}).</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>Hodnota minValue nemůže být větší než hodnota maxValue.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetUptimeStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/GetUptimeStrings.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetUptimePlatformIsNotSupported" xml:space="preserve">
-    <value>"The platform is not supported (System.Diagnostics.Stopwatch.IsHighResolution is false)."</value>
+    <value>Platforma není podporována (System.Diagnostics.Stopwatch.IsHighResolution má hodnotu false).</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/MatchStringStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/MatchStringStrings.cs.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileOpenError" xml:space="preserve">
-    <value>Cannot open the file because the current provider ({0}) cannot open files.</value>
+    <value>Soubor nejde otevřít, protože aktuální poskytovatel ({0}) neumí otevírat soubory.</value>
   </data>
   <data name="FileReadError" xml:space="preserve">
-    <value>The file {0} cannot be read: {1}</value>
+    <value>Soubor {0} nejde přečíst: {1}</value>
   </data>
   <data name="FilterContextWarning" xml:space="preserve">
-    <value>The option "Context" is not valid when searching results that are piped from Select-String output.</value>
+    <value>Možnost Context není platná při hledání výsledků předaných kanálem z výstupu Select-String.</value>
   </data>
   <data name="InvalidRegex" xml:space="preserve">
-    <value>The string {0} is not a valid regular expression: {1}</value>
+    <value>Řetězec {0} není platný regulární výraz: {1}</value>
   </data>
   <data name="CannotSpecifyCultureWithoutSimpleMatch" xml:space="preserve">
-    <value>You must specify -Culture parameter only with -SimpleMatch parameter.</value>
+    <value>Parametr -Culture musíte zadat jen společně s parametrem -SimpleMatch.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/NewObjectStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/NewObjectStrings.cs.resx
@@ -118,45 +118,45 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotFindAppropriateCtor" xml:space="preserve">
-    <value>A constructor was not found. Cannot find an appropriate constructor for type {0}.</value>
+    <value>Konstruktor nebyl nalezen. Nelze najít odpovídající konstruktor pro typ {0}.</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
-    <value>Cannot find type [{0}]: verify that the assembly containing this type is loaded.</value>
+    <value>Nelze najít typ [{0}]: Ověřte, že je načteno sestavení obsahující tento typ.</value>
   </data>
   <data name="CannotLoadComObjectType" xml:space="preserve">
-    <value>Cannot load COM type {0}.</value>
+    <value>Nelze načíst typ modelu COM {0}.</value>
   </data>
   <data name="ComInteropLoaded" xml:space="preserve">
-    <value>The object written to the pipeline is an instance of the type "{0}" from the component's primary interoperability assembly. If this type exposes different members than the IDispatch members, scripts that are written to work with this object might not work if the primary interoperability assembly is not installed.</value>
+    <value>Objekt zapsaný do kanálu je instancí typu {0} z primárního sestavení komponenty pro interoperabilitu. Pokud tento typ zpřístupňuje jiné členy než členy IDispatch, skripty napsané pro práci s tímto objektem nemusí fungovat, pokud není nainstalováno primární sestavení pro interoperabilitu.</value>
   </data>
   <data name="MemberNotFound" xml:space="preserve">
-    <value>The member "{1}" was not found for the specified {2} object.</value>
+    <value>Člen {1} nebyl pro zadaný objekt {2} nalezen.</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>The value supplied is not valid, or the property is read-only. Change the value, and then try again.</value>
+    <value>Zadaná hodnota není platná nebo je vlastnost jen pro čtení. Změňte hodnotu a zkuste to znovu.</value>
   </data>
   <data name="CannotInstantiateWinRTType" xml:space="preserve">
-    <value>Creating instances of attribute and delegated Windows RT types is not supported.</value>
+    <value>Vytváření instancí atributů a delegovaných typů Windows RT není podporováno.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create instances of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nelze vytvořit instance typu podobného ByRef {0}. PowerShell nepodporuje typy podobné ByRef.</value>
   </data>
   <data name="CannotCreateTypeConstrainedLanguage" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in this language mode.</value>
+    <value>Typ nelze vytvořit. V tomto jazykovém režimu se podporují jen základní typy.</value>
   </data>
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
+    <value>Typ nelze vytvořit. V počítači uzamčeném zásadou jsou v jazykovém režimu {0} podporovány pouze základní typy.</value>
   </data>
   <data name="TypeWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet Type Creation</value>
+    <value>Vytvoření typu rutiny New-Object</value>
   </data>
   <data name="TypeWDACLogMessage" xml:space="preserve">
-    <value>The type '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>Typ {0} nebude vytvořen v režimu ConstrainedLanguage.</value>
   </data>
   <data name="ComWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet COM Object Creation</value>
+    <value>Vytvoření objektu COM rutiny New-Object</value>
   </data>
   <data name="ComWDACLogMessage" xml:space="preserve">
-    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>Objekt COM {0} nebude vytvořen v režimu ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/SelectObjectStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/SelectObjectStrings.cs.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RenamingMultipleResults" xml:space="preserve">
-    <value>Cannot rename multiple results.</value>
+    <value>Více výsledků nelze přejmenovat.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>Property "{0}" cannot be found.</value>
+    <value>Vlastnost {0} nebyla nalezena.</value>
   </data>
   <data name="MutlipleExpandProperties" xml:space="preserve">
-    <value>Multiple properties cannot be expanded.</value>
+    <value>Nelze rozbalit více vlastností.</value>
   </data>
   <data name="AlreadyExistingProperty" xml:space="preserve">
-    <value>The property cannot be processed because the property "{0}" already exists.</value>
+    <value>Vlastnost nelze zpracovat, protože vlastnost {0} již existuje.</value>
   </data>
   <data name="EmptyScriptBlockAndNoName" xml:space="preserve">
-    <value>A property is an empty script block and does not provide a name.</value>
+    <value>Vlastnost je prázdný blok skriptu a neposkytuje název.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/SortObjectStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/SortObjectStrings.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>Sort-Object – {0} nelze nalézt v InputObject.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/StartSleepStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/StartSleepStrings.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>Hodnota parametru -Duration nesmí překročit hodnotu {0}, zadaná hodnota byla {1}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/cs/TestJsonCmdletStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/cs/TestJsonCmdletStrings.cs.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>Schéma JSON nejde parsovat.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>JSON nejde parsovat.</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>JSON není platný se schématem: {0} v {1}.</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>Nelze otevřít soubor schématu JSON: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>Schéma identifikátoru URI {0} není podporováno. Povoleny jsou pouze identifikátory URI protokolu HTTP(S) a místního systému souborů.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/AddTypeStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/AddTypeStrings.de.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Der Quellcode wurde bereits kompiliert und geladen.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Die Endung „{0}“ wird nicht unterstützt.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Eingabedateien müssen alle die gleiche Dateiendung aufweisen.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Die Assembly „{0}“ wurde nicht gefunden.</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Der Typname „{0}“ ist bereits vorhanden.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Die Ausgabeassembly kann nicht festgelegt werden. Der Pfad {0} wurde nicht in eine einzelne Datei aufgelöst.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Fehler bei der Kompilierung.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Der OutputType-Parameter erfordert, dass der OutputAssembly-Parameter angegeben wird.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Der Typ kann nicht hinzugefügt werden. Die Definition neuer Typen wird in diesem Sprachmodus nicht unterstützt.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>Die angegebene Verweisassembly „{0}“ ist nicht erforderlich und wird ignoriert.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Die Assemblytypen „ConsoleApplication“ und „WindowsApplication“ werden derzeit nicht unterstützt.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Add-Type-Cmdlet</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Das Add-Type-cmdlet ist im ConstrainedLanguage-Modus nicht zulässig.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/EventingStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/EventingStrings.de.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>Das Ereignis mit dem Quellbezeichner „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>Das Ereignis mit dem Bezeichner „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>Das Ereignisabonnement mit dem Quellbezeichner „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>Das Ereignisabonnement mit dem Bezeichner „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>Ereignisabonnement „{0}“</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>Ereignis „{0}“</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>Für nicht weitergeleitete Ereignisse muss eine Aktion angegeben werden.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>Abonnement kündigen</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/FormatAndOut_out_gridview.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/FormatAndOut_out_gridview.de.resx
@@ -118,13 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Das Datenformat wird von Out-GridView nicht unterstützt.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>Microsoft .NET Framework 4.5 wurde installiert, während mindestens eine PowerShell-Sitzung ausgeführt wurde. Schließen Sie zum Verwenden des {0} Cmdlets alle PowerShell-Fenster und öffnen Sie dann ein neues PowerShell-Fenster.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>Typ</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>Wert</value>
@@ -133,16 +133,16 @@
     <value>Index</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>Ein Befehl mit dem Namen „{0}“ wurde nicht gefunden.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>Es wurden mehrere Befehle mit dem Namen „{0}“ gefunden. Starten Sie „{1}“ ohne Parameter und geben Sie dann „{0}“ ein, um die Ergebnisse zu filtern.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>In den Konsoleneingabepuffer kann nicht geschrieben werden.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} muss kleiner als {1} sein.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/GetRandomCommandStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/GetRandomCommandStrings.de.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>„maxValue“ muss größer als Null sein.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>Der Mindestwert ({0}) darf nicht größer oder gleich dem Höchstwert ({1}) sein.</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>„minValue“ darf nicht größer als maxValue sein.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/SortObjectStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/SortObjectStrings.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>„Sort-Object“ – „{0}“ wurde in „InputObject“ nicht gefunden.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/StartSleepStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/StartSleepStrings.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>Der Parameterwert „-Duration“ darf „{0}“ nicht überschreiten. Der angegebene Wert war „{1}“.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/TestJsonCmdletStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/TestJsonCmdletStrings.de.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>Das JSON-Schema kann nicht analysiert werden.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>Der JSON-Code kann nicht analysiert werden.</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>Der JSON-Code ist mit dem Schema ungültig: {0} bei „{1}“</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>Die JSON-Schemadatei kann nicht geöffnet werden: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>Das URI-Schema „{0}“ wird nicht unterstützt. Nur HTTP(S) und lokale Dateisystem-URIs sind zulässig.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/de/WriteErrorStrings.de.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/de/WriteErrorStrings.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>„Das Cmdlet Write-Error hat einen Fehler gemeldet.“</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/es/AddTypeStrings.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/es/AddTypeStrings.es.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>El código fuente ya se compiló y cargó.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>No se puede agregar el tipo. No se admite la extensión "{0}".</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>No se puede agregar el tipo. Todos los archivos de entrada deben tener la misma extensión de archivo.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>No se puede agregar el tipo. No se encontró el ensamblado "{0}".</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>No se puede agregar el tipo. El nombre de tipo "{0}" ya existe.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>No se puede establecer el ensamblado de salida. La ruta de acceso {0} no se resolvió en un solo archivo.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>No se puede agregar el tipo. Se produjeron errores de compilación.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>No se puede agregar el tipo. El parámetro OutputType requiere que se especifique el parámetro OutputAssembly.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>No se puede agregar el tipo. No se admite la definición de nuevos tipos en este modo de lenguaje.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>El ensamblado de referencia especificado "{0}" no es necesario y se omite.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Actualmente no se admiten los tipos de ensamblado "ConsoleApplication" y "WindowsApplication".</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>cmdlet Add-Type</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>El cmdlet Add-Type no se permitirá en el modo ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/es/EventingStrings.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/es/EventingStrings.es.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>El evento con el identificador de origen "{0}" no existe.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>El evento con el identificador "{0}" no existe.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>La suscripción de eventos con el identificador de origen "{0}" no existe.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>La suscripción de eventos con el identificador "{0}" no existe.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>Suscripción de eventos "{0}"</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>Evento "{0}"</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>Se debe especificar una acción para los eventos no reenviados.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>Cancelar suscripción</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/es/SortObjectStrings.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/es/SortObjectStrings.es.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" - "{0}" no se encuentra en "InputObject".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/es/StartSleepStrings.es.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/es/StartSleepStrings.es.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>El valor del parámetro "-Duration" no debe superar ''{0}". El valor proporcionado es "{1}".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/AddTypeStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/AddTypeStrings.fr.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Le code source a déjà été compilé et chargé.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Nous ne pouvons pas ajouter de type. L’extension « {0} » n’est pas prise en charge.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Nous ne pouvons pas ajouter de type. Tous les fichiers d’entrée doivent avoir la même extension de fichier.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Nous ne pouvons pas ajouter de type. Nous n’avons pas pu trouver l’assembly « {0} ».</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Nous ne pouvons pas ajouter de type. Le nom de type « {0} » existe déjà.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Nous ne pouvons pas définir l’assembly de sortie. Le chemin d’accès {0} n’a pas été résolu en un seul fichier.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Nous ne pouvons pas ajouter de type. Des erreurs de compilation se sont produites.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Nous ne pouvons pas ajouter de type. Le paramètre OutputType nécessite que le paramètre OutputAssembly soit indiqué.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Nous ne pouvons pas ajouter de type. La définition de nouveaux types n’est pas prise en charge dans ce mode de langage.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>L’assembly de référence spécifié « {0} » est inutile et ignoré.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Les types d’assembly « ConsoleApplication » et « WindowsApplication » ne sont actuellement pas pris en charge.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Cmdlet Add-Type</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>La cmdlet Add-Type ne sera pas autorisée en mode ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/EventingStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/EventingStrings.fr.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>L’événement avec l’identificateur source '{0}' n’existe pas.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>L’événement avec l’identificateur '{0}' n’existe pas.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>L’abonnement aux événements avec l’identificateur source «{0}» n’existe pas.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>L’abonnement aux événements avec l’identificateur «{0}» n’existe pas.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>Abonnement aux événements '{0}'</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>Événement '{0}'</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>L’action doit être spécifiée pour les événements non transférés.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>Se désabonner</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/ImplicitRemotingStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/ImplicitRemotingStrings.fr.resx
@@ -118,99 +118,99 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ErrorMalformedDataFromRemoteCommand" xml:space="preserve">
-    <value>Data returned by the remote {0} command is not in the expected format.</value>
+    <value>Les données renvoyées par la commande distante {0} n’ont pas le format attendu.</value>
   </data>
   <data name="ErrorRequiredRemoteCommandNotFound" xml:space="preserve">
-    <value>The {0} cmdlet requires the following commands in the remote session: Get-Command, Get-FormatData, and Select-Object. The following commands are used, but optional: Get-Help, and Measure-Object. Verify that the remote session includes the required commands, and then try again.</value>
+    <value>La cmdlet {0} nécessite les commandes suivantes dans la session distante : Get-Command, Get-FormatData et Select-Object. Les commandes suivantes sont utilisées, mais facultatives : Get-Help et Measure-Object. Vérifiez que la session distante inclut les commandes nécessaires, puis réessayez.</value>
   </data>
   <data name="ErrorFromRemoteCommand" xml:space="preserve">
-    <value>Running the {0} command in a remote session reported the following error: {1}.</value>
+    <value>L’exécution de la commande {0} dans une session distante a signalé l’erreur suivante : {1}.</value>
   </data>
   <data name="ErrorNoResultsFromRemoteEnd" xml:space="preserve">
-    <value>Running the {0} command in a remote session returned no results.</value>
+    <value>L’exécution de la commande {0} dans une session distante n’a renvoyé aucun résultat.</value>
   </data>
   <data name="ErrorNoRunspaceForThisModule" xml:space="preserve">
-    <value>No session has been associated with this implicit remoting module.</value>
+    <value>Aucune session n’a été associée à ce module de communication à distance implicite.</value>
   </data>
   <data name="ErrorCouldntResolveAlias" xml:space="preserve">
-    <value>Could not resolve remote alias '{0}'.</value>
+    <value>Nous n’avons pas pu résoudre l’alias distant « {0} ».</value>
   </data>
   <data name="ErrorSkippedNonRequestedCommand" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because the name did not match the value of the Name parameter.</value>
+    <value>La création du proxy a été ignorée pour la commande « {0} », car le nom ne correspondait pas à la valeur du paramètre Name.</value>
   </data>
   <data name="ErrorSkippedNonRequestedTypeDefinition" xml:space="preserve">
-    <value>Extended type definition has been skipped for the '{0}' type because its name did not match the value of the FormatTypeName parameter.</value>
+    <value>La définition de type étendue a été ignorée pour le type « {0} », car son nom ne correspondait pas à la valeur du paramètre FormatTypeName.</value>
   </data>
   <data name="ErrorSkippedUnsafeCommandName" xml:space="preserve">
-    <value>Proxy creation has been skipped for the '{0}' command, because PowerShell could not verify the safety of the command name.</value>
+    <value>La création du proxy a été ignorée pour la commande « {0} », car PowerShell n’a pas pu vérifier la sécurité du nom de la commande.</value>
   </data>
   <data name="ErrorCommandSkippedBecauseOfShadowing" xml:space="preserve">
-    <value>Proxy creation has been skipped for the following command: '{0}', because it would shadow an existing local command.  Use the AllowClobber parameter if you want to shadow existing local commands.</value>
+    <value>La création du proxy a été ignorée pour la commande suivante : « {0} », car elle va masquer une commande locale existante.  Utilisez le paramètre AllowClobber si vous souhaitez masquer des commandes locales existantes.</value>
   </data>
   <data name="ErrorNoCommandsImportedBecauseOfSkipping" xml:space="preserve">
-    <value>No command proxies have been created, because all of the requested remote commands would shadow existing local commands.  Use the AllowClobber parameter if you want to shadow existing local commands.</value>
+    <value>Aucun proxy de commande n’a été créé, car toutes les commandes distantes demandées vont masquer des commandes locales existantes.  Utilisez le paramètre AllowClobber si vous souhaitez masquer des commandes locales existantes.</value>
   </data>
   <data name="ProxyModuleDescription" xml:space="preserve">
-    <value>Implicit remoting for {0}</value>
+    <value>Module de communication à distance implicite pour {0}</value>
   </data>
   <data name="EventSourceIdentifier" xml:space="preserve">
-    <value>Implicit remoting event (session id: {0}; event handler id: {1})</value>
+    <value>Événement de communication à distance implicite (ID de session : {0}, ID du gestionnaire d’événements : {1})</value>
   </data>
   <data name="ModuleHeaderTitle" xml:space="preserve">
-    <value>Implicit remoting module</value>
+    <value>Module de communication à distance implicite</value>
   </data>
   <data name="ModuleHeaderDate" xml:space="preserve">
-    <value>generated on {0}</value>
+    <value>généré le {0}</value>
   </data>
   <data name="ModuleHeaderCommand" xml:space="preserve">
-    <value>by {0} cmdlet</value>
+    <value>par la cmdlet {0}</value>
   </data>
   <data name="ModuleHeaderCommandLine" xml:space="preserve">
-    <value>Invoked with the following command line: {0}</value>
+    <value>Nous l’appelons avec la ligne de commande suivante : {0}</value>
   </data>
   <data name="ModuleHeaderRunspaceOverrideParameter" xml:space="preserve">
-    <value>Optional parameter that can be used to specify the session on which this proxy module works</value>
+    <value>Paramètre facultatif que vous pouvez utiliser pour spécifier la session sur laquelle ce module proxy fonctionne</value>
   </data>
   <data name="CreateNewRunspaceMessageTemplate" xml:space="preserve">
-    <value>Creating a new session for implicit remoting of "{{0}}" command...</value>
+    <value>Création d’une nouvelle session pour la communication à distance implicite de la commande « {{0}} » en cours...</value>
   </data>
   <data name="ProxyRunspaceNameTemplate" xml:space="preserve">
-    <value>Session for implicit remoting module at {{0}}</value>
+    <value>Session pour le module de communication à distance implicite sur {{0}}</value>
   </data>
   <data name="ProgressActivity" xml:space="preserve">
-    <value>Creating implicit remoting module ...</value>
+    <value>Création du module de communication à distance implicite...</value>
   </data>
   <data name="ProgressStatusGetCommandStart" xml:space="preserve">
-    <value>Getting command information from remote session ...</value>
+    <value>Obtention des informations de commande à partir de la session distante en cours...</value>
   </data>
   <data name="ProgressStatusGetCommandProgress" xml:space="preserve">
-    <value>Getting command information from remote session ... {0} commands received</value>
+    <value>Obtention des informations de commande à partir de la session distante en cours... {0} commandes reçues</value>
   </data>
   <data name="ProgressStatusGetFormatDataStart" xml:space="preserve">
-    <value>Getting formatting and output information from remote session ...</value>
+    <value>Obtention des informations de mise en forme et de sortie à partir de la session distante en cours...</value>
   </data>
   <data name="ProgressStatusGetFormatDataProgress" xml:space="preserve">
-    <value>Getting formatting and output information from remote session ... {0} objects received</value>
+    <value>Obtention des informations de mise en forme et de sortie à partir de la session distante en cours... {0} objets reçus</value>
   </data>
   <data name="ProgressStatusCompleted" xml:space="preserve">
-    <value>Completed.</value>
+    <value>Terminé.</value>
   </data>
   <data name="CredentialRequestTitle" xml:space="preserve">
-    <value>PowerShell Credential Request</value>
+    <value>Requête d’informations d’identification PowerShell</value>
   </data>
   <data name="CredentialRequestBody" xml:space="preserve">
-    <value>Enter your credentials for {0}.</value>
+    <value>Entrez vos informations d’identification pour {0}.</value>
   </data>
   <data name="ProxyCredentialRequestBody" xml:space="preserve">
-    <value>Enter the HTTP proxy credentials that are used for the following connection: {0}</value>
+    <value>Entrez les informations d’identification du proxy HTTP utilisées pour la connexion suivante : {0}</value>
   </data>
   <data name="WarningMismatchedImplicitRemotingHash" xml:space="preserve">
-    <value>Commands that are available in the new remote session are different than those available when the implicit remoting module was created.  Consider creating the module again by using the Export-PSSession cmdlet.</value>
+    <value>Les commandes disponibles dans la nouvelle session distante sont différentes de celles disponibles au moment de la création du module de communication à distance implicite.  Envisagez de recréer le module en utilisant la cmdlet Export-PSSession.</value>
   </data>
   <data name="CertificateNeeded" xml:space="preserve">
-    <value>Files cannot be loaded because running scripts is disabled on this system. Provide a valid certificate with which to sign the files.</value>
+    <value>Nous ne pouvons pas charger les fichiers, car l’exécution de scripts est désactivée sur ce système. Fournissez un certificat valide avec lequel signer les fichiers.</value>
   </data>
   <data name="InvalidSigningOperation" xml:space="preserve">
-    <value>The file {0} could not be signed.</value>
+    <value>Nous n’avons pas pu signer le fichier {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/SortObjectStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/SortObjectStrings.fr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>« Sort-Object » - «{0}» est introuvable dans « InputObject ».</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/fr/StartSleepStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/fr/StartSleepStrings.fr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>La valeur du paramètre « -Duration » ne doit pas dépasser «{0}», la valeur fournie était «{1}».</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/AddMember.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/AddMember.it.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WrongMemberCount" xml:space="preserve">
-    <value>To add a member, only one member type can be specified. The member types specified are: "{0}"</value>
+    <value>Per aggiungere un membro, è possibile specificare un solo tipo di membro. I tipi di membro specificati sono: "{0}"</value>
   </data>
   <data name="CannotAddMemberType" xml:space="preserve">
-    <value>Cannot add a member with type "{0}". Specify a different type for the MemberTypes parameter.</value>
+    <value>Non è possibile aggiungere un membro di tipo "{0}". Specificare un tipo diverso per il parametro MemberTypes.</value>
   </data>
   <data name="Value2ShouldNotBeSpecified" xml:space="preserve">
-    <value>The SecondValue parameter is not necessary for a member of type "{0}", and should not be specified. Do not specify the SecondValue parameter when you add members of this type.</value>
+    <value>Il parametro SecondValue non è necessario per un membro di tipo "{0}" e non deve essere specificato. Non specificare il parametro SecondValue quando si aggiungono membri di questo tipo.</value>
   </data>
   <data name="Value1Prompt" xml:space="preserve">
-    <value>The Value parameter is required for a member of type "{0}". Specify the Value parameter when adding members of this type.</value>
+    <value>Il parametro Value è obbligatorio per un membro di tipo "{0}". Specificare il parametro Value quando si aggiungono membri di questo tipo.</value>
   </data>
   <data name="Value1AndValue2AreNotBothNull" xml:space="preserve">
-    <value>Both Value and SecondValue parameters should not be null for a member of type "{0}". Specify a non-null value for one of the two parameters.</value>
+    <value>Entrambi i parametri Value e SecondValue non devono essere Null per un membro di tipo "{0}". Specificare un valore non null per uno dei due parametri.</value>
   </data>
   <data name="MemberAlreadyExists" xml:space="preserve">
-    <value>Cannot add a member with the name "{0}" because a member with that name already exists. To overwrite the member anyway, add the Force parameter to your command.</value>
+    <value>Non è possibile aggiungere un membro con il nome "{0}" perché esiste già un membro con tale nome. Per sovrascrivere comunque il membro, aggiungere il parametro Force al comando.</value>
   </data>
   <data name="CannotRemoveTypeDataMember" xml:space="preserve">
-    <value>Cannot force the member with name "{0}" and type "{1}" to be added. A member with that name and type already exists, and the existing member is not an instance extension.</value>
+    <value>Non è possibile forzare l'aggiunta del membro con nome "{0}" e tipo "{1}". Esiste già un membro con tale nome e tipo e il membro esistente non è un'estensione di istanza.</value>
   </data>
   <data name="AliasReferenceShouldNotBeNullOrEmpty" xml:space="preserve">
-    <value>The member referenced by this alias should not be null or empty.</value>
+    <value>Il membro a cui fa riferimento questo alias non deve essere Null o vuoto.</value>
   </data>
   <data name="Value1ShouldNotBeNull" xml:space="preserve">
-    <value>The Value parameter should not be null for a member of type "{0}". Specify a non-null value for the Value parameter when adding members of this type.</value>
+    <value>Il parametro Value non deve essere Null per un membro di tipo "{0}". Specificare un valore non Null per il parametro Value quando si aggiungono membri di questo tipo.</value>
   </data>
   <data name="Value2ShouldNotBeNull" xml:space="preserve">
-    <value>The SecondValue parameter should not be null for a member of type "{0}". Specify a non-null value for the SecondValue parameter when adding members of this type.</value>
+    <value>Il parametro SecondValue non deve essere Null per un membro di tipo "{0}". Specificare un valore non Null per il parametro SecondValue quando si aggiungono membri di questo tipo.</value>
   </data>
   <data name="InvalidValueForNotePropertyName" xml:space="preserve">
-    <value>The parameter NotePropertyName cannot take values that could be converted to the type {0}. To define the name of a member with those values, use Add-Member, and specify the member type.</value>
+    <value>Il parametro NotePropertyName non può accettare valori che possono essere convertiti nel tipo {0}. Per definire il nome di un membro con tali valori, utilizzare Add-Member e specificare il tipo di membro.</value>
   </data>
   <data name="NotePropertyNameShouldNotBeNull" xml:space="preserve">
-    <value>The name for a NoteProperty member should not be null or an empty string.</value>
+    <value>Il nome di un membro NoteProperty non deve essere Null o una stringa vuota.</value>
   </data>
   <data name="TypeNameShouldNotBeEmpty" xml:space="preserve">
-    <value>The TypeName parameter should not be null, empty, or contain only white spaces.</value>
+    <value>Il parametro TypeName non deve essere Null, vuoto o contenere solo spazi vuoti.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/AddTypeStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/AddTypeStrings.it.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Il codice sorgente è già stato compilato e caricato.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Non è possibile aggiungere il tipo. L'estensione "{0}" non è supportata.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Non è possibile aggiungere il tipo. Tutti i file di input devono avere la stessa estensione.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Non è possibile aggiungere il tipo. Non è possibile trovare l'assembly '{0}'.</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Non è possibile aggiungere il tipo. Il nome del tipo '{0}' esiste già.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Non è possibile impostare l'assembly di output. Il percorso {0} non è stato risolto in un singolo file.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Non è possibile aggiungere il tipo. Si sono verificati errori di compilazione.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Non è possibile aggiungere il tipo. Per il parametro OutputType è necessario specificare il parametro OutputAssembly.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Non è possibile aggiungere il tipo. La definizione de nuovi tipi non è supportata in questa modalità di linguaggio.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>L'assembly di riferimento '{0}' specificato non è necessario e viene ignorato.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Entrambi i tipi di assembly 'ConsoleApplication' e 'WindowsApplication' non sono attualmente supportati.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
     <value>Add-Type Cmdlet</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Il cmdlet Add-Type non sarà consentito in modalità ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/FormatAndOut_out_gridview.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/FormatAndOut_out_gridview.it.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Il formato dei dati non è supportato da Out-GridView.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>Microsoft .NET Framework 4.5 è stato installato durante l'esecuzione di una o più sessioni di PowerShell. Per usare il cmdlet {0}, chiudere tutte le finestre di PowerShell e quindi aprire una nuova finestra di PowerShell.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>Tipo</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>Valore</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>Indice</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>Non è possibile trovare un comando denominato ''{0}''.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>È stato trovato più di un comando denominato ''{0}''. Avviare ''{1}'' senza parametri, quindi digitare ''{0}'' per filtrare i risultati.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>Non è possibile scrivere nel buffer di input della console.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} deve essere minore di {1}.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/GetRandomCommandStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/GetRandomCommandStrings.it.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>''maxValue'' deve essere maggiore di zero.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>Il valore minimo ({0}) non può essere maggiore o uguale al valore massimo ({1}).</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>''minValue'' non può essere maggiore di maxValue.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/HostStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/HostStrings.it.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidColorErrorTemplate" xml:space="preserve">
-    <value>Cannot process the color because {0} is not a valid color.</value>
+    <value>Non è possibile elaborare il colore perché {0} non è un colore valido.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/ImportLocalizedDataStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/ImportLocalizedDataStrings.it.resx
@@ -118,35 +118,35 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileNotExist" xml:space="preserve">
-    <value>The data file '{0}' cannot be found. </value>
+    <value>Non è possibile trovare il file di dati '{0}'. </value>
   </data>
   <data name="NotCalledFromAScriptFile" xml:space="preserve">
-    <value>The FileName parameter was not specified. The FileName parameter is required when Import-LocalizedData is not called from a script file.</value>
+    <value>Il parametro FileName non è specificato. Il parametro FileName è obbligatorio quando Import-LocalizedData non viene richiamato da un file script.</value>
   </data>
   <data name="ErrorOpeningFile" xml:space="preserve">
-    <value>The following error occurred while PowerShell was opening the data file '{0}':
+    <value>Si è verificato l'errore seguente durante l'apertura del file di dati '{0}' da parte di PowerShell:
 {1}.</value>
   </data>
   <data name="ErrorLoadingDataFile" xml:space="preserve">
-    <value>The following error occurred while PowerShell was loading the '{0}' script data file:
+    <value>Si è verificato l'errore seguente durante il caricamento del file di dati script '{0}' da parte di PowerShell:
 {1}.</value>
   </data>
   <data name="FileNameParameterCannotHavePath" xml:space="preserve">
-    <value>The argument for the FileName parameter should not contain a path.</value>
+    <value>L'argomento per il parametro FileName non deve contenere un percorso.</value>
   </data>
   <data name="CannotFindPsd1File" xml:space="preserve">
-    <value>Cannot find the PowerShell data file '{0}' in directory '{1}', or in any parent culture directories.</value>
+    <value>Non è possibile trovare il file di dati di PowerShell '{0}' nella directory '{1}' o in alcuna directory delle impostazioni cultura padre.</value>
   </data>
   <data name="CannotDefineSupportedCommand" xml:space="preserve">
-    <value>Cannot import localized data. The definition of additional supported commands is not allowed in this language mode.</value>
+    <value>Non è possibile importare dati localizzati. La definizione di comandi aggiuntivi supportati non è consentita in questa modalità del linguaggio.</value>
   </data>
   <data name="IncorrectVariableName" xml:space="preserve">
-    <value>The BindingVariable name '{0}' is invalid.</value>
+    <value>Il nome della BindingVariable '{0}' non è valido.</value>
   </data>
   <data name="WDACLogTitle" xml:space="preserve">
     <value>Import-LocalizedData Cmdlet</value>
   </data>
   <data name="WDACLogMessage" xml:space="preserve">
-    <value>Additional supported commands (via SupportedCommand parameter) will not be allowed in ConstrainedLanguage mode.</value>
+    <value>I comandi aggiuntivi supportati (tramite il parametro SupportedCommand) non sono consentiti in modalità ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/NewObjectStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/NewObjectStrings.it.resx
@@ -118,45 +118,45 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotFindAppropriateCtor" xml:space="preserve">
-    <value>A constructor was not found. Cannot find an appropriate constructor for type {0}.</value>
+    <value>Costruttore non trovato. Non è possibile trovare un costruttore appropriato per il tipo {0}.</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
-    <value>Cannot find type [{0}]: verify that the assembly containing this type is loaded.</value>
+    <value>Non è possibile trovare il tipo [{0}]: verificare che l'assembly contenente questo tipo sia caricato.</value>
   </data>
   <data name="CannotLoadComObjectType" xml:space="preserve">
-    <value>Cannot load COM type {0}.</value>
+    <value>Non è possibile caricare il tipo COM {0}.</value>
   </data>
   <data name="ComInteropLoaded" xml:space="preserve">
-    <value>The object written to the pipeline is an instance of the type "{0}" from the component's primary interoperability assembly. If this type exposes different members than the IDispatch members, scripts that are written to work with this object might not work if the primary interoperability assembly is not installed.</value>
+    <value>L'oggetto scritto nella pipeline è un'istanza del tipo "{0}" dall'assembly di interoperabilità primario del componente. Se questo tipo espone membri diversi rispetto ai membri IDispatch, gli script scritti per lavorare con questo oggetto potrebbero non funzionare se l'assembly di interoperabilità primario non è installato.</value>
   </data>
   <data name="MemberNotFound" xml:space="preserve">
-    <value>The member "{1}" was not found for the specified {2} object.</value>
+    <value>Non è possibile trovare il membro "{1}" per l'oggetto {2} specificato.</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>The value supplied is not valid, or the property is read-only. Change the value, and then try again.</value>
+    <value>Il valore specificato non è valido o la proprietà è di sola lettura. Modificare il valore, quindi riprovare.</value>
   </data>
   <data name="CannotInstantiateWinRTType" xml:space="preserve">
-    <value>Creating instances of attribute and delegated Windows RT types is not supported.</value>
+    <value>La creazione di istanze di attributi e tipi di Windows RT delegati non è supportata.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create instances of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Non è possibile creare istanze del tipo simile a ByRef "{0}". I tipi simili a ByRef non sono supportati in PowerShell.</value>
   </data>
   <data name="CannotCreateTypeConstrainedLanguage" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in this language mode.</value>
+    <value>Non è possibile creare il tipo. In questa modalità linguaggio sono supportati solo i tipi di base.</value>
   </data>
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
+    <value>Non è possibile creare il tipo. Solo i tipi di base sono supportati in modalità lingua {0} in un computer con criteri bloccati.</value>
   </data>
   <data name="TypeWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet Type Creation</value>
+    <value>Creazione del tipo di cmdlet New-Object</value>
   </data>
   <data name="TypeWDACLogMessage" xml:space="preserve">
-    <value>The type '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>Il tipo ''{0}'' non verrà creato in modalità ConstrainedLanguage.</value>
   </data>
   <data name="ComWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet COM Object Creation</value>
+    <value>Creazione di oggetti COM cmdlet New-Object</value>
   </data>
   <data name="ComWDACLogMessage" xml:space="preserve">
-    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>L'oggetto COM ''{0}'' non verrà creato in modalità ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/it/WriteErrorStrings.it.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/it/WriteErrorStrings.it.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>"Il cmdlet Write-Error ha segnalato un errore".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/AddTypeStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/AddTypeStrings.ja.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>ソース コードはすでにコンパイルされ、読み込まれています。</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>型を追加できません。"{0}" 拡張子はサポートされていません。</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>型を追加できません。入力ファイルはすべて同じファイル拡張子である必要があります。</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>型を追加できません。アセンブリ {0} が見つかりませんでした。</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>型を追加できません。型の名前 '{0}' は既に存在します。</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>出力アセンブリを設定できません。パス {0} は 1 つのファイルに解決されませんでした。</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>型を追加できません。コンパイル エラーが発生しました。</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>型を追加できません。OutputType パラメーターを指定するには、OutputAssembly パラメーターが必要です。</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>型を追加できません。この言語モードでは、新しい型の定義はサポートされていません。</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>指定された参照アセンブリ '{0}' は不要なため、無視されます。</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>アセンブリの型 'ConsoleApplication' と 'WindowsApplication' は、どちらも現在サポートされていません。</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Add-Type コマンドレット</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Add-Type コマンドレットは ConstrainedLanguage モードでは許可されません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/EventingStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/EventingStrings.ja.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>ソース識別子 '{0}' を持つイベントは存在しません。</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>識別子 '{0}' を持つイベントは存在しません。</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>ソース識別子 '{0}' を持つイベント サブスクリプションは存在しません。</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>識別子 '{0}' を持つイベント サブスクリプションは存在しません。</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>イベント サブスクリプション '{0}'</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>イベント '{0}'</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>転送されないイベントには、アクションを指定する必要があります。</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>受信登録の取り消し</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/FormatAndOut_out_gridview.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/FormatAndOut_out_gridview.ja.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>このデータ形式は Out-GridView ではサポートされていません。</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>1 つ以上の PowerShell セッションの実行中に、Microsoft .NET Framework 4.5 がインストールされました。{0} コマンドレットを使用するには、すべての PowerShell ウィンドウを閉じてから、新しい PowerShell ウィンドウを開いてください。</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>型</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>値</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>インデックス</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>'{0}' という名前のコマンドが見つかりませんでした。</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>'{0}' という名前のコマンドが複数見つかりました。パラメーターなしで '{1}' を開始し、'{0}' と入力して結果をフィルター処理します。</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>コンソールの入力バッファーに書き込めません。</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} は {1} より小さくする必要があります。</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/GetRandomCommandStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/GetRandomCommandStrings.ja.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>'maxValue' は 0 よりも大きくする必要があります。</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>最小値 ({0}) を最大値 ({1}) 以上にすることはできません。</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>'minValue' を maxValue より大きくすることはできません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/MeasureObjectStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/MeasureObjectStrings.ja.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property "{0}" cannot be found in the input for any objects.</value>
+    <value>プロパティ "{0}" は、どのオブジェクトの入力にも見つかりません。</value>
   </data>
   <data name="NonNumericInputObject" xml:space="preserve">
-    <value>Input object "{0}" is not numeric.</value>
+    <value>入力オブジェクト "{0}" は数値ではありません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/NewObjectStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/NewObjectStrings.ja.resx
@@ -118,45 +118,45 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotFindAppropriateCtor" xml:space="preserve">
-    <value>A constructor was not found. Cannot find an appropriate constructor for type {0}.</value>
+    <value>コンストラクターが見つかりませんでした。型 {0}の適切なコンストラクターが見つかりません。</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
-    <value>Cannot find type [{0}]: verify that the assembly containing this type is loaded.</value>
+    <value>型 [{0}] が見つかりません: この型を含むアセンブリが読み込まれていることを確認してください。</value>
   </data>
   <data name="CannotLoadComObjectType" xml:space="preserve">
-    <value>Cannot load COM type {0}.</value>
+    <value>COM 型 {0} を読み込めません。</value>
   </data>
   <data name="ComInteropLoaded" xml:space="preserve">
-    <value>The object written to the pipeline is an instance of the type "{0}" from the component's primary interoperability assembly. If this type exposes different members than the IDispatch members, scripts that are written to work with this object might not work if the primary interoperability assembly is not installed.</value>
+    <value>パイプラインに書き込まれるオブジェクトは、コンポーネントのプライマリ相互運用性アセンブリからの "{0}" 型のインスタンスです。この型が IDispatch メンバーとは異なるメンバーを公開している場合、プライマリ相互運用性アセンブリがインストールされていないと、このオブジェクトで動作するように書き込まれたスクリプトが機能しない可能性があります。</value>
   </data>
   <data name="MemberNotFound" xml:space="preserve">
-    <value>The member "{1}" was not found for the specified {2} object.</value>
+    <value>指定された {2} オブジェクトのメンバー "{1}" が見つかりませんでした。</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>The value supplied is not valid, or the property is read-only. Change the value, and then try again.</value>
+    <value>指定された値が無効であるか、プロパティが読み取り専用です。値を変更して、もう一度やり直してください。</value>
   </data>
   <data name="CannotInstantiateWinRTType" xml:space="preserve">
-    <value>Creating instances of attribute and delegated Windows RT types is not supported.</value>
+    <value>属性型と委任されたWindows RT 型のインスタンスの作成はサポートされていません。</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create instances of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef に似た "{0}" 型のインスタンスは作成できません。ByRef に似た型は、PowerShell ではサポートされていません。</value>
   </data>
   <data name="CannotCreateTypeConstrainedLanguage" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in this language mode.</value>
+    <value>型を作成できません。この言語モードでは、コア型のみがサポートされています。</value>
   </data>
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
+    <value>型を作成できません。ポリシーがロック ダウンされたコンピューターでは、{0} 言語モードではコア型のみがサポートされています。</value>
   </data>
   <data name="TypeWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet Type Creation</value>
+    <value>New-Object コマンドレットの型の作成</value>
   </data>
   <data name="TypeWDACLogMessage" xml:space="preserve">
-    <value>The type '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>型 '{0}' は ConstrainedLanguage モードでは作成されません。</value>
   </data>
   <data name="ComWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet COM Object Creation</value>
+    <value>New-Object コマンドレットの COM オブジェクトの作成</value>
   </data>
   <data name="ComWDACLogMessage" xml:space="preserve">
-    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>COM オブジェクト '{0}' は ConstrainedLanguage モードでは作成されません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/SelectObjectStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/SelectObjectStrings.ja.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RenamingMultipleResults" xml:space="preserve">
-    <value>Cannot rename multiple results.</value>
+    <value>複数の結果の名前を変更することはできません。</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>Property "{0}" cannot be found.</value>
+    <value>プロパティ "{0}" が見つかりません。</value>
   </data>
   <data name="MutlipleExpandProperties" xml:space="preserve">
-    <value>Multiple properties cannot be expanded.</value>
+    <value>複数のプロパティを展開することはできません。</value>
   </data>
   <data name="AlreadyExistingProperty" xml:space="preserve">
-    <value>The property cannot be processed because the property "{0}" already exists.</value>
+    <value>プロパティ "{0}" が既に存在するため、プロパティを処理できません。</value>
   </data>
   <data name="EmptyScriptBlockAndNoName" xml:space="preserve">
-    <value>A property is an empty script block and does not provide a name.</value>
+    <value>プロパティは空のスクリプト ブロックであり、名前は指定されません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/SortObjectStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/SortObjectStrings.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" - "{0}" が "InputObject" に見つかりません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/StartSleepStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/StartSleepStrings.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>'-Duration' パラメーターの値は '{0}' を超えることはできません。指定された値は '{1}' でした。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/TestJsonCmdletStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/TestJsonCmdletStrings.ja.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>JSON スキーマを解析できません。</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>JSON を解析できません。</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>JSON は '{1}' のスキーマ {0} で無効です</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>JSON スキーマ ファイルを開けません: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>URI スキーム '{0}' はサポートされていません。HTTP(S) およびローカル ファイル システムの URI のみが許可されています。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ja/WriteErrorStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ja/WriteErrorStrings.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>"Write-Error コマンドレットでエラーが報告されました。"</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/AddTypeStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/AddTypeStrings.ko.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>소스 코드가 이미 컴파일되어 로드되었습니다.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>유형을 추가할 수 없습니다. "{0}" 확장은 지원되지 않습니다.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>유형을 추가할 수 없습니다. 입력 파일의 파일 확장명은 모두 같아야 합니다.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>유형을 추가할 수 없습니다. 어셈블리 '{0}'을(를) 찾을 수 없습니다.</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>유형을 추가할 수 없습니다. 형식 이름 '{0}'이(가) 이미 있습니다.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>출력 어셈블리를 설정할 수 없습니다. 경로 {0}이(가) 단일 파일로 확인되지 않았습니다.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>유형을 추가할 수 없습니다. 컴파일 오류가 발생했습니다.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>유형을 추가할 수 없습니다. OutputType 매개 변수를 사용하려면 OutputAssembly 매개 변수를 지정해야 합니다.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>유형을 추가할 수 없습니다. 이 언어 모드에서는 새 형식 정의를 지원하지 않습니다.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>지정한 참조 어셈블리 '{0}'은(는) 필요하지 않으므로 무시됩니다.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>어셈블리 형식 'ConsoleApplication'과 'WindowsApplication'은 현재 지원되지 않습니다.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Add-Type cmdlet</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 Add-Type cmdlet을 사용할 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/ConvertHTMLStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/ConvertHTMLStrings.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetaPropertyNotFound" xml:space="preserve">
-    <value>Accepted meta properties are content-type, default-style, application-name, author, description, generator, keywords, x-ua-compatible, and viewport. The meta pair: {0} and {1} may not function correctly.</value>
+    <value>허용되는 메타 속성은 content-type, default-style, application-name, author, description, generator, keywords, x-ua-compatible, viewport입니다. 메타 쌍 {0} 및 {1}이(가) 제대로 작동하지 않을 수 있습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/EventingStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/EventingStrings.ko.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>원본 식별자가 '{0}'인 이벤트는 없습니다.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>식별자가 '{0}'인 이벤트는 없습니다.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>원본 식별자 '{0}'의 이벤트 구독이 없습니다.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>식별자 '{0}'의 이벤트 구독이 없습니다.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>이벤트 구독 '{0}'</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>‘{0}’ 이벤트</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>전달되지 않는 이벤트에는 작업을 지정해야 합니다.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>구독 취소</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/FormatAndOut_out_gridview.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/FormatAndOut_out_gridview.ko.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Out-GridView에서 지원하지 않는 데이터 형식입니다.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>하나 이상의 PowerShell 세션이 실행되는 동안 Microsoft .NET Framework 4.5가 설치되었습니다. {0} cmdlet을 사용하려면 모든 PowerShell 창을 닫은 다음 새 PowerShell 창을 여세요.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>형식</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>값</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>인덱스</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>'{0}'(이)라는 이름의 명령을 찾을 수 없습니다.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>'{0}'(이)라는 이름의 명령이 둘 이상 발견되었습니다. 매개 변수 없이 '{1}'을(를) 시작한 다음 '{0}'을(를) 입력하여 결과를 필터링하세요.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>콘솔 입력 버퍼에 쓸 수 없습니다.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0}은(는) {1}보다 작아야 합니다.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/GetMember.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/GetMember.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoObjectSpecified" xml:space="preserve">
-    <value>You must specify an object for the Get-Member cmdlet.</value>
+    <value>Get-Member cmdlet에 사용할 개체를 지정해야 합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/GetRandomCommandStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/GetRandomCommandStrings.ko.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>'maxValue'는 0보다 커야 합니다.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>최솟값({0})은 최댓값({1})보다 크거나 같을 수 없습니다.</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>'minValue'는 maxValue보다 클 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/NewObjectStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/NewObjectStrings.ko.resx
@@ -118,45 +118,45 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotFindAppropriateCtor" xml:space="preserve">
-    <value>A constructor was not found. Cannot find an appropriate constructor for type {0}.</value>
+    <value>생성자를 찾을 수 없습니다. 형식 {0}에 적합한 생성자를 찾을 수 없습니다.</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
-    <value>Cannot find type [{0}]: verify that the assembly containing this type is loaded.</value>
+    <value>[{0}] 형식을 찾을 수 없습니다. 이 형식을 포함하는 어셈블리가 로드되었는지 확인하세요.</value>
   </data>
   <data name="CannotLoadComObjectType" xml:space="preserve">
-    <value>Cannot load COM type {0}.</value>
+    <value>COM 형식을 로드할 수 없습니다. {0}</value>
   </data>
   <data name="ComInteropLoaded" xml:space="preserve">
-    <value>The object written to the pipeline is an instance of the type "{0}" from the component's primary interoperability assembly. If this type exposes different members than the IDispatch members, scripts that are written to work with this object might not work if the primary interoperability assembly is not installed.</value>
+    <value>파이프라인에 기록된 개체는 구성 요소의 기본 상호 운용 어셈블리에 있는 "{0}" 형식의 인스턴스입니다. 이 형식이 IDispatch 멤버와 다른 멤버를 노출하는 경우, 이 개체와 함께 작동하도록 작성된 스크립트는 기본 상호 운용 어셈블리가 설치되어 있지 않으면 제대로 작동하지 않을 수 있습니다.</value>
   </data>
   <data name="MemberNotFound" xml:space="preserve">
-    <value>The member "{1}" was not found for the specified {2} object.</value>
+    <value>지정한 {2} 개체에서 멤버 "{1}"을(를) 찾을 수 없습니다.</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>The value supplied is not valid, or the property is read-only. Change the value, and then try again.</value>
+    <value>제공된 값이 올바르지 않거나 속성이 읽기 전용입니다. 값을 바꾼 다음 다시 시도하세요.</value>
   </data>
   <data name="CannotInstantiateWinRTType" xml:space="preserve">
-    <value>Creating instances of attribute and delegated Windows RT types is not supported.</value>
+    <value>특성 및 위임된 Windows RT 형식의 인스턴스를 만들 수 없습니다.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create instances of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef와 유사한 형식 "{0}"의 인스턴스를 만들 수 없습니다. PowerShell에서는 ByRef와 유사한 형식이 지원되지 않습니다.</value>
   </data>
   <data name="CannotCreateTypeConstrainedLanguage" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in this language mode.</value>
+    <value>형식을 만들 수 없습니다. 이 언어 모드에서는 핵심 형식만 지원됩니다.</value>
   </data>
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
+    <value>형식을 만들 수 없습니다. 핵심 형식만 정책 잠금 컴퓨터의 {0} 언어 모드에서 지원됩니다.</value>
   </data>
   <data name="TypeWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet Type Creation</value>
+    <value>New-Object Cmdlet 형식 만들기</value>
   </data>
   <data name="TypeWDACLogMessage" xml:space="preserve">
-    <value>The type '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 '{0}' 형식이 만들어지지 않습니다.</value>
   </data>
   <data name="ComWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet COM Object Creation</value>
+    <value>New-Object Cmdlet COM 개체 만들기</value>
   </data>
   <data name="ComWDACLogMessage" xml:space="preserve">
-    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 COM 개체 '{0}'이(가) 만들어지지 않습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/SelectObjectStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/SelectObjectStrings.ko.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RenamingMultipleResults" xml:space="preserve">
-    <value>Cannot rename multiple results.</value>
+    <value>여러 결과의 이름을 바꿀 수 없습니다.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>Property "{0}" cannot be found.</value>
+    <value>속성 "{0}"을(를) 찾을 수 없습니다.</value>
   </data>
   <data name="MutlipleExpandProperties" xml:space="preserve">
-    <value>Multiple properties cannot be expanded.</value>
+    <value>여러 속성을 확장할 수 없습니다.</value>
   </data>
   <data name="AlreadyExistingProperty" xml:space="preserve">
-    <value>The property cannot be processed because the property "{0}" already exists.</value>
+    <value>속성 "{0}"이(가) 이미 있어서 이 속성을 처리할 수 없습니다.</value>
   </data>
   <data name="EmptyScriptBlockAndNoName" xml:space="preserve">
-    <value>A property is an empty script block and does not provide a name.</value>
+    <value>이 속성은 빈 스크립트 블록이며 이름을 제공하지 않습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/SortObjectStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/SortObjectStrings.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" - "InputObject"에서 "{0}"을(를) 찾을 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/WebCmdletStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/WebCmdletStrings.ko.resx
@@ -121,132 +121,132 @@
     <value>'{0}' 경로에 대한 액세스가 거부되었습니다.</value>
   </data>
   <data name="AllowUnencryptedAuthenticationRequired" xml:space="preserve">
-    <value>The cmdlet cannot protect plain text secrets sent over unencrypted connections. To suppress this warning and send plain text secrets over unencrypted networks, reissue the command specifying the AllowUnencryptedAuthentication parameter.</value>
+    <value>cmdlet은 암호화되지 않은 연결을 통해 전송되는 일반 텍스트 비밀을 보호할 수 없습니다. 이 경고를 표시하지 않고 암호화되지 않은 네트워크를 통해 일반 텍스트 비밀을 보내려면 AllowUnencryptedAuthentication 매개 변수를 지정하여 명령을 다시 실행하세요.</value>
   </data>
   <data name="AuthenticationConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Authentication and UseDefaultCredentials. Authentication does not support Default Credentials. Specify either Authentication or UseDefaultCredentials, then retry.</value>
+    <value>충돌하는 매개 변수 Authentication 및 UseDefaultCredentials가 지정되어 cmdlet을 실행할 수 없습니다. Authentication은 기본 자격 증명을 지원하지 않습니다. Authentication 또는 UseDefaultCredentials를 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="AuthenticationCredentialNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is not specified: Credential. The supplied Authentication type requires a Credential. Specify Credential, then retry.</value>
+    <value>Credential 매개 변수가 지정되지 않아 cmdlet을 실행할 수 없습니다. 지정한 Authentication 형식에는 Credential이 필요합니다. Credential을 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="AuthenticationTokenNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is not specified: Token. The supplied Authentication type requires a Token. Specify Token, then retry.</value>
+    <value>Token 매개 변수가 지정되지 않아 cmdlet을 실행할 수 없습니다. 지정한 Authentication 형식에는 Token이 필요합니다. Token을 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="AuthenticationTokenConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and Token. Specify either Credential or Token, then retry.</value>
+    <value>충돌하는 매개 변수 Credential 및 Token이 지정되어 cmdlet을 실행할 수 없습니다. Credential 또는 Token을 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="BodyConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Body and InFile. Specify either Body or Infile, then retry.  </value>
+    <value>충돌하는 매개 변수 Body 및 InFile이 지정되어 cmdlet을 실행할 수 없습니다. Body 또는 InFile을 지정한 후 다시 시도하세요.  </value>
   </data>
   <data name="BodyFormConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Body and Form. Specify either Body or Form, then retry.  </value>
+    <value>충돌하는 매개 변수 Body 및 Form이 지정되어 cmdlet을 실행할 수 없습니다. Body 또는 Form을 지정한 후 다시 시도하세요.  </value>
   </data>
   <data name="FormInFileConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: InFile and Form. Specify either InFile or Form, then retry.  </value>
+    <value>충돌하는 매개 변수 InFile 및 Form이 지정되어 cmdlet을 실행할 수 없습니다. InFile 또는 Form을 지정한 후 다시 시도하세요.  </value>
   </data>
   <data name="ContentTypeException" xml:space="preserve">
-    <value>The cmdlet cannot run because the -ContentType parameter is not a valid Content-Type header. Specify a valid Content-Type for -ContentType, then retry. To suppress header validation, supply the -SkipHeaderValidation parameter.</value>
+    <value>-ContentType 매개 변수가 올바른 Content-Type 헤더가 아니므로 cmdlet을 실행할 수 없습니다. -ContentType에 유효한 Content-Type을 지정한 후 다시 시도하세요. 헤더 유효성 검사를 건너뛰려면 -SkipHeaderValidation 매개 변수를 제공하세요.</value>
   </data>
   <data name="CredentialConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Credential and UseDefaultCredentials. Specify either Credential or UseDefaultCredentials, then retry.</value>
+    <value>충돌하는 매개 변수 Credential 및 UseDefaultCredentials가 지정되어 cmdlet을 실행할 수 없습니다. Credential 또는 UseDefaultCredentials를 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="DirectoryPathSpecified" xml:space="preserve">
-    <value>Path '{0}' resolves to a directory. Specify a path including a file name, and then retry the command.</value>
+    <value>경로 '{0}'은(는) 디렉터리로 확인됩니다. 파일 이름을 포함한 경로를 지정한 후 명령을 다시 시도하세요.</value>
   </data>
   <data name="EmptyKeyInJsonString" xml:space="preserve">
-    <value>The provided JSON includes a property whose name is an empty string, this is only supported using the -AsHashTable switch.</value>
+    <value>제공된 JSON에 이름이 빈 문자열인 속성이 포함되어 있습니다. 이는 -AsHashTable 스위치를 사용하는 경우에만 지원됩니다.</value>
   </data>
   <data name="DuplicateKeysInJsonString" xml:space="preserve">
-    <value>Cannot convert the JSON string because a dictionary that was converted from the string contains the duplicated key '{0}'.</value>
+    <value>문자열에서 변환된 사전에 중복된 키 '{0}'이(가) 포함되어 있으므로 JSON 문자열을 변환할 수 없습니다.</value>
   </data>
   <data name="IEDomNotSupported" xml:space="preserve">
-    <value>The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again. </value>
+    <value>응답 콘텐츠를 구문 분석할 수 없습니다. Internet Explorer 엔진을 사용할 수 없거나 Internet Explorer의 첫 실행 구성이 완료되지 않았습니다. UseBasicParsing 매개 변수를 지정하고 다시 시도하세요. </value>
   </data>
   <data name="InsecureRedirection" xml:space="preserve">
-    <value>Cannot follow an insecure redirection by default. Reissue the command specifying the -AllowInsecureRedirect switch. </value>
+    <value>기본적으로 안전하지 않은 리디렉션은 따를 수 없습니다. -AllowInsecureRedirect 스위치를 지정하여 명령을 다시 실행하세요. </value>
   </data>
   <data name="KeysWithDifferentCasingInJsonString" xml:space="preserve">
-    <value>Cannot convert the JSON string because it contains keys with different casing. Please use the -AsHashTable switch instead. The key that was attempted to be added to the existing key '{0}' was '{1}'.</value>
+    <value>대/소문자가 다른 키를 포함하므로 JSON 문자열을 변환할 수 없습니다. 대신 -AsHashTable 스위치를 사용하세요. 기존 키 '{0}'에 추가하려던 키는 '{1}'입니다.</value>
   </data>
   <data name="MaximumRedirectionCountExceeded" xml:space="preserve">
-    <value>The maximum redirection count has been exceeded. To increase the number of redirections allowed, supply a higher value to the -MaximumRedirection parameter.</value>
+    <value>최대 리디렉션 횟수를 초과했습니다. 허용되는 리디렉션 수를 늘리려면 -MaximumRedirection 매개 변수에 더 큰 값을 지정하세요.</value>
   </data>
   <data name="MultiplePathsResolved" xml:space="preserve">
-    <value>Path '{0}' can be resolved to multiple paths.</value>
+    <value>경로 '{0}'은(는) 여러 경로로 확인될 수 있습니다.</value>
   </data>
   <data name="NonStringKeyInDictionary" xml:space="preserve">
-    <value>The type '{0}' is not supported for serialization or deserialization of a dictionary. Keys must be strings.</value>
+    <value>'{0}' 유형은 사전의 직렬화 또는 역직렬화에 지원되지 않습니다. 키는 문자열이어야 합니다.</value>
   </data>
   <data name="NoPathResolved" xml:space="preserve">
-    <value>Path '{0}' cannot be resolved to a file.</value>
+    <value>경로 '{0}'을(를) 파일로 확인할 수 없습니다.</value>
   </data>
   <data name="NotFilesystemPath" xml:space="preserve">
-    <value>Path '{0}' is not a file system path. Please specify the path to a file in the file system.</value>
+    <value>'{0}' 경로는 파일 시스템 경로가 아닙니다. 파일 시스템의 파일 경로를 지정하세요.</value>
   </data>
   <data name="OutFileMissing" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is missing: OutFile. Provide a valid OutFile parameter value when using the {0} parameter, then retry.</value>
+    <value>OutFile 매개 변수가 지정되지 않아 cmdlet을 실행할 수 없습니다. {0} 매개 변수를 사용할 때는 유효한 OutFile 매개 변수 값을 제공한 후 다시 시도하세요.</value>
   </data>
   <data name="OutFileWritingSkipped" xml:space="preserve">
-    <value>The file will not be re-downloaded because the remote file is the same size as the OutFile: {0}</value>
+    <value>원격 파일의 크기가 OutFile {0}와(과) 같으므로 파일이 다시 다운로드되지 않습니다.</value>
   </data>
   <data name="ProxyCredentialConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: ProxyCredential and ProxyUseDefaultCredentials. Specify either ProxyCredential or ProxyUseDefaultCredentials, then retry.</value>
+    <value>충돌하는 매개 변수 ProxyCredential 및 ProxyUseDefaultCredentials가 지정되어 cmdlet을 실행할 수 없습니다. ProxyCredential 또는 ProxyUseDefaultCredentials를 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="ProxyUriNotSupplied" xml:space="preserve">
-    <value>The cmdlet cannot run because the following parameter is missing: Proxy. Provide a valid proxy URI for the Proxy parameter when using the ProxyCredential or ProxyUseDefaultCredentials parameters, then retry.</value>
+    <value>Proxy 매개 변수가 지정되지 않아 cmdlet을 실행할 수 없습니다. ProxyCredential 또는 ProxyUseDefaultCredentials 매개 변수를 사용할 때는 Proxy 매개 변수에 유효한 프록시 URI를 제공한 후 다시 시도하세요.</value>
   </data>
   <data name="ReadResponseComplete" xml:space="preserve">
-    <value>Reading web response stream completed. Bytes downloaded: {0}</value>
+    <value>웹 응답 스트림 읽기가 완료되었습니다. 다운로드된 바이트: {0}</value>
   </data>
   <data name="ReadResponseProgressActivity" xml:space="preserve">
-    <value>Reading web response stream</value>
+    <value>웹 응답 스트림을 읽는 중</value>
   </data>
   <data name="ReadResponseProgressStatus" xml:space="preserve">
-    <value>Downloaded: {0} of {1}</value>
+    <value>{1}개 중 {0}개를 다운로드함</value>
   </data>
   <data name="ResumeNotFilePath" xml:space="preserve">
-    <value>The Resume switch can only be used if OutFile targets a file but it resolves to a directory: {0}.</value>
+    <value>Resume 스위치는 OutFile이 파일을 대상으로 할 때만 사용할 수 있지만 파일이 {0} 디렉터리로 확인됩니다.</value>
   </data>
   <data name="SessionConflict" xml:space="preserve">
-    <value>The cmdlet cannot run because the following conflicting parameters are specified: Session and SessionVariable. Specify either Session or SessionVariable, then retry.</value>
+    <value>충돌하는 매개 변수 Session 및 SessionVariable이 지정되어 cmdlet을 실행할 수 없습니다. Session 또는 SessionVariable을 지정한 후 다시 시도하세요.</value>
   </data>
   <data name="ThumbprintNotFound" xml:space="preserve">
-    <value>Unable to retrieve certificates because the thumbprint is not valid. Verify the thumbprint and retry. </value>
+    <value>지문이 올바르지 않아 인증서를 검색할 수 없습니다. 지문을 확인한 후 다시 시도하세요. </value>
   </data>
   <data name="WriteRequestComplete" xml:space="preserve">
-    <value>Web request completed. (Number of bytes processed: {0})</value>
+    <value>웹 요청이 완료되었습니다. (처리된 바이트 수: {0})</value>
   </data>
   <data name="WriteRequestCancelled" xml:space="preserve">
-    <value>Web request cancelled. (Number of bytes processed: {0})</value>
+    <value>웹 요청이 취소되었습니다. (처리된 바이트 수: {0})</value>
   </data>
   <data name="WriteRequestProgressActivity" xml:space="preserve">
-    <value>Web request status</value>
+    <value>웹 요청 상태</value>
   </data>
   <data name="WriteRequestProgressStatus" xml:space="preserve">
-    <value>Downloaded: {0} of {1}</value>
+    <value>{1}개 중 {0}개를 다운로드함</value>
   </data>
   <data name="JsonDeserializationFailed" xml:space="preserve">
-    <value>Conversion from JSON failed with error: {0}</value>
+    <value>다음 오류로 JSON 변환에 실패했습니다. {0}</value>
   </data>
   <data name="ResponseStatusCodeFailure" xml:space="preserve">
-    <value>Response status code does not indicate success: {0} ({1}).</value>
+    <value>다음 응답 상태 코드가 성공을 나타내지 않습니다. {0}({1})</value>
   </data>
   <data name="FollowingRelLinkVerboseMsg" xml:space="preserve">
-    <value>Following rel link {0}</value>
+    <value>rel 링크 {0}을(를) 따르는 중</value>
   </data>
   <data name="WebMethodResumeFailedVerboseMsg" xml:space="preserve">
-    <value>The remote server indicated it could not resume downloading. The local file will be overwritten.</value>
+    <value>원격 서버에서 다운로드를 다시 시작할 수 없다고 응답했습니다. 로컬 파일을 덮어씁니다.</value>
   </data>
   <data name="WebResponseNoSizeVerboseMsg" xml:space="preserve">
-    <value>Received HTTP/{0} response of content type {1} of unknown size</value>
+    <value>알 수 없는 크기의 콘텐츠 형식 {0}의 HTTP/{1} 응답을 받았습니다.</value>
   </data>
   <data name="RetryVerboseMsg" xml:space="preserve">
-    <value>Retrying after interval of {0} seconds. Status code for previous attempt: {1}</value>
+    <value>{0}초 간격 후 다시 시도합니다. 이전 시도의 상태 코드: {1}</value>
   </data>
   <data name="JsonMaxDepthReached" xml:space="preserve">
-    <value>Resulting JSON is truncated as serialization has exceeded the set depth of {0}.</value>
+    <value>직렬화가 설정된 깊이({0})를 초과하므로 결과 JSON이 잘립니다.</value>
   </data>
   <data name="WebSessionConnectionRecreated" xml:space="preserve">
-    <value>The WebSession properties were changed between requests forcing all HTTP connections in the session to be recreated.</value>
+    <value>WebSession 속성이 요청 사이에 변경되어 세션의 모든 HTTP 연결을 다시 만들어야 합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ko/WriteErrorStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ko/WriteErrorStrings.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>Write-Error cmdlet에서 오류가 보고되었습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/AddTypeStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/AddTypeStrings.pl.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Kod źródłowy został już skompilowany i załadowany.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Nie można dodać typu. Rozszerzenie „{0}” nie jest obsługiwane.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Nie można dodać typu. Wszystkie pliki wejściowe muszą mieć to samo rozszerzenie.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Nie można dodać typu. Nie można odnaleźć zestawu „{0}”.</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Nie można dodać typu. Nazwa typu „{0}” już istnieje.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Nie można ustawić zestawu wyjściowego. Ścieżka {0} nie została rozpoznana jako pojedynczy plik.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Nie można dodać typu. Wystąpiły błędy kompilacji.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Nie można dodać typu. Parametr OutputType wymaga określenia parametru OutputAssembly.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Nie można dodać typu. Definiowanie nowych typów nie jest obsługiwane w tym trybie języka.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>Określony zestaw odwołania „{0}” jest niepotrzebny i zostanie zignorowany.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Typy zestawów „ConsoleApplication” i „WindowsApplication” nie są obecnie obsługiwane.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Polecenie cmdlet Add-Type</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Polecenie cmdlet Add-Type nie będzie dozwolone w trybie ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/EventingStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/EventingStrings.pl.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>Zdarzenie o identyfikatorze źródła „{0}” nie istnieje.</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>Zdarzenie o identyfikatorze „{0}” nie istnieje.</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>Subskrypcja zdarzeń o identyfikatorze źródła „{0}” nie istnieje.</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>Subskrypcja zdarzeń o identyfikatorze „{0}” nie istnieje.</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>Subskrypcja zdarzenia „{0}”</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>Wydarzenie „{0}”</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>W przypadku zdarzeń nieprzekazanych należy określić działanie.</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>Anuluj subskrypcję</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/FormatAndOut_out_gridview.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/FormatAndOut_out_gridview.pl.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Format danych nie jest obsługiwany przez element Out-GridView.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>Program Microsoft .NET Framework 4.5 został zainstalowany, gdy była uruchomiona co najmniej jedna sesja programu PowerShell. Aby użyć {0} polecenia cmdlet, zamknij wszystkie okna programu PowerShell, a następnie otwórz nowe okno programu PowerShell.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>Typ</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>Wartość</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>Indeks</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>Nie znaleziono polecenia o nazwie „{0}”.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>Znaleziono więcej niż jedno polecenie o nazwie „{0}”. Rozpocznij „{1}” bez parametrów, a następnie wpisz „{0}”, aby odfiltrować wyniki.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>Nie można zapisać w buforze wejściowym konsoli.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} powinno być mniejsze niż {1}.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/StartSleepStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/StartSleepStrings.pl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>Wartość parametru '-Duration' nie może przekraczać „{0}”. Podana wartość wynosiła „{1}”.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/TestJsonCmdletStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/TestJsonCmdletStrings.pl.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>Nie można przeanalizować schematu JSON.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>Nie można przeanalizować kodu JSON.</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>JSON jest nieprawidłowy względem schematu: {0} w „{1}”</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>Nie można otworzyć pliku schematu JSON: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>Schemat identyfikatora URI „{0}” nie jest obsługiwany. Dozwolone są tylko identyfikatory URI HTTP(S) i lokalnego systemu plików.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/pl/WriteErrorStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/pl/WriteErrorStrings.pl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>„Polecenie Write-Error zgłosiło błąd.”</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/AddTypeStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/AddTypeStrings.ru.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Исходный код уже скомпилирован и загружен.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Не удается добавить тип. Расширение "{0}" не поддерживается.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Не удается добавить тип. Все входные файлы должны иметь одинаковое расширение.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Не удается добавить тип. Не удается найти сборку "{0}".</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Не удается добавить тип. Тип "{0}" уже существует.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Не удается задать выходную сборку. Путь {0} не разрешен в один файл.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Не удается добавить тип. Произошли ошибки компиляции.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Не удается добавить тип. Для параметра OutputType необходимо указать параметр OutputAssembly.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Не удается добавить тип. Определение новых типов не поддерживается в этом языковом режиме.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>Указанная базовая сборка "{0}" не требуется и не учитывается.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Типы сборок "ConsoleApplication" и "WindowsApplication" в настоящее время не поддерживаются.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
-    <value>Add-Type Cmdlet</value>
+    <value>Командлет Add-Type</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Командлет Add-Type не будет разрешен в режиме ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/CsvCommandStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/CsvCommandStrings.ru.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotAppendCsvWithMismatchedPropertyNames" xml:space="preserve">
-    <value>Cannot append CSV content to the following file: {1}. The appended object does not have a property that corresponds to the following column: {0}. To continue with mismatched properties, add the -Force parameter, and then retry the command.</value>
+    <value>Не удается добавить содержимое CSV в следующий файл: {1}. Добавленный объект не содержит свойства, соответствующего следующему столбцу: {0}. Чтобы продолжить работу с несовпадающими свойствами, добавьте параметр -Force и повторите команду.</value>
     <comment>{0} is a placeholder for property name (i.e. ProcessId)
         {1} is a placeholder for filename (i.e. c:\users\lukasza\foo.csv)
 
@@ -128,33 +128,33 @@
     </comment>
   </data>
   <data name="CannotSpecifyQuoteFieldsAndUseQuotes" xml:space="preserve">
-    <value>You must specify either the -UseQuotes or -QuoteFields parameters, but not both.</value>
+    <value>Необходимо указать либо параметр -UseQuotes, либо параметр -QuoteFields, но не оба.</value>
   </data>
   <data name="CannotSpecifyPathAndLiteralPath" xml:space="preserve">
-    <value>You must specify either the -Path or -LiteralPath parameters, but not both.</value>
+    <value>Необходимо указать либо параметр -Path, либо параметр -LiteralPath, но не оба.</value>
   </data>
   <data name="UseDefaultNameForUnspecifiedHeader" xml:space="preserve">
-    <value>One or more headers were not specified. Default names starting with "H" have been used in place of any missing headers.</value>
+    <value>Не указан один или несколько заголовков. Вместо отсутствующих заголовков использованы имена по умолчанию, начинающиеся с "H".</value>
   </data>
   <data name="FileNameIsAMandatoryParameter" xml:space="preserve">
-    <value>FileName is a mandatory parameter.</value>
+    <value>FileName является обязательным параметром.</value>
   </data>
   <data name="ReconcilePreexistingPropertyNamesMethodShouldOnlyGetCalledWhenAppending" xml:space="preserve">
-    <value>ReconcilePreexistingPropertyNames method should only get called when appending.</value>
+    <value>Метод ReconcilePreexistingPropertyNames следует вызывать только при добавлении.</value>
   </data>
   <data name="ReconcilePreexistingPropertyNamesMethodShouldOnlyGetCalledWhenPreexistingPropertyNamesHaveBeenReadSuccessfully" xml:space="preserve">
-    <value>ReconcilePreexistingPropertyNames method should only get called when preexisting property names have been read successfully.</value>
+    <value>Метод ReconcilePreexistingPropertyNames следует вызывать только после успешного чтения существующих имен свойств.</value>
   </data>
   <data name="BuildPropertyNamesMethodShouldBeCalledOnlyOncePerCmdletInstance" xml:space="preserve">
-    <value>BuildPropertyNames method should be called only once per cmdlet instance.</value>
+    <value>Метод BuildPropertyNames следует вызывать только один раз для каждого экземпляра командлета.</value>
   </data>
   <data name="TypeHierarchyShouldNotHaveNullValues" xml:space="preserve">
-    <value>Type hierarchy should not have null values.</value>
+    <value>Иерархия типов не должна содержать значения null.</value>
   </data>
   <data name="EOFIsReached" xml:space="preserve">
-    <value>EOF is reached.</value>
+    <value>Достигнут конец файла.</value>
   </data>
   <data name="CannotSpecifyAppendAndNoHeader" xml:space="preserve">
-    <value>You must specify either the -Append or -NoHeader parameters, but not both.</value>
+    <value>Необходимо указать либо параметр -Append, либо параметр -NoHeader, но не оба.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/FormatAndOut_out_gridview.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/FormatAndOut_out_gridview.ru.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Формат данных не поддерживается в Out-GridView.</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>Платформа Microsoft .NET Framework 4.5 была установлена, когда выполнялся один или несколько сеансов PowerShell. Чтобы использовать командлет {0}, закройте все окна PowerShell, а затем откройте новое окно PowerShell.</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>Тип</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>Значение</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>Индекс</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>Команда "{0}" не найдена.</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>Найдено несколько команд с именем "{0}". Запустите "{1}" без параметров, а затем введите "{0}", чтобы отфильтровать результаты.</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>Невозможно записать данные в буфер ввода консоли.</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>Значение {0} должно быть меньше {1}.</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/GetRandomCommandStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/GetRandomCommandStrings.ru.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>Значение "maxValue" должно быть больше нуля.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>Минимальное значение ({0}) не может быть больше или равно максимальному значению ({1}).</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>"minValue" не может быть больше maxValue.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/NewObjectStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/NewObjectStrings.ru.resx
@@ -118,45 +118,45 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotFindAppropriateCtor" xml:space="preserve">
-    <value>A constructor was not found. Cannot find an appropriate constructor for type {0}.</value>
+    <value>Конструктор не найден. Не удается найти подходящий конструктор для типа {0}.</value>
   </data>
   <data name="TypeNotFound" xml:space="preserve">
-    <value>Cannot find type [{0}]: verify that the assembly containing this type is loaded.</value>
+    <value>Не удается найти тип [{0}]: убедитесь, что сборка, содержащая этот тип, загружена.</value>
   </data>
   <data name="CannotLoadComObjectType" xml:space="preserve">
-    <value>Cannot load COM type {0}.</value>
+    <value>Не удается загрузить тип COM {0}.</value>
   </data>
   <data name="ComInteropLoaded" xml:space="preserve">
-    <value>The object written to the pipeline is an instance of the type "{0}" from the component's primary interoperability assembly. If this type exposes different members than the IDispatch members, scripts that are written to work with this object might not work if the primary interoperability assembly is not installed.</value>
+    <value>Объект, записанный в конвейер, является экземпляром типа "{0}" из основной сборки взаимодействия компонента. Если этот тип предоставляет не элементы IDispatch, а другие элементы, то скрипты, написанные для работы с этим объектом, могут не работать, если основная сборка взаимодействия не установлена.</value>
   </data>
   <data name="MemberNotFound" xml:space="preserve">
-    <value>The member "{1}" was not found for the specified {2} object.</value>
+    <value>Элемент "{1}" не найден для указанного объекта {2}.</value>
   </data>
   <data name="InvalidValue" xml:space="preserve">
-    <value>The value supplied is not valid, or the property is read-only. Change the value, and then try again.</value>
+    <value>Указанное значение недопустимо, или свойство доступно только для чтения. Измените значение и повторите попытку.</value>
   </data>
   <data name="CannotInstantiateWinRTType" xml:space="preserve">
-    <value>Creating instances of attribute and delegated Windows RT types is not supported.</value>
+    <value>Создание экземпляров атрибутов и делегированных типов Windows RT не поддерживается.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create instances of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Не удается создать экземпляры подобного ByRef типа "{0}". Типы, подобные ByRef, не поддерживаются в PowerShell.</value>
   </data>
   <data name="CannotCreateTypeConstrainedLanguage" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in this language mode.</value>
+    <value>Не удается создать тип. В этом языковом режиме поддерживаются только основные типы.</value>
   </data>
   <data name="CannotCreateTypeLanguageMode" xml:space="preserve">
-    <value>Cannot create type. Only core types are supported in {0} language mode on a policy locked down machine.</value>
+    <value>Не удается создать тип. В языковом режиме {0} на компьютере, заблокированном политикой, поддерживаются только основные типы.</value>
   </data>
   <data name="TypeWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet Type Creation</value>
+    <value>Создание типа с помощью командлета New-Object</value>
   </data>
   <data name="TypeWDACLogMessage" xml:space="preserve">
-    <value>The type '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>Тип "{0}" не будет создан в режиме ConstrainedLanguage.</value>
   </data>
   <data name="ComWDACLogTitle" xml:space="preserve">
-    <value>New-Object Cmdlet COM Object Creation</value>
+    <value>Создание COM-объекта с помощью командлета New-Object</value>
   </data>
   <data name="ComWDACLogMessage" xml:space="preserve">
-    <value>The COM object '{0}' will not be created in ConstrainedLanguage mode.</value>
+    <value>Объект COM "{0}" не будет создан в режиме ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/SelectObjectStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/SelectObjectStrings.ru.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="RenamingMultipleResults" xml:space="preserve">
-    <value>Cannot rename multiple results.</value>
+    <value>Не удается переименовать несколько результатов.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>Property "{0}" cannot be found.</value>
+    <value>Не удается найти свойство "{0}".</value>
   </data>
   <data name="MutlipleExpandProperties" xml:space="preserve">
-    <value>Multiple properties cannot be expanded.</value>
+    <value>Не удается развернуть несколько свойств.</value>
   </data>
   <data name="AlreadyExistingProperty" xml:space="preserve">
-    <value>The property cannot be processed because the property "{0}" already exists.</value>
+    <value>Не удается обработать свойство, так как свойство "{0}" уже существует.</value>
   </data>
   <data name="EmptyScriptBlockAndNoName" xml:space="preserve">
-    <value>A property is an empty script block and does not provide a name.</value>
+    <value>Свойство является пустым блоком сценария и не предоставляет имя.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/ru/SortObjectStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/ru/SortObjectStrings.ru.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" — "{0}" не удается найти в "InputObject".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/AddTypeStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/AddTypeStrings.tr.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AlreadyCompiledandLoaded" xml:space="preserve">
-    <value>The source code was already compiled and loaded.</value>
+    <value>Kaynak kodu zaten derlenmiş ve yüklenmişti.</value>
   </data>
   <data name="FileExtensionNotSupported" xml:space="preserve">
-    <value>Cannot add type. The "{0}" extension is not supported.</value>
+    <value>Tür eklenemiyor. “{0}" uzantısı desteklenmiyor.</value>
   </data>
   <data name="MultipleExtensionsNotSupported" xml:space="preserve">
-    <value>Cannot add type. Input files must all have the same file extension.</value>
+    <value>Tür eklenemiyor. Giriş dosyalarının tümü aynı dosya adı uzantısına sahip olmalıdır.</value>
   </data>
   <data name="AssemblyNotFound" xml:space="preserve">
-    <value>Cannot add type. The assembly '{0}' could not be found.</value>
+    <value>Tür eklenemiyor. ‘{0}' derlemesi bulunamadı.</value>
   </data>
   <data name="TypeAlreadyExists" xml:space="preserve">
-    <value>Cannot add type. The type name '{0}' already exists.</value>
+    <value>Tür eklenemiyor. ‘{0}' tür adı zaten mevcut.</value>
   </data>
   <data name="OutputAssemblyDidNotResolve" xml:space="preserve">
-    <value>Cannot set output assembly. The path {0} did not resolve to a single file.</value>
+    <value>Çıktı derlemesi ayarlanamıyor. Yol {0} tek bir dosyaya çözümlenemedi.</value>
   </data>
   <data name="CompilerErrors" xml:space="preserve">
-    <value>Cannot add type. Compilation errors occurred.</value>
+    <value>Tür eklenemiyor. Derleme hataları oluştu.</value>
   </data>
   <data name="OutputTypeRequiresOutputAssembly" xml:space="preserve">
-    <value>Cannot add type. The OutputType parameter requires that the OutputAssembly parameter be specified.</value>
+    <value>Tür eklenemiyor. OutputType parametresi, OutputAssembly parametresinin belirtilmesini gerektirir.</value>
   </data>
   <data name="CannotDefineNewType" xml:space="preserve">
-    <value>Cannot add type. Definition of new types is not supported in this language mode.</value>
+    <value>Tür eklenemiyor. Bu bilgisayar dili modunda yeni türlerin tanımlanması desteklenmiyor.</value>
   </data>
   <data name="ReferenceAssemblyIgnored" xml:space="preserve">
-    <value>The specified reference assembly '{0}' is unnecessary and ignored.</value>
+    <value>Belirtilen '{0}' başvuru bütünleştirilmiş kodu gereksizdir ve yoksayılır.</value>
   </data>
   <data name="AssemblyTypeNotSupported" xml:space="preserve">
-    <value>Both the assembly types 'ConsoleApplication' and 'WindowsApplication' are not currently supported.</value>
+    <value>Hem 'ConsoleApplication' hem de 'WindowsApplication' derleme türleri şu anda desteklenmiyor.</value>
   </data>
   <data name="AddTypeLogTitle" xml:space="preserve">
     <value>Add-Type Cmdlet</value>
   </data>
   <data name="AddTypeLogMessage" xml:space="preserve">
-    <value>Add-Type cmdlet will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage modunda Add-Type cmdlet'ine izin verilmeyecek.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/GetRandomCommandStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/GetRandomCommandStrings.tr.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>'maxValue' sıfırdan büyük olmalıdır.</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>En Küçük değer ({0}), En Büyük değerden ({1}) büyük veya buna eşit olamaz.</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>'minValue', maxValue değerinden büyük olamaz.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/SortObjectStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/SortObjectStrings.tr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" - "{0}", "InputObject" içinde bulunamıyor.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/StartSleepStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/StartSleepStrings.tr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>'-Duration' parametresi değeri '{0}' değerini aşmamalıdır, sağlanan değer '{1}' idi.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/TestJsonCmdletStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/TestJsonCmdletStrings.tr.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>JSON şeması ayrıştırılamıyor.</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>JSON ayrıştırılamıyor.</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>JSON, '{1}' konumunda {0} şeması ile geçerli değil</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>JSON şema dosyası açılamıyor: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>'{0}' URI düzeni desteklenmiyor. Yalnızca HTTP(S) ve yerel dosya sistemi URI'lerine izin verilir.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/tr/WriteErrorStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/tr/WriteErrorStrings.tr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>"Write-Error cmdlet'i bir Hata bildirdi."</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/EventingStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/EventingStrings.zh-Hans.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SourceIdentifierNotFound" xml:space="preserve">
-    <value>Event with source identifier '{0}' does not exist.</value>
+    <value>源标识符为“{0}”的事件不存在。</value>
   </data>
   <data name="EventIdentifierNotFound" xml:space="preserve">
-    <value>Event with identifier '{0}' does not exist.</value>
+    <value>标识符为“{0}”的事件不存在。</value>
   </data>
   <data name="EventSubscriptionSourceNotFound" xml:space="preserve">
-    <value>Event subscription with source identifier '{0}' does not exist.</value>
+    <value>源标识符为“{0}”的事件订阅不存在。</value>
   </data>
   <data name="EventSubscriptionNotFound" xml:space="preserve">
-    <value>Event subscription with identifier '{0}' does not exist.</value>
+    <value>标识符为“{0}”的事件订阅不存在。</value>
   </data>
   <data name="EventSubscription" xml:space="preserve">
-    <value>Event subscription '{0}'</value>
+    <value>事件订阅“{0}”</value>
   </data>
   <data name="EventResource" xml:space="preserve">
-    <value>Event '{0}'</value>
+    <value>事件“{0}”</value>
   </data>
   <data name="ActionMandatoryForLocal" xml:space="preserve">
-    <value>Action must be specified for non-forwarded events.</value>
+    <value>必须为非转发事件指定操作。</value>
   </data>
   <data name="Unsubscribe" xml:space="preserve">
     <value>取消订阅</value>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/GetRandomCommandStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/GetRandomCommandStrings.zh-Hans.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaxMustBeGreaterThanZeroApi" xml:space="preserve">
-    <value>'maxValue' must be greater than zero.</value>
+    <value>'maxValue' 必须大于零。</value>
   </data>
   <data name="MinGreaterThanOrEqualMax" xml:space="preserve">
-    <value>The Minimum value ({0}) cannot be greater than or equal to the Maximum value ({1}).</value>
+    <value>最小值({0})不能大于或等于最大值({1})。</value>
   </data>
   <data name="MinGreaterThanOrEqualMaxApi" xml:space="preserve">
-    <value>'minValue' cannot be greater than maxValue.</value>
+    <value>'minValue' 不能大于 maxValue。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/SortObjectStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/SortObjectStrings.zh-Hans.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>在 "InputObject" 中找不到 "Sort-Object" -“{0}”。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/StartSleepStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/StartSleepStrings.zh-Hans.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>"-Duration" 参数值不能超过“{0}”，提供的值为“{1}”。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/UpdateDataStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hans/UpdateDataStrings.zh-Hans.resx
@@ -118,69 +118,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UpdateData_WrongProviderError" xml:space="preserve">
-    <value>Cannot open the file because the current provider is "{0}", and this command requires a file.</value>
+    <value>无法打开文件，因为当前提供程序为“{0}”，而此命令需要一个文件。</value>
   </data>
   <data name="UpdateData_WrongExtension" xml:space="preserve">
-    <value>Cannot read the file "{0}"  because it does not have the file name extension "{1}".</value>
+    <value>无法读取文件“{0}”，因为它没有文件扩展名“{1}”。</value>
   </data>
   <data name="UpdateTypeDataAction" xml:space="preserve">
-    <value>Update TypeData</value>
+    <value>更新 TypeData</value>
   </data>
   <data name="UpdateFormatDataAction" xml:space="preserve">
-    <value>Update FormatData</value>
+    <value>更新 FormatData</value>
   </data>
   <data name="UpdateTarget" xml:space="preserve">
-    <value>FileName: {0}</value>
+    <value>文件名: {0}</value>
   </data>
   <data name="CannotUpdateMemberType" xml:space="preserve">
-    <value>Cannot update a member with type "{0}". Specify a different type for the MemberType parameter.</value>
+    <value>无法更新类型为“{0}”的成员。请为 MemberType 参数指定其他类型。</value>
   </data>
   <data name="ShouldBeSpecified" xml:space="preserve">
-    <value>The {0} parameter is required for the type "{1}". Please specify the {0} parameter.</value>
+    <value>类型“{1}”需要 {0} 参数。请指定 {0} 参数。</value>
   </data>
   <data name="ShouldNotBeNull" xml:space="preserve">
-    <value>The {0} parameter should not be null or an empty string for a member of type "{1}". Specify a non-null value for the {0} parameter when updating this member type.</value>
+    <value>对于类型为“{1}”的成员，{0} 参数不能为 null 或为空字符串。更新此成员类型时，请为 {0} 参数指定一个非 null 值。</value>
   </data>
   <data name="ShouldNotBeSpecified" xml:space="preserve">
-    <value>The {0} parameter is not necessary for a member of type "{1}", and should not be specified. Do not specify the {0} parameter when updating this member type.</value>
+    <value>对于类型为“{1}”的成员，{0} 参数不是必需项，因此不应指定。更新此成员类型时，请不要指定 {0} 参数。</value>
   </data>
   <data name="TypeDataEmpty" xml:space="preserve">
-    <value>No member is specified for the update on type "{0}".</value>
+    <value>未为类型“{0}”的更新指定任何成员。</value>
   </data>
   <data name="TargetTypeNameEmpty" xml:space="preserve">
-    <value>The target type name should not be null, empty, or contain only white spaces.</value>
+    <value>目标类型名称不能为 null、不能为空或仅包含空格。</value>
   </data>
   <data name="Value1AndValue2AreNotBothNull" xml:space="preserve">
-    <value>The Value and SecondValue parameters should not both be null for a member of type "{0}". Specify a non-null value for one of the two parameters.</value>
+    <value>对于类型为“{0}”的成员，Value 和 SecondValue 参数不能同时为 null。请为这两个参数中的一个指定非 null 值。</value>
   </data>
   <data name="WrongMemberCount" xml:space="preserve">
-    <value>Only one member type can be specified. The member types specified are: "{0}". Update the type with only one member type.</value>
+    <value>只能指定一个成员类型。指定的成员类型为: “{0}”。仅使用一种成员类型更新类型。</value>
   </data>
   <data name="MemberTypeIsMissing" xml:space="preserve">
-    <value>The MemberName, Value, and SecondValue parameters cannot be specified without the MemberType parameter.</value>
+    <value>如果没有 MemberType 参数，则不能指定 MemberName、Value 和 SecondValue 参数。</value>
   </data>
   <data name="RemoveTypeDataAction" xml:space="preserve">
-    <value>Remove TypeData</value>
+    <value>移除 TypeData</value>
   </data>
   <data name="RemoveTypeDataTarget" xml:space="preserve">
-    <value>Name of the type that will be removed: {0}</value>
+    <value>要移除的类型名称: {0}</value>
   </data>
   <data name="UpdateTypeDataTarget" xml:space="preserve">
-    <value>Type to update: {0}</value>
+    <value>要更新的类型: {0}</value>
   </data>
   <data name="RemoveTypeFileAction" xml:space="preserve">
-    <value>Remove type file</value>
+    <value>移除类型文件</value>
   </data>
   <data name="TypeFileNotExistsInCurrentSession" xml:space="preserve">
-    <value>The file {0} is not imported into the current session.</value>
+    <value>文件 {0} 未导入到当前会话中。</value>
   </data>
   <data name="FormatUpdatesDisabled" xml:space="preserve">
-    <value>Updating format data is not allowed in this runspace. The 'DisableFormatUpdates' property is set to True when creating the runspace.</value>
+    <value>此运行空间不允许更新格式数据。创建运行空间时，"DisableFormatUpdates" 属性设置为 True。</value>
   </data>
   <data name="CannotUpdateFormatWithFormatTable" xml:space="preserve">
-    <value>Cannot update the format data with a FormatTable instance.</value>
+    <value>无法使用 FormatTable 实例更新格式数据。</value>
   </data>
   <data name="CannotUpdateTypeWithTypeTable" xml:space="preserve">
-    <value>Cannot update the type data with a TypeTable instance.</value>
+    <value>无法使用 TypeTable 实例更新类型数据。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/FormatAndOut_out_gridview.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/FormatAndOut_out_gridview.zh-Hant.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="DataNotQualifiedForGridView" xml:space="preserve">
-    <value>The data format is not supported by Out-GridView.</value>
+    <value>Out-GridView 不支援此資料格式。</value>
   </data>
   <data name="RestartPowerShell" xml:space="preserve">
-    <value>Microsoft .NET Framework 4.5 was installed while one or more PowerShell sessions were running. To use the {0} cmdlet, close all PowerShell windows, and then open a new PowerShell window.</value>
+    <value>在執行一或多個 PowerShell 工作階段時安裝了 Microsoft .NET Framework 4.5。若要使用 {0} Cmdlet，請關閉所有 PowerShell 視窗，然後開啟新的 PowerShell 視窗。</value>
   </data>
   <data name="TypeColumnName" xml:space="preserve">
-    <value>Type</value>
+    <value>類型</value>
   </data>
   <data name="ValueColumnName" xml:space="preserve">
     <value>值</value>
   </data>
   <data name="IndexColumnName" xml:space="preserve">
-    <value>Index</value>
+    <value>索引</value>
   </data>
   <data name="CommandNotFound" xml:space="preserve">
-    <value>A command named '{0}' was not found.</value>
+    <value>找不到名為 '{0}' 的命令。</value>
   </data>
   <data name="MoreThanOneCommand" xml:space="preserve">
-    <value>More than one command named '{0}' was found. Start '{1}' with no parameters, and then type '{0}' to filter the results.</value>
+    <value>找到多個名為 '{0}' 的命令。在沒有參數的情況下啟動 '{1}'，然後輸入 '{0}' 以篩選結果。</value>
   </data>
   <data name="CannotWriteToConsoleInputBuffer" xml:space="preserve">
-    <value>Cannot write to console input buffer.</value>
+    <value>無法寫入至主控台輸入緩衝區。</value>
   </data>
   <data name="PropertyValidate" xml:space="preserve">
-    <value>{0} should be smaller than {1}.</value>
+    <value>{0} 應小於 {1}。</value>
     <comment>{0} is the property "Height"
 {1} is the maximum allowed value for the height property.</comment>
   </data>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/SortObjectStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/SortObjectStrings.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>"Sort-Object" - "{0}" cannot be found in "InputObject".</value>
+    <value>"Sort-Object" - 無法在 "InputObject" 中找到 "{0}"。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/StartSleepStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/StartSleepStrings.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MaximumDurationExceeded" xml:space="preserve">
-    <value>The '-Duration' parameter value must not exceed '{0}', provided value was '{1}'.</value>
+    <value>'-Duration' 參數值不得超過 '{0}'，您提供的值為 '{1}'。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/TestJsonCmdletStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/TestJsonCmdletStrings.zh-Hant.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidJsonSchema" xml:space="preserve">
-    <value>Cannot parse the JSON schema.</value>
+    <value>無法剖析 JSON 結構描述。</value>
   </data>
   <data name="InvalidJson" xml:space="preserve">
-    <value>Cannot parse the JSON.</value>
+    <value>無法剖析 JSON。</value>
   </data>
   <data name="InvalidJsonAgainstSchemaDetailed" xml:space="preserve">
-    <value>The JSON is not valid with the schema: {0} at '{1}'</value>
+    <value>JSON 對位於 '{1}' 的結構描述 {0} 無效</value>
   </data>
   <data name="JsonSchemaFileOpenFailure" xml:space="preserve">
-    <value>Can not open JSON schema file: {0}</value>
+    <value>無法開啟 JSON 結構描述檔案: {0}</value>
   </data>
   <data name="InvalidUriScheme" xml:space="preserve">
-    <value>URI scheme '{0}' is not supported. Only HTTP(S) and local file system URIs are allowed.</value>
+    <value>不支援 URI 配置 '{0}'。只允許 HTTP(S) 和本機檔案系統 URI。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/UpdateDataStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/UpdateDataStrings.zh-Hant.resx
@@ -118,69 +118,69 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UpdateData_WrongProviderError" xml:space="preserve">
-    <value>Cannot open the file because the current provider is "{0}", and this command requires a file.</value>
+    <value>無法開啟檔案，因為目前的提供者是 "{0}"，而此命令需要檔案。</value>
   </data>
   <data name="UpdateData_WrongExtension" xml:space="preserve">
-    <value>Cannot read the file "{0}"  because it does not have the file name extension "{1}".</value>
+    <value>無法讀取檔案 "{0}"，因為它沒有副檔名 "{1}"。</value>
   </data>
   <data name="UpdateTypeDataAction" xml:space="preserve">
-    <value>Update TypeData</value>
+    <value>更新 TypeData</value>
   </data>
   <data name="UpdateFormatDataAction" xml:space="preserve">
-    <value>Update FormatData</value>
+    <value>更新 FormatData</value>
   </data>
   <data name="UpdateTarget" xml:space="preserve">
     <value>FileName: {0}</value>
   </data>
   <data name="CannotUpdateMemberType" xml:space="preserve">
-    <value>Cannot update a member with type "{0}". Specify a different type for the MemberType parameter.</value>
+    <value>無法使用類型 "{0}" 更新成員。請為 MemberTypes 參數指定不同的類型。</value>
   </data>
   <data name="ShouldBeSpecified" xml:space="preserve">
-    <value>The {0} parameter is required for the type "{1}". Please specify the {0} parameter.</value>
+    <value>類型 "{1}" 需要 {0} 參數。請指定 {0} 參數。</value>
   </data>
   <data name="ShouldNotBeNull" xml:space="preserve">
-    <value>The {0} parameter should not be null or an empty string for a member of type "{1}". Specify a non-null value for the {0} parameter when updating this member type.</value>
+    <value>對於類型 "{1}" 的成員，{0} 參數不應為 null 或空字串。更新此成員類型時，請為 {0} 參數指定非 null 值。</value>
   </data>
   <data name="ShouldNotBeSpecified" xml:space="preserve">
-    <value>The {0} parameter is not necessary for a member of type "{1}", and should not be specified. Do not specify the {0} parameter when updating this member type.</value>
+    <value>類型 "{1}" 的成員不需要 {0} 參數，因此不應指定此參數。更新此成員類型時，請勿指定 {0} 參數。</value>
   </data>
   <data name="TypeDataEmpty" xml:space="preserve">
-    <value>No member is specified for the update on type "{0}".</value>
+    <value>未為類型 "{0}" 的更新指定成員。</value>
   </data>
   <data name="TargetTypeNameEmpty" xml:space="preserve">
-    <value>The target type name should not be null, empty, or contain only white spaces.</value>
+    <value>目標類型名稱不應為 null、空白，或只包含空白字元。</value>
   </data>
   <data name="Value1AndValue2AreNotBothNull" xml:space="preserve">
-    <value>The Value and SecondValue parameters should not both be null for a member of type "{0}". Specify a non-null value for one of the two parameters.</value>
+    <value>類型為 "{0}" 的成員，其 Value 和 SecondValue 參數不應同時為 null。請為這兩個參數的其中一個指定非 null 值。</value>
   </data>
   <data name="WrongMemberCount" xml:space="preserve">
-    <value>Only one member type can be specified. The member types specified are: "{0}". Update the type with only one member type.</value>
+    <value>只能指定一種成員類型。指定的成員類型為: "{0}"。請只使用一種成員類型更新此類型。</value>
   </data>
   <data name="MemberTypeIsMissing" xml:space="preserve">
-    <value>The MemberName, Value, and SecondValue parameters cannot be specified without the MemberType parameter.</value>
+    <value>若未指定 MemberType 參數，則無法指定 MemberName、Value 及 SecondValue 參數。</value>
   </data>
   <data name="RemoveTypeDataAction" xml:space="preserve">
-    <value>Remove TypeData</value>
+    <value>移除 TypeData</value>
   </data>
   <data name="RemoveTypeDataTarget" xml:space="preserve">
-    <value>Name of the type that will be removed: {0}</value>
+    <value>將移除的類型名稱: {0}</value>
   </data>
   <data name="UpdateTypeDataTarget" xml:space="preserve">
-    <value>Type to update: {0}</value>
+    <value>要更新的類型: {0}</value>
   </data>
   <data name="RemoveTypeFileAction" xml:space="preserve">
-    <value>Remove type file</value>
+    <value>移除類型檔案</value>
   </data>
   <data name="TypeFileNotExistsInCurrentSession" xml:space="preserve">
-    <value>The file {0} is not imported into the current session.</value>
+    <value>檔案 {0} 未匯入目前的工作階段。</value>
   </data>
   <data name="FormatUpdatesDisabled" xml:space="preserve">
-    <value>Updating format data is not allowed in this runspace. The 'DisableFormatUpdates' property is set to True when creating the runspace.</value>
+    <value>此 Runspace 不允許更新格式資料。建立 Runspace 時，已將 'DisableFormatUpdates' 屬性設為 True。</value>
   </data>
   <data name="CannotUpdateFormatWithFormatTable" xml:space="preserve">
-    <value>Cannot update the format data with a FormatTable instance.</value>
+    <value>無法使用 FormatTable 執行個體更新格式資料。</value>
   </data>
   <data name="CannotUpdateTypeWithTypeTable" xml:space="preserve">
-    <value>Cannot update the type data with a TypeTable instance.</value>
+    <value>無法使用 TypeTable 執行個體更新類型資料。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/WriteErrorStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Commands.Utility/resources/zh-Hant/WriteErrorStrings.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteErrorException" xml:space="preserve">
-    <value>"The Write-Error cmdlet reported an error."</value>
+    <value>「Write-Error Cmdlet 已報告一個錯誤。」</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/cs/ConsoleHostRawUserInterfaceStrings.cs.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/cs/ConsoleHostRawUserInterfaceStrings.cs.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Operaci nelze zpracovat, protože zadané souřadnice nejsou platné. Zadejte souřadnici v oblasti {0} vyrovnávací paměti.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Velikost vyrovnávací paměti nelze nastavit, protože zadaná velikost je příliš velká nebo příliš malá.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Barvu konzoly nelze nastavit, protože zadaná hodnota není platná. Zadejte platnou barvu definovanou typem System.ConsoleColor.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Vlastnost CursorSize nelze zpracovat, protože zadaná velikost kurzoru není platná.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Nelze načíst možnosti čtení klávesy. Chcete-li číst stisknutí kláves, nastavte jednu nebo obě z následujících možností: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>Hodnota {0} musí být větší nebo rovna {1}.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Zadanou pozici X okna (sloupec) nelze použít, protože přesahuje šířku vyrovnávací paměti obrazovky. Zadejte jinou pozici X, přičemž 0 představuje krajní levý sloupec vyrovnávací paměti.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Zadanou pozici Y okna (řádek) nelze použít, protože přesahuje výšku vyrovnávací paměti obrazovky. Zadejte jinou pozici Y, přičemž 0 představuje horní krajní řádek vyrovnávací paměti.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>Šířka okna nemůže být menší než 1.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>Výška okna musí být alespoň 1.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Okno nemůže být širší než vyrovnávací paměť obrazovky.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Okno nemůže být vyšší než vyrovnávací paměť obrazovky.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>Okno nemůže být širší než {0}.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>Okno nemůže být vyšší než {0}.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Šířka okna je příliš malá.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>Výška okna je příliš malá.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Název okna nemůže být prázdný.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Název okna nemůže být delší než {0} znaků.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Správce: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/cs/ProgressNodeStrings.cs.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/cs/ProgressNodeStrings.cs.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>Zbývá: {0} {1} </value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>{0} aktivita se nezobrazuje...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>Tento počet aktivit se nezobrazuje: {0}...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/de/ConsoleHostRawUserInterfaceStrings.de.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/de/ConsoleHostRawUserInterfaceStrings.de.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Der Vorgang kann nicht verarbeitet werden, da die angegebene Koordinate ungültig ist. Geben Sie eine Koordinate innerhalb des Pufferbereichs von {0} an.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Die Puffergröße kann nicht festgelegt werden, da die angegebene Größe zu groß oder zu klein ist.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Die Konsolenfarbe kann nicht festgelegt werden, da der angegebene Wert ungültig ist. Geben Sie eine gültige Farbe an, wie sie vom Typ System.ConsoleColor definiert wird.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>CursorSize kann nicht verarbeitet werden, da die angegebene Cursorgröße ungültig ist.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Tastenoptionen können nicht gelesen werden. Legen Sie zum Lesen von Optionen eine oder beide der folgenden Optionen fest: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0} muss größer als oder gleich {1} sein.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Die angegebene X-Position des Fensters (Spalte) kann nicht verwendet werden, da sie über die Breite des Bildschirmpuffers hinausgeht. Geben Sie eine andere X-Position an, beginnend mit 0 als der linken Spalte des Puffers.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Die angegebene Y-Position des Fensters (Zeile) kann nicht verwendet werden, da sie über die Höhe des Bildschirmpuffers hinausgeht. Geben Sie eine andere Y-Position an, beginnend mit 0 als oberster Zeile des Puffers.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>Die Fensterbreite darf nicht kleiner als 1 sein.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>Die Fensterhöhe muss mindestens 1 betragen.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Das Fenster darf nicht breiter als der Bildschirmpuffer sein.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Das Fenster darf nicht größer als der Bildschirmpuffer sein.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>Das Fenster darf nicht breiter als {0} sein.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>Das Fenster darf nicht höher als {0} sein.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Das Fenster ist zu schmal.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>Das Fenster ist zu kurz.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Der Titel des Fensters darf nicht leer sein.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Der Titel des Fensters darf nicht länger als {0} Zeichen sein.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Admin: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/de/ConsoleHostUserInterfaceStrings.de.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/de/ConsoleHostUserInterfaceStrings.de.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>Die Sammlung „{0}“ muss mindestens ein Element enthalten.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>„{1}“ kann aufgrund eines Überlauffehlers nicht als {0} erkannt werden.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>„{1}“ kann aufgrund eines Formatfehlers nicht als {0} erkannt werden.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>„{0}“ kann nicht als gültiger Promptbefehl erkannt werden.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>Es ist keine Hilfe für {0} verfügbar.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>Das Feld „{0}“ ist ein Nullrangarray.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>„{0}“ muss mindestens ein Element aufweisen.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>„{0}“ muss ein gültiger Index in „{1}“ oder -1 sein, wenn keine Standardauswahl vorhanden ist.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>„{0}“ muss ein gültiger Index in „{1}“ sein. „{2}“ ist kein gültiger Index.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] Hilfe </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>Der Prompt wurde abgebrochen.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Der Hotkey kann nicht verarbeitet werden, da ein Fragezeichen („?“) nicht als Hotkey verwendet werden kann.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>Der Prompt für „{0}“ kann nicht angezeigt werden, da der Typ „{1}“ nicht geladen werden kann.</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>'{0}' darf nicht NULL oder leer sein.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>„{0}“ darf nicht NULL sein.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Geben Sie !? ein, um Hilfe zu erhalten.)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(Standard ist „{0}“): </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(Standard ist „{0}“)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(Standardoptionen sind {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Auswahl[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>DEBUGGEN: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>AUSFÜHRLICH: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>WARNUNG: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell befindet sich im Nichtinteraktiv-Modus. Lese- und Promptfunktionen sind nicht verfügbar.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/es/ConsoleHostUserInterfaceStrings.es.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/es/ConsoleHostUserInterfaceStrings.es.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>La colección "{0}" debe tener al menos un elemento.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>No se puede reconocer "{1}" como debido a un {0} error de desbordamiento.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>No se puede reconocer "{1}" debido a un {0} error de formato.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>"{0}" no se puede reconocer como un comando prompt válido.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>No hay ayuda disponible para {0}.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>El campo "{0}" es una matriz de rango cero.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>"{0}" debe tener al menos un elemento.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>"{0}" debe ser un índice válido en "{1}" o -1 para que no haya ninguna opción predeterminada.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}" debe ser un índice válido en "{1}". "{2}" no es un índice válido.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>Ayuda </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>Se canceló la solicitud.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>No se puede procesar la tecla activa porque no se puede usar un signo de interrogación ("?") como tecla activa.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>No se puede mostrar el mensaje de "{0}" porque no se puede cargar el tipo "{1}".</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>El valor de '{0}' no puede ser de tipo NULL ni estar vacío.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>"{0}" no puede ser null.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Escriba !? para obtener ayuda.)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(el valor predeterminado es "{0}"): </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(el valor predeterminado es "{0}")</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(las opciones predeterminadas son {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Opción[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>DEPURACIÓN: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>DETALLADO: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>ADVERTENCIA: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell está en modo NonInteractive. La funcionalidad de lectura y petición de mensajes no está disponible.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/es/ProgressNodeStrings.es.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/es/ProgressNodeStrings.es.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>{0}{1} restantes. </value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>{0} actividad no mostrada...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>{0} actividades no mostradas...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ConsoleHostRawUserInterfaceStrings.fr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ConsoleHostRawUserInterfaceStrings.fr.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Nous ne pouvons pas traiter l’opération, car la coordonnée fournie n’est pas valide. Spécifiez une coordonnée dans la zone de la mémoire tampon de {0}.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Nous ne pouvons pas définir la taille de la mémoire tampon, car la taille spécifiée est trop grande ou trop petite.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Nous ne pouvons pas définir la couleur de la console, car la valeur spécifiée n’est pas valide. Indiquez une couleur valide telle que définie par le type System.ConsoleColor.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Nous ne pouvons pas traiter CursorSize, car la taille du curseur spécifiée n’est pas valide.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Nous ne pouvons pas lire les options de touche. Si vous souhaitez lire les options, définissez l’une ou les deux options suivantes : IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0} doit être supérieur ou égal à {1}.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Nous ne pouvons pas utiliser la position X (colonne) de la fenêtre spécifiée, car elle dépasse la largeur de la mémoire tampon d’écran. Indiquez une autre position X, en commençant par 0 pour la colonne la plus à gauche de la mémoire tampon.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Nous ne pouvons pas utiliser la position Y (ligne) de la fenêtre spécifiée, car elle dépasse la hauteur de la mémoire tampon d’écran. Indiquez une autre position Y, en commençant par 0 pour la ligne la plus haute de la mémoire tampon.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>La largeur de la fenêtre ne peut pas être inférieure à 1.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>La hauteur de la fenêtre doit être au moins égale à 1.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Une fenêtre ne peut pas être plus large que la mémoire tampon de l’écran.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Une fenêtre ne peut pas être plus grande que la mémoire tampon de l’écran.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>La fenêtre ne peut pas être plus large que {0}.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>La fenêtre ne peut pas être plus grande que {0}.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>La taille de la fenêtre est trop étroite.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>La taille de la fenêtre est trop courte.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Un titre de fenêtre ne peut pas être vide.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Le titre de fenêtre ne peut pas dépasser {0} caractères.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Administrateur : </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ConsoleHostUserInterfaceStrings.fr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ConsoleHostUserInterfaceStrings.fr.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>La collection « {0} »doit contenir au moins un élément.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>Nous ne pouvons pas reconnaître « {1} » en tant que {0} en raison d’une erreur de dépassement.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>Nous ne pouvons pas reconnaître « {1} » en tant que {0} en raison d’une erreur de format.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>« {0} » ne peut pas être reconnu comme une commande d’invite valide.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>Aucune aide n’est disponible pour {0}.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
-    <value>{0}: </value>
+    <value>{0} : </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>Le champ « {0} » est un tableau de rang zéro.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>« {0} » doit comporter au moins un élément.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>« {0} » doit être un index valide dans « {1} » ou -1 pour aucun choix par défaut.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>« {0} » doit être un index valide dans « {1} ». « {2} » n’est pas un index valide.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] Aide </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>La requête a été annulée.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Nous ne pouvons pas traiter la touche d’accès rapide, car un point d’interrogation (« ? ») ne peut pas être utilisé comme touche d’accès rapide.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>Nous ne pouvons pas d’afficher la requête pour « {0} » car le type « {1} » ne peut pas être chargé.</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>« {0} » ne peut pas être NULL ou vide.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>« {0} » ne peut pas avoir une valeur nulle.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Tapez !? pour obtenir de l’aide.)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(la valeur par défaut est « {0} ») : </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(la valeur par défaut est « {0} »)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(les choix par défaut sont {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Choix[{0}] : </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>DÉBOGUER : {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>DÉTAILLÉ : {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>AVERTISSEMENT : {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell est en mode NonInteractive. Les fonctionnalités de lecture et de requête ne sont pas disponibles.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ManagedEntranceStrings.fr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/fr/ManagedEntranceStrings.fr.resx
@@ -151,7 +151,7 @@
 </value>
   </data>
   <data name="UsageHelp" xml:space="preserve">
-    <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
+    <value>Utilisation : pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
                                 | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
                   [-CommandWithArgs &lt;string&gt; [&lt;CommandParameters&gt;]
@@ -166,9 +166,9 @@
 
        pwsh[.exe] -h | -Help | -? | /?
 
-PowerShell Online Help https://aka.ms/powershell-docs
+Aide en ligne PowerShell https://aka.ms/powershell-docs
 
-All parameters are case-insensitive.</value>
+Tous les paramètres ne tiennent pas compte de la casse.</value>
   </data>
   <data name="ExtendedHelp" xml:space="preserve">
     <value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostRawUserInterfaceStrings.it.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostRawUserInterfaceStrings.it.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Non è possibile elaborare l'operazione perché la coordinata specificata non è valida. Specificare una coordinata all'interno dell'area del buffer di {0}.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Non è possibile impostare le dimensioni del buffer perché quelle specificate sono troppo grandi o troppo piccole.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Non è possibile impostare il colore della console perché il valore specificato non è valido. Specificare un colore valido come definito dal tipo System.ConsoleColor.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Non è possibile elaborare CursorSize perché la dimensione del cursore specificata non è valida.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Non è possibile leggere le opzioni dei tasti. Per leggere le opzioni, impostare uno o entrambi i seguenti valori: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0} deve essere maggiore o uguale a {1}.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Non è possibile usare la posizione della finestra X (colonna) specificata perché si estende oltre la larghezza del buffer dello schermo. Specificare un'altra posizione X, partendo da 0 come colonna più a sinistra del buffer.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Non è possibile usare la posizione della finestra Y (riga) specificata perché si estende oltre la l'altezza del buffer dello schermo. Specificare un'altra posizione Y, partendo da 0 come riga più alta del buffer.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>La larghezza della finestra non può essere minore di 1.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>L'altezza della finestra deve essere almeno 1.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>La finestra non può essere più larga del buffer dello schermo.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>La finestra non può essere più alta del buffer dello schermo.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>La finestra non può essere più larga di {0}.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>La finestra non può essere più alta di {0}.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Le dimensioni della finestra sono insufficienti.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>L'altezza della finestra è insufficiente.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Il titolo della finestra non può essere vuoto.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Il titolo della finestra non può superare i {0} caratteri.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Amministratore: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostStrings.it.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostStrings.it.resx
@@ -118,74 +118,74 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TooManyNestedPromptsError" xml:space="preserve">
-    <value>Cannot display prompt because too many nested prompts are already running.</value>
+    <value>Non è possibile visualizzare la richiesta perché sono già in esecuzione troppi prompt annidati.</value>
   </data>
   <data name="InputExitCurrentLoopOutOfSyncError" xml:space="preserve">
-    <value>Cannot process input loop. ExitCurrentLoop was called when no InputLoops were running.</value>
+    <value>Non è possibile elaborare il ciclo di input. ExitCurrentLoop è stato chiamato quando non era in esecuzione alcun InputLoops.</value>
   </data>
   <data name="DefaultPrompt" xml:space="preserve">
     <value>PS&gt;</value>
   </data>
   <data name="ShellCannotBeStarted" xml:space="preserve">
-    <value>The shell cannot be started. A failure occurred during initialization:</value>
+    <value>Non è possibile avviare la shell. Errore durante l'inizializzazione:</value>
   </data>
   <data name="ShellCannotBeStartedWithConfigConflict" xml:space="preserve">
-    <value>The shell cannot be started. An InitialSessionState object has been provided along with a -ConfigurationFile argument. Both configuration directives cannot be used at the same time.</value>
+    <value>Non è possibile avviare la shell. È stato fornito un oggetto InitialSessionState insieme a un argomento -ConfigurationFile. Entrambe le direttive di configurazione non possono essere usate contemporaneamente.</value>
   </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
-    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.</value>
+    <value>Si è verificato un errore che non è stato gestito correttamente. Di seguito sono riportate informazioni aggiuntive. Il processo di PowerShell verrà chiuso.</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username  : {1}\{2}
-Machine   : {3} ({4})
+Avvio della trascrizione di PowerShell
+Ora di inizio: {0:yyyyMMddHHmmss}
+Nome utente : {1}\{2}
+Computer : {3} ({4})
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+Fine della trascrizione di PowerShell
+Ora di fine: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' could not be run because some PowerShell Snap-Ins did not load.</value>
+    <value>Non è possibile eseguire il comando ''{0}'' perché alcuni snap-in di PowerShell non sono stati caricati.</value>
   </data>
   <data name="CommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' was not run as the session in which it was intended to run was either closed or broken</value>
+    <value>Il comando ''{0}'' non è stato eseguito perché la sessione in cui era destinata all'esecuzione è stata chiusa o interrotta</value>
   </data>
   <data name="EnteringDebugger" xml:space="preserve">
-    <value>Entering debug mode. Use h or ? for help. </value>
+    <value>Attivazione della modalità di debug. Usare h o ? per assistenza. </value>
   </data>
   <data name="HitBreakpoint" xml:space="preserve">
-    <value>Hit {0}</value>
+    <value>Riscontri {0}</value>
   </data>
   <data name="DebuggerSourceCodeFormat" xml:space="preserve">
     <value>{0}:{1,-3} {2}</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; execution will continue.
+La sessione corrente non supporta il debug; l'esecuzione continuerà.
 
 </value>
   </data>
   <data name="CannotLoadPSReadline" xml:space="preserve">
-    <value>Cannot load PSReadline module.  Console is running without PSReadline.</value>
+    <value>Non è possibile caricare il modulo PSReadline.  La console è in esecuzione senza PSReadline.</value>
   </data>
   <data name="ConflictingServerModeParameters" xml:space="preserve">
-    <value>More than one server mode parameter was specified. Server mode parameters must be used exclusively.</value>
+    <value>È stato specificato più di un parametro della modalità server. I parametri della modalità server devono essere utilizzati esclusivamente.</value>
   </data>
   <data name="SlowProfileLoadingMessage" xml:space="preserve">
-    <value>Loading personal and system profiles took {0}ms.</value>
+    <value>Il caricamento dei profili personali e di sistema ha richiesto {0} ms.</value>
   </data>
   <data name="RunAsAdministrator" xml:space="preserve">
-    <value>Run as Administrator</value>
+    <value>Esegui come amministratore</value>
   </data>
   <data name="PushRunspaceNotRemote" xml:space="preserve">
-    <value>PushRunspace can only push a remote runspace.</value>
+    <value>PushRunspace può eseguire il push solo di uno spazio di esecuzione remoto.</value>
   </data>
   <data name="MissingMandatoryParameter" xml:space="preserve">
-    <value>The '{0}' parameter is mandatory and must be specified when using the '{1}' parameter.</value>
+    <value>Il parametro ''{0}'' è obbligatorio e deve essere specificato quando si utilizza il parametro ''{1}''.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostUserInterfaceStrings.it.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/it/ConsoleHostUserInterfaceStrings.it.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>La raccolta "{0}" deve contenere almeno un elemento.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>Non è possibile riconoscere "{1}" come {0} a causa di un errore di overflow.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>Non è possibile riconoscere "{1}" come {0} a causa di un errore di formato.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>"{0}" non può essere riconosciuto come comando Prompt valido.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>Nessuna Guida è disponibile per {0}.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>Il campo "{0}" è una matrice di rango zero.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>"{0}" deve avere almeno un elemento.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>"{0}" deve essere un indice valido in "{1}" o -1 se non è stata scelta alcuna opzione predefinita.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}" deve essere un indice valido in "{1}". "{2}" non è un indice valido.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] Guida </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>Il prompt è stato annullato.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Non è possibile elaborare il tasto di scelta rapida perché il punto interrogativo ("?") non può essere usato come tasto di scelta rapida.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>Non è possibile visualizzare il prompt per "{0}" perché il tipo "{1}" non può essere caricato.</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>"{0}" non può essere Null o vuoto.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>"{0}" non può essere Null.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Digitare !? per la Guida).</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(l'impostazione predefinita è ''{0}''): </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(l'impostazione predefinita è ''{0}'')</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(le opzioni predefinite sono {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Opzione[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
     <value>DEBUG: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>DETTAGLIATO: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>AVVISO: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell è in modalità NonInteractive. Le funzionalità Read e Prompt non sono disponibili.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/it/ManagedEntranceStrings.it.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/it/ManagedEntranceStrings.it.resx
@@ -151,7 +151,7 @@
 </value>
   </data>
   <data name="UsageHelp" xml:space="preserve">
-    <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
+    <value>Utilizzo: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
                                 | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
                   [-CommandWithArgs &lt;string&gt; [&lt;CommandParameters&gt;]
@@ -166,9 +166,9 @@
 
        pwsh[.exe] -h | -Help | -? | /?
 
-PowerShell Online Help https://aka.ms/powershell-docs
+Guida in linea di PowerShell https://aka.ms/powershell-docs
 
-All parameters are case-insensitive.</value>
+Tutti i parametri non fanno distinzione tra maiuscole e minuscole.</value>
   </data>
   <data name="ExtendedHelp" xml:space="preserve">
     <value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ja/ConsoleHostRawUserInterfaceStrings.ja.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ja/ConsoleHostRawUserInterfaceStrings.ja.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>指定された座標が無効なため、操作を処理できません。{0} のバッファー領域内の座標を指定してください。</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>指定されたサイズが大きすぎるか小さすぎるため、バッファー サイズを設定できません。</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>指定された値が無効なため、コンソールの色を設定できません。System.ConsoleColor 型で定義されている有効な色を指定してください。</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>指定されたカーソル サイズが無効なため、CursorSize を処理できません。</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>キー オプションを読み取れません。オプションを読み取るには、IncludeKeyDown、IncludeKeyUp のどちらかまたは両方を設定してください。</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0} は {1} 以上である必要があります。</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>指定した Window X (列) の位置は、画面バッファーの幅を超えているため、使用できません。バッファーの左端の列を 0 として、別の X 位置を指定してください。</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>指定した Window Y (行) の位置は、画面バッファーの高さを超えているため、使用できません。バッファーの一番上の行を 0 として、別の Y 位置を指定してください。</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>ウィンドウの幅を 1 未満にすることはできません。</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>ウィンドウの高さは 1 以上である必要があります。</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>ウィンドウの幅は画面バッファーを超えられません。</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>ウィンドウの高さは画面バッファーを超えられません。</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>ウィンドウの幅は {0} 以下である必要があります。</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>ウィンドウの高さは {0} を超えられません。</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>ウィンドウの幅が狭すぎます。</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>ウィンドウの高さが短すぎます。</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>ウィンドウのタイトルを空にすることはできません。</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>ウィンドウのタイトルを {0} 文字より長くすることはできません。</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>管理者:</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ko/ConsoleHostStrings.ko.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ko/ConsoleHostStrings.ko.resx
@@ -118,74 +118,74 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TooManyNestedPromptsError" xml:space="preserve">
-    <value>Cannot display prompt because too many nested prompts are already running.</value>
+    <value>중첩 프롬프트가 너무 많이 실행 중이어서 프롬프트를 표시할 수 없습니다.</value>
   </data>
   <data name="InputExitCurrentLoopOutOfSyncError" xml:space="preserve">
-    <value>Cannot process input loop. ExitCurrentLoop was called when no InputLoops were running.</value>
+    <value>입력 루프를 처리할 수 없습니다. 실행 중인 InputLoop가 없을 때 ExitCurrentLoop가 호출되었습니다.</value>
   </data>
   <data name="DefaultPrompt" xml:space="preserve">
     <value>PS&gt;</value>
   </data>
   <data name="ShellCannotBeStarted" xml:space="preserve">
-    <value>The shell cannot be started. A failure occurred during initialization:</value>
+    <value>셸을 시작할 수 없습니다. 초기화 중에 오류가 발생했습니다:</value>
   </data>
   <data name="ShellCannotBeStartedWithConfigConflict" xml:space="preserve">
-    <value>The shell cannot be started. An InitialSessionState object has been provided along with a -ConfigurationFile argument. Both configuration directives cannot be used at the same time.</value>
+    <value>셸을 시작할 수 없습니다. InitialSessionState 개체가 -ConfigurationFile 인수와 함께 제공되었습니다. 두 구성 지시문은 동시에 사용할 수 없습니다.</value>
   </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
-    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.</value>
+    <value>적절하게 처리되지 않은 오류가 발생했습니다. 자세한 내용은 아래에 표시됩니다. PowerShell 프로세스가 종료됩니다.</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username  : {1}\{2}
-Machine   : {3} ({4})
+PowerShell 기록 시작
+시작 시간: {0:yyyyMMddHHmmss}
+사용자 이름  : {1}\{2}
+컴퓨터   : {3} ({4})
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+PowerShell 기록 끝
+종료 시간: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' could not be run because some PowerShell Snap-Ins did not load.</value>
+    <value>일부 PowerShell 스냅인(Snap-In)이 로드되지 않아 명령 '{0}'을(를) 실행할 수 없습니다.</value>
   </data>
   <data name="CommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' was not run as the session in which it was intended to run was either closed or broken</value>
+    <value>명령 '{0}'을(를) 실행해야 할 세션이 닫혔거나 손상되어 실행되지 않았습니다.</value>
   </data>
   <data name="EnteringDebugger" xml:space="preserve">
-    <value>Entering debug mode. Use h or ? for help. </value>
+    <value>디버그 모드로 들어갑니다. h 또는 ? 사용에 도움이 될 수 있습니다. </value>
   </data>
   <data name="HitBreakpoint" xml:space="preserve">
-    <value>Hit {0}</value>
+    <value>{0} 적중</value>
   </data>
   <data name="DebuggerSourceCodeFormat" xml:space="preserve">
     <value>{0}:{1,-3} {2}</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; execution will continue.
+현재 세션은 디버깅을 지원하지 않습니다. 실행을 계속합니다.
 
 </value>
   </data>
   <data name="CannotLoadPSReadline" xml:space="preserve">
-    <value>Cannot load PSReadline module.  Console is running without PSReadline.</value>
+    <value>PSReadline 모듈을 로드할 수 없습니다.  콘솔은 PSReadline 없이 실행됩니다.</value>
   </data>
   <data name="ConflictingServerModeParameters" xml:space="preserve">
-    <value>More than one server mode parameter was specified. Server mode parameters must be used exclusively.</value>
+    <value>서버 모드 매개 변수가 두 개 이상 지정되었습니다. 서버 모드 매개 변수는 하나만 사용해야 합니다.</value>
   </data>
   <data name="SlowProfileLoadingMessage" xml:space="preserve">
-    <value>Loading personal and system profiles took {0}ms.</value>
+    <value>개인 및 시스템 프로필을 로드하는 데 {0}ms가 걸렸습니다.</value>
   </data>
   <data name="RunAsAdministrator" xml:space="preserve">
-    <value>Run as Administrator</value>
+    <value>관리자 권한으로 실행</value>
   </data>
   <data name="PushRunspaceNotRemote" xml:space="preserve">
-    <value>PushRunspace can only push a remote runspace.</value>
+    <value>PushRunspace는 원격 runspace만 푸시할 수 있습니다.</value>
   </data>
   <data name="MissingMandatoryParameter" xml:space="preserve">
-    <value>The '{0}' parameter is mandatory and must be specified when using the '{1}' parameter.</value>
+    <value>'{0}' 매개 변수는 필수이며 '{1}' 매개 변수를 사용할 때는 반드시 지정해야 합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ko/ConsoleHostUserInterfaceStrings.ko.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ko/ConsoleHostUserInterfaceStrings.ko.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>"{0}" 컬렉션에는 요소가 하나 이상 있어야 합니다.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>오버플로 오류로 인해 "{1}"을(를) {0}(으)로 인식할 수 없습니다.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>형식 오류로 인해 "{1}"을(를) {0}(으)로 인식할 수 없습니다.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>"{0}"은(는) 유효한 Prompt 명령으로 인식할 수 없습니다.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>{0}에 사용할 수 있는 도움말이 없습니다.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>"{0}" 필드는 0차원 배열입니다.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>"{0}"에는 요소가 하나 이상 있어야 합니다.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>"{0}"은(는) "{1}"의 유효한 인덱스이거나, 기본 선택 항목이 없으면 -1이어야 합니다.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}"은(는) "{1}"의 유효한 인덱스여야 합니다. "{2}"은(는) 유효한 인덱스가 아닙니다.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] 도움말 </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>프롬프트가 취소되었습니다.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>물음표("?")는 바로 가기 키로 사용할 수 없으므로 바로 가기 키를 처리할 수 없습니다.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>"{0}"의 프롬프트를 표시할 수 없습니다. "{1}" 형식을 로드할 수 없습니다.</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>"{0}"은(는) Null이거나 비워 둘 수 없습니다.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>“{0}”은(는) null일 수 없습니다.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(도움말을 보려면 !?를 입력하세요.)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(기본값은 "{0}"입니다.) </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(기본값은 "{0}"입니다.)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(기본 선택 항목은 {0}입니다.)</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>선택[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>디버그: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>자세한 정보: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>경고: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell이 NonInteractive 모드입니다. Read 및 Prompt 기능을 사용할 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ko/TranscriptStrings.ko.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ko/TranscriptStrings.ko.resx
@@ -118,27 +118,27 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TranscriptionStarted" xml:space="preserve">
-    <value>Transcript started, output file is {0}</value>
+    <value>대화 내용 기록이 시작되었습니다. 출력 파일은 {0}입니다.</value>
   </data>
   <data name="TranscriptionStopped" xml:space="preserve">
-    <value>Transcript stopped, output file is {0}</value>
+    <value>대화 내용 기록이 중지되었습니다. 출력 파일은 {0}입니다.</value>
   </data>
   <data name="CannotStartTranscription" xml:space="preserve">
-    <value>Transcription cannot be started due to the error: {0}</value>
+    <value>다음 오류로 인해 대화 내용 기록을 시작할 수 없습니다. {0}</value>
   </data>
   <data name="ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>The current provider ({0}) cannot open a file.</value>
+    <value>현재 공급자({0})는 파일을 열 수 없습니다.</value>
   </data>
   <data name="TranscriptFileReadOnly" xml:space="preserve">
-    <value>File {0} is read-only. Cannot write to this file. "Start-Transcript -Force" will clear the read-only attribute.</value>
+    <value>파일 {0}이(가) 읽기 전용 파일입니다. 이 파일에 쓸 수 없습니다. "Start-Transcript -Force"를 사용하면 읽기 전용 특성이 해제됩니다.</value>
   </data>
   <data name="MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>경로가 두 개 이상의 파일로 확인되어 작업을 수행할 수 없습니다. 이 명령은 여러 파일에 사용할 수 없습니다.</value>
   </data>
   <data name="TranscriptFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>파일 {0}이(가) 이미 존재하며 {1}이(가) 지정되었습니다.</value>
   </data>
   <data name="ErrorStoppingTranscript" xml:space="preserve">
-    <value>An error occurred stopping transcription: {0}</value>
+    <value>대화 내용 기록을 중지하는 동안 다음 오류가 발생했습니다. {0}</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ConsoleHostRawUserInterfaceStrings.pl.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ConsoleHostRawUserInterfaceStrings.pl.resx
@@ -118,58 +118,58 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Nie można przetworzyć operacji, ponieważ podana współrzędna jest nieprawidłowa. Określ współrzędną znajdującą się w obszarze buforu {0}.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Nie można ustawić rozmiaru buforu, ponieważ określony rozmiar jest za duży lub za mały.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Nie można ustawić koloru konsoli, ponieważ określona wartość jest nieprawidłowa. Określ prawidłowy kolor zdefiniowany przez typ System.ConsoleColor.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Nie można przetworzyć elementu CursorSize, ponieważ określony rozmiar kursora jest nieprawidłowy.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Nie można odczytać opcji klawisza. Aby odczytać opcje, ustaw jedną lub obie z następujących wartości: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>Wartość {0} powinna być większa lub równa {1}.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Nie można użyć określonej pozycji X okna (kolumny), ponieważ wykracza ona poza szerokość buforu ekranu. Określ inną pozycję X, zaczynając od 0 jako skrajnej lewej kolumny buforu.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Nie można użyć określonej pozycji okna Y (wiersz), ponieważ wykracza poza wysokość buforu ekranu. Określ inną pozycję Y, zaczynając od 0 jako najwyższego wiersza buforu.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>Szerokość okna nie może być mniejsza niż 1.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>Wysokość okna musi wynosić co najmniej 1.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Okno nie może być szersze niż bufor ekranu.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Okno nie może być wyższe niż bufor ekranu.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>Okno nie może być szersze niż {0}.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>Okno nie może być wyższe niż {0}.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Rozmiar okna jest zbyt wąski.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>Rozmiar okna jest za mały.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Tytuł okna nie może być pusty.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Długość tytułu okna nie może przekraczać {0} znaków.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
     <value>Administrator: </value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ConsoleHostUserInterfaceStrings.pl.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ConsoleHostUserInterfaceStrings.pl.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>Kolekcja „{0}” musi mieć co najmniej jeden element.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>Nie można rozpoznać „{1}” jako {0} z powodu błędu przepełnienia.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>Nie można rozpoznać „{1}” jako {0} z powodu błędu formatu.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>Nie można rozpoznać „{0}” jako prawidłowego polecenia Prompt.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>Brak dostępnej pomocy dla {0}.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>Pole „{0}” jest tablicą o randze zerowej.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>Element „{0}” powinien mieć co najmniej jeden element.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>„{0}” musi być prawidłowym indeksem w „{1}” lub -1 w przypadku braku opcji domyślnej.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>„{0}” musi być prawidłowym indeksem w „{1}”. „{2}” nie jest prawidłowym indeksem.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] Pomoc </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>Monit został anulowany.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Nie można przetworzyć klawisza skrótu, ponieważ znak zapytania ("?") nie może być użyty jako klawisz skrótu.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>Nie można wyświetlić monitu dla „{0}”, ponieważ nie można załadować typu „{1}”.</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>Argument „{0}” nie może mieć wartości null ani nie może być pusty.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>Wartość „{0}” nie może mieć wartości null.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Aby uzyskać Pomoc, wpisz !?).</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(wartość domyślna to „{0}”): </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(wartość domyślna to „{0}”)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(domyślne opcje to {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Wybór[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>DEBUGOWANIE: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>PEŁNE INFORMACJE: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>OSTRZEŻENIE: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>Program PowerShell działa w trybie nieinteraktywnym. Funkcje Read i Prompt są niedostępne.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ProgressNodeStrings.pl.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/pl/ProgressNodeStrings.pl.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>Pozostało {0}{1}. </value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>{0} aktywność nie jest wyświetlana...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>{0} aktywności nie są wyświetlane...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostRawUserInterfaceStrings.ru.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostRawUserInterfaceStrings.ru.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>Невозможно обработать операцию, так как переданная координата недопустима. Укажите координату в пределах области буфера {0}.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Невозможно задать размер буфера, так как указанный размер слишком велик или слишком мал.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Невозможно задать цвет консоли, так как указанное значение недопустимо. Укажите допустимый цвет, определенный типом System.ConsoleColor.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Невозможно обработать CursorSize, так как указан недопустимый размер курсора.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Не удается прочитать параметры клавиш. Чтобы прочитать параметры, задайте один или оба из следующих параметров: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>Значение {0} должно быть больше или равно {1}.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Невозможно использовать указанную позицию окна X (столбец), так как она выходит за ширину буфера экрана. Укажите другую позицию X, начиная со значения 0 для крайнего левого столбца буфера.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Невозможно использовать указанную позицию окна Y (строка), так как она выходит за высоту буфера экрана. Укажите другую позицию Y, начиная со значения 0 для верхней строки буфера.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>Ширина окна не может быть меньше 1.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>Высота окна должна быть не менее 1.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Ширина окна не может превышать ширину буфера экрана.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Высота окна не может превышать высоту буфера экрана.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>Ширина окна не может превышать {0}.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>Высота окна не может превышать {0}.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Окно слишком узкое.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>Окно слишком короткое.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Заголовок окна не может быть пустым.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Длина заголовка окна не должна превышать {0} символов.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Администратор: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostStrings.ru.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostStrings.ru.resx
@@ -118,74 +118,74 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TooManyNestedPromptsError" xml:space="preserve">
-    <value>Cannot display prompt because too many nested prompts are already running.</value>
+    <value>Невозможно отобразить запрос, так как уже выполняется слишком много вложенных запросов.</value>
   </data>
   <data name="InputExitCurrentLoopOutOfSyncError" xml:space="preserve">
-    <value>Cannot process input loop. ExitCurrentLoop was called when no InputLoops were running.</value>
+    <value>Не удается обработать цикл ввода. Вызывается ExitCurrentLoop, когда не выполняется ни один цикл ввода.</value>
   </data>
   <data name="DefaultPrompt" xml:space="preserve">
     <value>PS&gt;</value>
   </data>
   <data name="ShellCannotBeStarted" xml:space="preserve">
-    <value>The shell cannot be started. A failure occurred during initialization:</value>
+    <value>Не удается запустить оболочку. Произошел сбой при инициализации:</value>
   </data>
   <data name="ShellCannotBeStartedWithConfigConflict" xml:space="preserve">
-    <value>The shell cannot be started. An InitialSessionState object has been provided along with a -ConfigurationFile argument. Both configuration directives cannot be used at the same time.</value>
+    <value>Не удается запустить оболочку. Вместе с аргументом -ConfigurationFile указан объект InitialSessionState. Обе директивы конфигурации нельзя использовать одновременно.</value>
   </data>
   <data name="UnhandledExceptionShutdownMessage" xml:space="preserve">
-    <value>An error has occurred that was not properly handled. Additional information is shown below. The PowerShell process will exit.</value>
+    <value>Произошла ошибка, которая не была должным образом обработана. Дополнительная информация приведена ниже. Процесс PowerShell будет завершен.</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username  : {1}\{2}
-Machine   : {3} ({4})
+Начало расшифровки PowerShell
+Время начала: {0:yyyyMMddHHmmss}
+Имя пользователя: {1}\{2}
+Компьютер: {3} ({4})
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+Завершение расшифровки PowerShell
+Время окончания: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InitialCommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' could not be run because some PowerShell Snap-Ins did not load.</value>
+    <value>Не удалось выполнить команду "{0}", так как не загружены некоторые оснастки PowerShell.</value>
   </data>
   <data name="CommandNotExecuted" xml:space="preserve">
-    <value>Command '{0}' was not run as the session in which it was intended to run was either closed or broken</value>
+    <value>Команда "{0}" не выполнена, так как сеанс, в котором она должна была выполняться, был закрыт или поврежден</value>
   </data>
   <data name="EnteringDebugger" xml:space="preserve">
-    <value>Entering debug mode. Use h or ? for help. </value>
+    <value>Переход в режим отладки. Используйте h или ? для справки. </value>
   </data>
   <data name="HitBreakpoint" xml:space="preserve">
-    <value>Hit {0}</value>
+    <value>Выполнение {0}</value>
   </data>
   <data name="DebuggerSourceCodeFormat" xml:space="preserve">
     <value>{0}:{1,-3} {2}</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; execution will continue.
+Текущий сеанс не поддерживает отладку; выполнение будет продолжено.
 
 </value>
   </data>
   <data name="CannotLoadPSReadline" xml:space="preserve">
-    <value>Cannot load PSReadline module.  Console is running without PSReadline.</value>
+    <value>Не удается загрузить модуль PSReadLine.  Консоль работает без PSReadLine.</value>
   </data>
   <data name="ConflictingServerModeParameters" xml:space="preserve">
-    <value>More than one server mode parameter was specified. Server mode parameters must be used exclusively.</value>
+    <value>Указано более одного параметра режима сервера. Параметры режима сервера следует использовать только по одному.</value>
   </data>
   <data name="SlowProfileLoadingMessage" xml:space="preserve">
-    <value>Loading personal and system profiles took {0}ms.</value>
+    <value>Загрузка личных и системных профилей заняла {0} мс.</value>
   </data>
   <data name="RunAsAdministrator" xml:space="preserve">
-    <value>Run as Administrator</value>
+    <value>Запустить от имени администратора</value>
   </data>
   <data name="PushRunspaceNotRemote" xml:space="preserve">
-    <value>PushRunspace can only push a remote runspace.</value>
+    <value>PushRunspace может отправлять только удаленное пространство выполнения.</value>
   </data>
   <data name="MissingMandatoryParameter" xml:space="preserve">
-    <value>The '{0}' parameter is mandatory and must be specified when using the '{1}' parameter.</value>
+    <value>Параметр "{0}" обязателен и должен быть указан при использовании параметра "{1}".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostUserInterfaceStrings.ru.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ConsoleHostUserInterfaceStrings.ru.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>В коллекции "{0}" должен быть по крайней мере один элемент.</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>Не удается распознать "{1}" как {0} из-за ошибки переполнения.</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>Не удается распознать "{1}" как {0} из-за ошибки формата.</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>"{0}" не распознается как допустимая команда запроса.</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>Справка недоступна для {0}.</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
     <value>{0}: </value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>Поле "{0}" представляет собой массив нулевого ранга.</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>В {0} должен быть указан по меньшей мере один элемент.</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>Значение "{0}" должно быть допустимым индексом в "{1}" или -1, если вариант по умолчанию не задан.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}" должен быть допустимым индексом в "{1}". "{2}" не является допустимым индексом.</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] справка </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>Запрос был отменен.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Невозможно обработать горячую клавишу, так как вопросительный знак ("?") нельзя использовать в качестве горячей клавиши.</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>Невозможно отобразить запрос для "{0}", так как не удается загрузить тип "{1}".</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>{0} не может быть пустым или иметь значение NULL.</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>"{0}" не может иметь значения null.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(Введите !? для справки.)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(по умолчанию — "{0}"): </value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(по умолчанию — "{0}")</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(значения по умолчанию: {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Выбор[{0}]: </value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>ОТЛАДКА: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>ПОДРОБНО: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>ВНИМАНИЕ! {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell находится в режиме NonInteractive. Функции чтения и запросов недоступны.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ProgressNodeStrings.ru.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/ru/ProgressNodeStrings.ru.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>Осталось {0}{1}. </value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>{0} действие не отображается...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>Действия не отображаются: {0}...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/tr/ConsoleHostRawUserInterfaceStrings.tr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/tr/ConsoleHostRawUserInterfaceStrings.tr.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>İşlem gerçekleştirilemiyor çünkü sağlanan koordinat geçersiz. Arabelleğin {0} alanı içinde bir koordinat belirtin.</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>Belirtilen boyut çok büyük ya da çok küçük olduğundan arabellek boyutu ayarlanamıyor.</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>Belirtilen değer geçerli olmadığından konsol rengi ayarlanmadı. System.ConsoleColor türü tarafından tanımlanan geçerli bir renk belirtin.</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>Belirtilen imleç boyutu geçerli olmadığından CursorSize işlenemedi.</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>Anahtar seçenekleri okunamıyor. Seçenekleri okumak için aşağıdakilerden birini veya her ikisini ayarlayın: IncludeKeyDown, IncludeKeyUp.</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0}, {1} değerinden büyük veya ona eşit olmalıdır.</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>Belirtilen Window X (sütun) konumu kullanılamaz çünkü ekran arabelleğinin genişliğini aşıyor. 0'dan başlayarak, arabelleğin en sol sütunu olacak şekilde başka bir X konumu belirtin.</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>Belirtilen Pencere Y (satır) konumu, ekran arabelleğinin yüksekliğini geçediğinden bu konum kullanılamıyor. Arabelleğin en üst satırı olarak 0 ile başlayarak başka bir Y konumu belirtin.</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>Pencere genişliği 1'den küçük olamaz.</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>Pencere yüksekliği en az 1 olmalıdır.</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>Pencere ekran arabelleğinden daha geniş olamaz.</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>Pencere, ekran arabelleğinden daha uzun olamaz.</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>Pencere {0} değerinden daha geniş olamaz.</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>Pencere {0} değerinden daha uzun olamaz.</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>Pencere boyutu çok dar.</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>Pencere boyutu çok kısa.</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>Pencere başlığı boş olamaz.</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>Pencere başlığı {0} karakterden daha uzun olamaz.</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>Yönetici: </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/tr/ProgressNodeStrings.tr.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/tr/ProgressNodeStrings.tr.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>{0}{1} kaldı. </value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>{0} etkinlik gösterilmiyor...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>{0} etkinlik gösterilmiyor...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ConsoleHostRawUserInterfaceStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ConsoleHostRawUserInterfaceStrings.zh-Hans.resx
@@ -118,60 +118,60 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CoordinateOutOfBufferErrorTemplate" xml:space="preserve">
-    <value>Cannot process the operation because the supplied coordinate is not valid. Specify a coordinate within the buffer area of {0}.</value>
+    <value>无法处理该操作，因为提供的坐标无效。请指定一个位于 {0} 缓冲区区域内的坐标。</value>
   </data>
   <data name="InvalidBufferSizeError" xml:space="preserve">
-    <value>Cannot set the buffer size because the size specified is too large or too small.</value>
+    <value>无法设置缓冲区大小，因为指定的大小过大或过小。</value>
   </data>
   <data name="InvalidConsoleColorError" xml:space="preserve">
-    <value>Cannot set the console color because the value specified is not valid. Specify a valid color as defined by the System.ConsoleColor type.</value>
+    <value>无法设置控制台颜色，因为指定的值无效。指定 System.ConsoleColor 类型定义的有效颜色。</value>
   </data>
   <data name="InvalidCursorSizeError" xml:space="preserve">
-    <value>Cannot process CursorSize because the cursor size specified is not valid.</value>
+    <value>无法处理 CursorSize，因为指定的光标大小无效。</value>
   </data>
   <data name="InvalidReadKeyOptionsError" xml:space="preserve">
-    <value>Cannot read key options. To read options, set one or both of the following: IncludeKeyDown, IncludeKeyUp.</value>
+    <value>无法读取按键选项。若要读取选项，请设置以下一项或两项: IncludeKeyDown、IncludeKeyUp。</value>
   </data>
   <data name="InvalidRegionErrorTemplate" xml:space="preserve">
-    <value>{0} should be greater than or equal to {1}.</value>
+    <value>{0} 应该大于或等于 {1}。</value>
   </data>
   <data name="InvalidXWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window X (column) position because it extends past the width of the screen buffer. Specify another X position, starting with 0 as the left most column of the buffer.</value>
+    <value>无法使用指定的窗口 X (列)位置，因为它超出了屏幕缓冲区的宽度。请指定另一个 X 位置，缓冲区最左侧的列为 0。</value>
   </data>
   <data name="InvalidYWindowPositionError" xml:space="preserve">
-    <value>Cannot use the specified Window Y (row) position because it extends past the height of the screen buffer. Specify another Y position, starting with 0 as the top-most row of the buffer.</value>
+    <value>无法使用指定的窗口 Y (行)位置，因为它超出了屏幕缓冲区的高度。请指定另一个 Y 位置，从缓冲区最顶层的行为 0。</value>
   </data>
   <data name="WindowWidthTooSmallError" xml:space="preserve">
-    <value>Window width cannot be less than 1.</value>
+    <value>窗口宽度不能小于 1。</value>
   </data>
   <data name="WindowHeightTooSmallError" xml:space="preserve">
-    <value>Window height must be at least 1.</value>
+    <value>窗口高度必须至少为 1。</value>
   </data>
   <data name="WindowWidthLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be wider than the screen buffer.</value>
+    <value>窗口宽度不能超过屏幕缓冲区。</value>
   </data>
   <data name="WindowHeightLargerThanBufferError" xml:space="preserve">
-    <value>Window cannot be taller than the screen buffer.</value>
+    <value>窗口高度不能超过屏幕缓冲区。</value>
   </data>
   <data name="WindowWidthTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be wider than {0}.</value>
+    <value>窗口宽度不能超过 {0}。</value>
   </data>
   <data name="WindowHeightTooLargeErrorTemplate" xml:space="preserve">
-    <value>Window cannot be taller than {0}.</value>
+    <value>窗口高度不能超过 {0}。</value>
   </data>
   <data name="WindowTooNarrowError" xml:space="preserve">
-    <value>Window size is too narrow.</value>
+    <value>窗口大小过窄。</value>
   </data>
   <data name="WindowTooShortError" xml:space="preserve">
-    <value>Window size is too short.</value>
+    <value>窗口大小过短。</value>
   </data>
   <data name="WindowTitleTooShortError" xml:space="preserve">
-    <value>Window title cannot be empty.</value>
+    <value>窗口标题不能为空。</value>
   </data>
   <data name="WindowTitleTooLongErrorTemplate" xml:space="preserve">
-    <value>Window title cannot be longer than {0} characters.</value>
+    <value>窗口标题长度不能超过 {0} 个字符。</value>
   </data>
   <data name="WindowTitleElevatedPrefix" xml:space="preserve">
-    <value>Administrator: </value>
+    <value>管理员:</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ConsoleHostUserInterfaceStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ConsoleHostUserInterfaceStrings.zh-Hans.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptEmptyDescriptionsErrorTemplate" xml:space="preserve">
-    <value>The "{0}" collection must have at least one element.</value>
+    <value>“{0}”集合必须包含至少一个元素。</value>
   </data>
   <data name="PromptParseOverflowErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to an overflow error.</value>
+    <value>由于溢出错误，无法将“{1}”识别为 {0}。</value>
   </data>
   <data name="PromptParseFormatErrorTemplate" xml:space="preserve">
-    <value>Cannot recognize "{1}" as a {0} due to a format error.</value>
+    <value>由于格式错误，无法将“{1}”识别为 {0}。</value>
   </data>
   <data name="PromptUnrecognizedCommandErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be recognized as a valid Prompt command.</value>
+    <value>无法将“{0}”识别为有效的提示命令。</value>
   </data>
   <data name="PromptNoHelpAvailableErrorTemplate" xml:space="preserve">
-    <value>No help is available for {0}.</value>
+    <value>{0} 没有可用的帮助。</value>
   </data>
   <data name="PromptFieldPromptInputSeparatorTemplate" xml:space="preserve">
-    <value>{0}: </value>
+    <value>{0}:</value>
   </data>
   <data name="RankZeroArrayErrorTemplate" xml:space="preserve">
-    <value>The field "{0}" is a zero rank array.</value>
+    <value>字段“{0}”是一个零秩数组。</value>
   </data>
   <data name="EmptyChoicesErrorTemplate" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>“{0}”应包含至少一个元素。</value>
   </data>
   <data name="InvalidDefaultChoiceErrorTemplate" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}" or -1 for no default choice.</value>
+    <value>“{0}”必须是“{1}”的有效索引或 -1(表示没有默认选择)。</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>“{0}”必须是“{1}”的有效索引。“{2}”不是有效索引。</value>
   </data>
   <data name="PromptForChoiceHelp" xml:space="preserve">
-    <value>[?] Help </value>
+    <value>[?] 帮助 </value>
   </data>
   <data name="PromptCanceledError" xml:space="preserve">
-    <value>The prompt was canceled.</value>
+    <value>提示已取消。</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>无法处理热键，因为问号("?")不能用作热键。</value>
   </data>
   <data name="PromptTypeLoadErrorTemplate" xml:space="preserve">
-    <value>Cannot display the prompt for "{0}" because type "{1}" cannot be loaded.</value>
+    <value>无法显示“{0}”的提示，因为无法加载类型“{1}”。</value>
   </data>
   <data name="NullOrEmptyErrorTemplate" xml:space="preserve">
     <value>“{0}”不能是 Null 或为空。</value>
   </data>
   <data name="NullErrorTemplate" xml:space="preserve">
-    <value>"{0}" cannot be null.</value>
+    <value>“{0}”不得为 null。</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>(Type !? for Help.)</value>
+    <value>(键入 !? 以获取帮助。)</value>
   </data>
   <data name="DefaultChoicePrompt" xml:space="preserve">
-    <value>(default is "{0}"): </value>
+    <value>(默认值为“{0}”):</value>
   </data>
   <data name="DefaultChoiceForMultipleChoices" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(默认值为“{0}”)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(默认选项为 {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Choice[{0}]:</value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>调试: {0}</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>详细信息: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>警告: {0}</value>
   </data>
   <data name="ReadFailsOnNonInteractiveFlag" xml:space="preserve">
-    <value>PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.</value>
+    <value>PowerShell 处于非交互模式。读取和提示功能不可用。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ManagedEntranceStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ManagedEntranceStrings.zh-Hans.resx
@@ -121,37 +121,37 @@
     <value>PowerShell {0}</value>
   </data>
   <data name="ShellBannerCLMode" xml:space="preserve">
-    <value>[Constrained Language Mode]</value>
+    <value>[受约束的语言模式]</value>
   </data>
   <data name="ShellBannerCLAuditMode" xml:space="preserve">
-    <value>[Constrained Language AUDIT Mode : No Restrictions]</value>
+    <value>[受约束的语言审核模式: 无限制]</value>
   </data>
   <data name="ShellBannerNLMode" xml:space="preserve">
-    <value>[No Language Mode]</value>
+    <value>[无语言模式]</value>
   </data>
   <data name="ShellBannerRLMode" xml:space="preserve">
-    <value>[Restricted Language Mode]</value>
+    <value>[受限语言模式]</value>
   </data>
   <data name="PreviewUpdateNotificationMessage" xml:space="preserve">
-    <value>  {1} A new PowerShell preview release is available: v{0} {2}
-  {1} Upgrade now, or check out the release page at:{3}{2}
+    <value>  {1} 有新的 PowerShell 预览版本可用: v{0} {2}
+  {1} 立即升级，或访问发布页:{3}{2}
   {1}   https://aka.ms/PowerShell-Release?tag=v{0} {4}{2}
 </value>
   </data>
   <data name="StableUpdateNotificationMessage" xml:space="preserve">
-    <value>  {1} A new PowerShell stable release is available: v{0} {2}
-  {1} Upgrade now, or check out the release page at:{3}{2}
+    <value>  {1} 有新的 PowerShell 稳定版本可用: v{0} {2}
+  {1} 立即升级，或访问发布页:{3}{2}
   {1}   https://aka.ms/PowerShell-Release?tag=v{0} {4}{2}
 </value>
   </data>
   <data name="LTSUpdateNotificationMessage" xml:space="preserve">
-    <value>  {1} A new PowerShell LTS release is available: v{0} {2}
-  {1} Upgrade now, or check out the release page at:{3}{2}
+    <value>  {1} 有新的 PowerShell LTS 版本可用: v{0} {2}
+  {1} 立即升级，或访问发布页:{3}{2}
   {1}   https://aka.ms/PowerShell-Release?tag=v{0} {4}{2}
 </value>
   </data>
   <data name="UsageHelp" xml:space="preserve">
-    <value>Usage: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
+    <value>用法: pwsh[.exe] [-Login] [[-File] &lt;filePath&gt; [args]]
                   [-Command { - | &lt;script-block&gt; [-args &lt;arg-array&gt;]
                                 | &lt;string&gt; [&lt;CommandParameters&gt;] } ]
                   [-CommandWithArgs &lt;string&gt; [&lt;CommandParameters&gt;]
@@ -166,9 +166,9 @@
 
        pwsh[.exe] -h | -Help | -? | /?
 
-PowerShell Online Help https://aka.ms/powershell-docs
+PowerShell 联机帮助 https://aka.ms/powershell-docs
 
-All parameters are case-insensitive.</value>
+所有参数都不区分大小写。</value>
   </data>
   <data name="ExtendedHelp" xml:space="preserve">
     <value>

--- a/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ProgressNodeStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.ConsoleHost/resources/zh-Hans/ProgressNodeStrings.zh-Hans.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SecondsRemaining" xml:space="preserve">
-    <value>{0}{1} remaining. </value>
+    <value>剩余 {0}{1}。</value>
   </data>
   <data name="InvisibleNodesMessageSingular" xml:space="preserve">
-    <value>{0} activity not shown...</value>
+    <value>未显示 {0} 活动...</value>
   </data>
   <data name="InvisibleNodesMessagePlural" xml:space="preserve">
-    <value>{0} activities not shown...</value>
+    <value>未显示 {0} 活动...</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/es/DotNetEventingStrings.es.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/es/DotNetEventingStrings.es.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Se requiere un número no negativo.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>El parámetro ID debe estar en el intervalo {0} hasta {1}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>El número total de parámetros no debe superar {0}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>El número de parámetros String no debe superar {0}.</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>El delimitador no puede ser una cadena vacía.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ja/DotNetEventingStrings.ja.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ja/DotNetEventingStrings.ja.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>正の数値が必要です。</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>ID パラメーターは {0} から {1} の範囲内である必要があります。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>パラメーターの総数は {0} 以下である必要があります。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>文字列パラメーターの数は {0} 以下である必要があります。</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>区切り記号を空の文字列にすることはできません。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ko/DotNetEventingStrings.ko.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ko/DotNetEventingStrings.ko.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>음수가 아닌 숫자가 필요합니다.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>ID 매개 변수는 {0}에서 {1}까지여야 합니다.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>전체 매개 변수 수는 {0}을(를) 초과하면 안 됩니다.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>String 매개 변수의 수는 {0}을(를) 초과할 수 없습니다.</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>구분 기호는 빈 문자열일 수 없습니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/pl/DotNetEventingStrings.pl.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/pl/DotNetEventingStrings.pl.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Wymagana jest liczba nieujemna.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>Parametr identyfikatora musi znajdować się w zakresie {0} do {1}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>Całkowita liczba parametrów nie może przekraczać {0}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>Liczba parametrów string nie może przekraczać {0}.</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>Ogranicznik nie może być pustym ciągiem.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ru/DotNetEventingStrings.ru.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/ru/DotNetEventingStrings.ru.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>Требуется неотрицательное число.</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>Параметр идентификатора должен быть в диапазоне от {0} до {1}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>Общее число параметров не должно превышать {0}.</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>Число параметров String не должно превышать {0}.</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>Разделитель не может быть пустой строкой.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/zh-Hans/DotNetEventingStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/zh-Hans/DotNetEventingStrings.zh-Hans.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>需要非负数。</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>ID 参数必须处于 {0} 到 {1} 的范围内。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>参数的总数不能超过 {0}。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>字符串参数的数量不能超过 {0}。</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>分隔符不能为空字符串。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/zh-Hant/DotNetEventingStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.CoreCLR.Eventing/resources/zh-Hant/DotNetEventingStrings.zh-Hant.resx
@@ -118,18 +118,18 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentOutOfRange_NeedNonNegNum" xml:space="preserve">
-    <value>Non negative number is required.</value>
+    <value>需要使用非負數。</value>
   </data>
   <data name="ArgumentOutOfRange_NeedValidId" xml:space="preserve">
-    <value>The ID parameter must be in the range {0} through {1}.</value>
+    <value>ID 參數必須在 {0} 到 {1} 的範圍內。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxArgExceeded" xml:space="preserve">
-    <value>The total number of parameters must not exceed {0}.</value>
+    <value>參數總數不得超過 {0}。</value>
   </data>
   <data name="ArgumentOutOfRange_MaxStringsExceeded" xml:space="preserve">
-    <value>The number of String parameters must not exceed {0}.</value>
+    <value>String 參數的數目不得超過 {0}。</value>
   </data>
   <data name="Argument_NeedNonemptyDelimiter" xml:space="preserve">
-    <value>Delimiter cannot be an empty string.</value>
+    <value>分隔符號不能為空字串。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/cs/CertificateCommands.cs.resx
+++ b/src/Microsoft.PowerShell.Security/resources/cs/CertificateCommands.cs.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>Zadejte heslo: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>Příkaz nemůže najít žádný ze zadaných souborů.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>Následující soubor nebyl nalezen: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/cs/UtilsStrings.cs.resx
+++ b/src/Microsoft.PowerShell.Security/resources/cs/UtilsStrings.cs.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileSmallerThan4Bytes" xml:space="preserve">
-    <value>Cannot digitally sign file because file {0} is smaller than 4 bytes in size. Files must be at least 4 bytes in order to be digitally signed.</value>
+    <value>Soubor {0} nelze digitálně podepsat, protože je menší než 4 bajty. Aby bylo možné soubory digitálně podepsat, musí mít velikost alespoň 4 bajty.</value>
   </data>
   <data name="OperationNotSupportedOnPath" xml:space="preserve">
-    <value>Cannot perform the operation because it is not supported on the object found in path {0}.</value>
+    <value>Operaci nelze provést, protože není podporována pro objekt nalezený v cestě {0}.</value>
   </data>
   <data name="GetMethodNotFound" xml:space="preserve">
-    <value>Cannot get the ACL because the necessary method, GetSecurityDescriptor, does not exist.</value>
+    <value>Nelze získat seznam ACL, protože neexistuje požadovaná metoda GetSecurityDescriptor.</value>
   </data>
   <data name="SetMethodNotFound" xml:space="preserve">
-    <value>Cannot set the ACL because the method that it needs to invoke, SetSecurityDescriptor, does not exist.</value>
+    <value>Nelze nastavit seznam ACL, protože neexistuje metoda SetSecurityDescriptor, kterou je potřeba vyvolat.</value>
   </data>
   <data name="MethodInvokeFail" xml:space="preserve">
-    <value>Could not perform operation because an exception was thrown during method invoke.</value>
+    <value>Operaci se nepodařilo provést, protože při vyvolání metody došlo k výjimce.</value>
   </data>
   <data name="GetSaclWithCapIdFail" xml:space="preserve">
-    <value>Could not create a SACL with the specified central access policy.</value>
+    <value>Nepodařilo se vytvořit seznam SACL se zadanou zásadou centrálního přístupu.</value>
   </data>
   <data name="GetEmptySaclFail" xml:space="preserve">
-    <value>Could not create an empty SACL.</value>
+    <value>Prázdný seznam SACL nelze vytvořit.</value>
   </data>
   <data name="GetTokenWithEnabledPrivilegeFail" xml:space="preserve">
-    <value>Could not enable SeSecurityPrivilege.</value>
+    <value>Nepovedlo se povolit SeSecurityPrivilege.</value>
   </data>
   <data name="SetCentralAccessPolicyFail" xml:space="preserve">
-    <value>Could not set central access policy.</value>
+    <value>Nepovedlo se nastavit zásady centrálního přístupu.</value>
   </data>
   <data name="InvalidCentralAccessPolicyParameters" xml:space="preserve">
-    <value>ClearCentralAccessPolicy and CentralAccessPolicy parameters cannot be used at the same time.</value>
+    <value>Parametry ClearCentralAccessPolicy a CentralAccessPolicy nelze použít současně.</value>
   </data>
   <data name="InvalidCentralAccessPolicyIdentifier" xml:space="preserve">
-    <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
+    <value>Identifikátor nebo název zásad centrálního přístupu nejsou platné. Pokud zadáváte identifikátor, musí začínat řetězcem S-1-17. Pokud zadáváte název, musí být zásada použita na cílovém počítači.</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request</value>
+    <value>Žádost o přihlašovací údaje k PowerShellu</value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Zadejte vaše přihlašovací údaje.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/de/CertificateCommands.de.resx
+++ b/src/Microsoft.PowerShell.Security/resources/de/CertificateCommands.de.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>Kennwort eingeben: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>Der Befehl kann keine der angegebenen Dateien finden.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>Die folgende Datei konnte nicht gefunden werden: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/de/CertificateProviderStrings.de.resx
+++ b/src/Microsoft.PowerShell.Security/resources/de/CertificateProviderStrings.de.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 Zertifikatanbieter</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>Das X509-Zertifikat wurde unter dem Pfad {0} nicht gefunden.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>Der X509-Zertifikatspeicher wurde im Pfad {0} nicht gefunden.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Der Zertifikatspeicher wurde nicht gefunden, da der angegebene X509-Speicherort {0} ungültig ist.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>Der Pfad kann nicht verarbeitet werden, da der Pfad {0} kein gültiger Zertifikatanbieterpfad ist.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Zertifikat verschieben</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Zertifikat entfernen</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Entfernen Sie das Zertifikat und den zugehörigen privaten Schlüssel.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Zertifikat-Manager aufrufen</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Element: {0} Ziel: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Sie können keinen Zertifikatcontainer verschieben. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Sie können ein Zertifikat nicht aus dem Benutzerspeicher auf den Computer oder vom Computer verschieben. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Sie können ein Zertifikat nicht in denselben Speicher verschieben. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Sie können kein anderes Element als den Zertifikatspeicher erstellen. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>Das Erstellen von Zertifikatspeichern unter CurrentUser wird nicht unterstützt. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>Das Löschen von Zertifikatspeichern unter CurrentUser wird nicht unterstützt. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>Das Ziel ist kein gültiger Speicher. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Element: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>Der Speicher {0} ist ein integrierter Systemspeicher und kann nicht gelöscht werden.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Ein Zertifikatcontainer kann nicht entfernt werden. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Privater Schlüssel übersprungen. Das Zertifikat weist keine Zuordnung mit einem privaten Schlüssel auf. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>Der Vorgang befindet sich im Benutzerstammspeicher und die Benutzeroberfläche ist nicht zulässig. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. Der folgende Fehler kann auf Benutzeranmeldeinformationen zurückzuführen sein, die auf dem Remotecomputer erforderlich sind. Informationen zum Aktivieren und Verwenden von CredSSP für die Delegierung mit PowerShell-Remoting finden Sie in der Hilfe zum Enable-WSManCredSSP-Cmdlet. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/de/ExecutionPolicyCommands.de.resx
+++ b/src/Microsoft.PowerShell.Security/resources/de/ExecutionPolicyCommands.de.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell hat Ihre Ausführungsrichtlinie erfolgreich aktualisiert, aber die Einstellung wird durch eine Richtlinie überschrieben, die in einem spezifischeren Bereich definiert ist.  Aufgrund der Außerkraftsetzung behält Ihre Shell die aktuelle effektive Ausführungsrichtlinie von {0} bei. Geben Sie „Get-ExecutionPolicy -List“ ein, um ihre Ausführungsrichtlinieneinstellungen anzuzeigen. Weitere Informationen finden Sie unter „Get-Help Set-ExecutionPolicy“.</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>Wenden Sie sich an Ihren Systemadministrator.</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>Ausführungsrichtlinie kann nicht abrufen werden. Geben Sie nur die Listen- oder Bereichsparameter an.</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>Die Ausführungsrichtlinie kann nicht festgelegt werden. Ausführungsrichtlinien in den Bereichen „MachinePolicy“ oder „UserPolicy“ müssen über die Gruppenrichtlinie festgelegt werden.</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>Änderung der Ausführungsrichtlinie</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>Die Ausführungsrichtlinie schützt Sie vor Skripten, denen Sie nicht vertrauen. Wenn Sie die Ausführungsrichtlinie ändern, sind Sie möglicherweise den Sicherheitsrisiken ausgesetzt, die im about_Execution_Policies Hilfethema unter https://go.microsoft.com/fwlink/?LinkID=135170 beschrieben werden. Möchten Sie die Ausführungsrichtlinie ändern?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+Um die Ausführungsrichtlinie für den Standardbereich (LocalMachine) zu ändern, öffnen Sie PowerShell mit der Option „Als Administrator ausführen“. Führen Sie „Set-ExecutionPolicy -Scope CurrentUser“ aus, um die Ausführungsrichtlinie für den aktuellen Benutzer zu ändern.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/es/CertificateCommands.es.resx
+++ b/src/Microsoft.PowerShell.Security/resources/es/CertificateCommands.es.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>Escribir contraseña: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>El comando no encuentra ninguno de los archivos especificados.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>No se encontró el siguiente archivo: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/es/CertificateProviderStrings.es.resx
+++ b/src/Microsoft.PowerShell.Security/resources/es/CertificateProviderStrings.es.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>Proveedor de certificados X509</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>No se encuentra el certificado X509 en la ruta de acceso {0}.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>No se encuentra el almacén de certificados X509 en la ruta de acceso {0}.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>No se encuentra el almacén de certificados porque la ubicación {0} del almacén X509 especificada no es válida.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>No se puede procesar la ruta de acceso porque la ruta de acceso {0} no es una ruta de acceso de proveedor de certificados válida.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Mover certificado</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Quitar certificado</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Quite el certificado y su clave privada.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Invocar administrador de certificados</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Elemento: {0} Destino: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>No se puede mover un contenedor de certificados. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>No se puede mover un certificado del almacén de usuarios al equipo o desde este. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>No se puede mover un certificado al mismo almacén. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>No se puede crear un elemento que no sea el almacén de certificados. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>No se admite la creación de almacenes de certificados en CurrentUser. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>No se admite la eliminación de almacenes de certificados en CurrentUser. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>El destino no es un almacén válido. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Elemento: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>El almacén {0} es un almacén del sistema integrado y no se puede eliminar.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>No se puede quitar un contenedor de certificados. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Clave privada omitida. El certificado no tiene ninguna asociación de clave privada. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>La operación está en el almacén raíz del usuario y no se permite la interfaz de usuario. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. El siguiente error puede deberse a las credenciales de usuario necesarias en el equipo remoto. Consulte la ayuda del cmdlet Enable-WSManCredSSP sobre cómo habilitar y usar CredSSP para la delegación con la comunicación remota de PowerShell. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/fr/CertificateProviderStrings.fr.resx
+++ b/src/Microsoft.PowerShell.Security/resources/fr/CertificateProviderStrings.fr.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>Fournisseur de certificat X509</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>Nous ne pouvons pas trouver le certificat X509 au chemin d’accès {0}.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>Nous ne pouvons pas trouver le magasin de certificats X509 au chemin d’accès {0}.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Nous ne pouvons pas trouver le magasin de certificats, car l’emplacement du magasin X509 spécifié {0} n’est pas valide.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>Vous ne pouvez pas traiter le chemin d’accès, car le chemin {0} n’est pas un chemin de fournisseur de certificats valide.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Déplacer un certificat</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Supprimer le certificat</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Supprimez le certificat et sa clé privée.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Appeler le gestionnaire de certificats</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Élément : {0} Destination : {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Vous ne pouvez pas déplacer un conteneur de certificats. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Vous ne pouvez pas déplacer un certificat d’un magasin utilisateur vers ou à partir d’un ordinateur. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Vous ne pouvez pas déplacer un certificat vers le même magasin. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Vous ne pouvez pas créer un élément autre qu’un magasin de certificats. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>La création de magasins de certificats sous CurrentUser n’est pas prise en charge. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>La suppression de magasins de certificats sous CurrentUser n’est pas prise en charge. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>La destination n’est pas un magasin valide. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Élément : {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>Le magasin {0} est un magasin système intégré et vous ne pouvez pas le supprimer.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Vous ne pouvez pas supprimer un conteneur de certificats. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Clé privée ignorée. Le certificat n’a aucune association de clé privée. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>L’opération concerne le magasin racine de l’utilisateur et l’interface utilisateur n’est pas autorisée. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. L’erreur suivante peut être due à des informations d’identification de l’utilisateur requises sur l’ordinateur distant. Consultez l’aide de la cmdlet Enable-WSManCredSSP pour savoir comment activer et utiliser CredSSP pour la délégation avec la communication à distance de PowerShell. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/fr/ExecutionPolicyCommands.fr.resx
+++ b/src/Microsoft.PowerShell.Security/resources/fr/ExecutionPolicyCommands.fr.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell a correctement mis à jour votre stratégie d’exécution, mais le paramètre est remplacé par une stratégie définie dans une étendue plus spécifique.  En raison de ce remplacement, votre interpréteur de commandes conservera sa stratégie d’exécution effective actuelle de {0}. Tapez « Get-ExecutionPolicy -List » pour afficher vos paramètres de stratégie d’exécution. Pour découvrir plus d’informations, veuillez consultez « Get-Help Set-ExecutionPolicy ».</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>Contactez l’administrateur système.</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>Nous ne pouvons pas obtenir une stratégie d’exécution. Spécifiez uniquement les paramètres List ou Scope.</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>Nous ne pouvons pas définir de stratégie d’exécution. Vous devez définir les stratégies d’exécution aux étendues MachinePolicy ou UserPolicy via la stratégie de groupe.</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>Stratégie d’exécution à utiliser</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>La stratégie d’exécution vous permet de vous protéger contre les scripts auxquels vous ne faites pas confiance. Il est possible que la modification de la stratégie d’exécution vous expose aux risques de sécurité décrits dans la rubrique d’Aide about_Execution_Policies à l’adresse https://go.microsoft.com/fwlink/?LinkID=135170. Voulez-vous modifier la stratégie d’exécution ?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+Si vous souhaitez modifier la stratégie d’exécution associée à l’étendue par défaut (LocalMachine), lancez PowerShell avec l’option « Exécuter en tant qu’administrateur ». Pour modifier la stratégie d’exécution de l’utilisateur actuel, exécutez « Set-ExecutionPolicy -Scope CurrentUser ».</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/fr/SecureStringCommands.fr.resx
+++ b/src/Microsoft.PowerShell.Security/resources/fr/SecureStringCommands.fr.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewSecureString_Prompt" xml:space="preserve">
-    <value>Enter secret: </value>
+    <value>Entrer le secret : </value>
   </data>
   <data name="ForceRequired" xml:space="preserve">
-    <value>The system cannot protect plain text input. To suppress this warning and convert the plain text to a SecureString, reissue the command specifying the Force parameter. For more information, type: get-help ConvertTo-SecureString.</value>
+    <value>Le système ne peut pas protéger l’entrée en texte brut. Pour supprimer cet avertissement et convertir le texte brut en SecureString, réexécutez la commande spécifiant le paramètre Force. Pour plus d’informations, tapez : get-help ConvertTo-SecureString.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/it/CertificateCommands.it.resx
+++ b/src/Microsoft.PowerShell.Security/resources/it/CertificateCommands.it.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>Immettere la password: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>Non è possibile trovare i file specificati.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>Non è stato possibile trovare il seguente file: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/it/CertificateProviderStrings.it.resx
+++ b/src/Microsoft.PowerShell.Security/resources/it/CertificateProviderStrings.it.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>Provider di certificati X509</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>Non è possibile trovare il certificato X509 nel percorso {0}.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>Non è possibile trovare l'archivio certificati X509 nel percorso {0}.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Non è possibile trovare l'archivio certificati perché il percorso dell'archivio X509 specificato {0} non è valido.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>Non è possibile elaborare il percorso perché il percorso {0} non è un percorso del provider di certificati valido.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Sposta certificato</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Rimuovi certificato</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Rimuovere il certificato e la relativa chiave privata.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Richiamare Gestione certificati</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Elemento: {0} Destinazione: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Non è possibile spostare un contenitore di certificati. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Non è possibile spostare un certificato dall'archivio utenti a o dal computer. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Non è possibile spostare un certificato nello stesso archivio. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Non è possibile creare un elemento diverso dall'archivio certificati. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>La creazione di archivi certificati in CurrentUser non è supportata. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>L'eliminazione di archivi certificati in CurrentUser non è supportata. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>La destinazione non è un archivio valido. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Elemento: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>L'archivio {0} è un archivio di sistema predefinito e non può essere eliminato.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Non è possibile rimuovere un contenitore di certificati. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Chiave privata ignorata. Il certificato non è associato ad alcuna chiave privata. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>L'operazione si trova nell'archivio radice dell'utente e l'interfaccia utente non è consentita. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. L'errore seguente può essere dovuto alle credenziali utente necessarie nel computer remoto. Vedere la Guida del cmdlet Enable-WSManCredSSP su come abilitare e usare CredSSP per la delega con la comunicazione remota di PowerShell. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ja/CertificateCommands.ja.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ja/CertificateCommands.ja.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>パスワードの入力:</value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>コマンドは、指定されたファイルを見つけることができません。</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>次のファイルが見つかりませんでした: {0}。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ja/CertificateProviderStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ja/CertificateProviderStrings.ja.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 証明書プロバイダー</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>パス {0} に X509 証明書が見つかりません。</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>パス {0} に X509 証明書ストアが見つかりません。</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>指定された X509 ストアの場所 {0} が無効なため、証明書ストアを見つけられません。</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>パス {0} が有効な証明書プロバイダー パスではないため、パスを処理できません。</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>証明書を移動</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>証明書の削除</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>証明書とその秘密キーを削除します。</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>証明書マネージャーを呼び出す</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>項目: {0} 宛先: {1}</value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>証明書コンテナーは移動できません。</value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>証明書をユーザー ストアからコンピューター ストアへ、またはその逆に移動することはできません。</value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>証明書を同じストアに移動することはできません。</value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>証明書ストア以外の項目は作成できません。</value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser 配下の証明書ストアの作成はサポートされていません。</value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser 配下の証明書ストアの削除はサポートされていません。</value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>移動先が有効なストアではありません。</value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>項目: {0}</value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>ストア {0} は組み込みのシステム ストアであるため、削除できません。</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>証明書コンテナーは削除できません。</value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>秘密キーはスキップされました。証明書に秘密キーの関連付けがありません。</value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>操作はユーザー ルート ストアに対して行われ、UI は許可されていません。</value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>。次のエラーは、リモート コンピューターでユーザー資格情報が必要なために発生した可能性があります。PowerShell リモート処理での委任に CredSSP を有効にして使用する方法については、Enable-WSManCredSSP コマンドレットのヘルプを参照してください。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ja/UtilsStrings.ja.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ja/UtilsStrings.ja.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileSmallerThan4Bytes" xml:space="preserve">
-    <value>Cannot digitally sign file because file {0} is smaller than 4 bytes in size. Files must be at least 4 bytes in order to be digitally signed.</value>
+    <value>ファイル {0} のサイズが 4 バイト未満であるため、ファイルにデジタル署名できません。デジタル署名するには、ファイルは 4 バイト以上である必要があります。</value>
   </data>
   <data name="OperationNotSupportedOnPath" xml:space="preserve">
-    <value>Cannot perform the operation because it is not supported on the object found in path {0}.</value>
+    <value>この操作は、パス {0} で見つかったオブジェクトではサポートされていないため、実行できません。</value>
   </data>
   <data name="GetMethodNotFound" xml:space="preserve">
-    <value>Cannot get the ACL because the necessary method, GetSecurityDescriptor, does not exist.</value>
+    <value>必要なメソッド GetSecurityDescriptor が存在しないため、ACL を取得できません。</value>
   </data>
   <data name="SetMethodNotFound" xml:space="preserve">
-    <value>Cannot set the ACL because the method that it needs to invoke, SetSecurityDescriptor, does not exist.</value>
+    <value>呼び出す必要があるメソッド SetSecurityDescriptor が存在しないため、ACL を設定できません。</value>
   </data>
   <data name="MethodInvokeFail" xml:space="preserve">
-    <value>Could not perform operation because an exception was thrown during method invoke.</value>
+    <value>メソッドの呼び出し中に例外がスローされたため、操作を実行できませんでした。</value>
   </data>
   <data name="GetSaclWithCapIdFail" xml:space="preserve">
-    <value>Could not create a SACL with the specified central access policy.</value>
+    <value>指定された集約型アクセス ポリシーで SACL を作成できませんでした。</value>
   </data>
   <data name="GetEmptySaclFail" xml:space="preserve">
-    <value>Could not create an empty SACL.</value>
+    <value>空の SACL を作成できませんでした。</value>
   </data>
   <data name="GetTokenWithEnabledPrivilegeFail" xml:space="preserve">
-    <value>Could not enable SeSecurityPrivilege.</value>
+    <value>SeSecurityPrivilege を有効にできませんでした。</value>
   </data>
   <data name="SetCentralAccessPolicyFail" xml:space="preserve">
-    <value>Could not set central access policy.</value>
+    <value>集約型アクセス ポリシーを設定できませんでした。</value>
   </data>
   <data name="InvalidCentralAccessPolicyParameters" xml:space="preserve">
-    <value>ClearCentralAccessPolicy and CentralAccessPolicy parameters cannot be used at the same time.</value>
+    <value>ClearCentralAccessPolicy と CentralAccessPolicy パラメーターを同時に使用することはできません。</value>
   </data>
   <data name="InvalidCentralAccessPolicyIdentifier" xml:space="preserve">
-    <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
+    <value>集約型アクセス ポリシーの識別子または名前が無効です。識別子を指定する場合は、S-1-17 で始まる必要があります。名前を指定する場合は、ターゲット マシンにポリシーを適用する必要があります。</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request</value>
+    <value>PowerShell 資格情報の要求</value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>資格情報を入力してください。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ko/CertificateCommands.ko.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ko/CertificateCommands.ko.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>암호 입력: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>명령이 지정한 파일을 하나도 찾을 수 없습니다.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>다음 파일을 찾을 수 없습니다: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ko/CertificateProviderStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ko/CertificateProviderStrings.ko.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 인증서 공급자</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>{0} 경로에서 X509 인증서를 찾을 수 없습니다.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>{0} 경로에서 X509 인증서 저장소를 찾을 수 없습니다.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>지정한 X509 저장소 위치 {0}이(가) 올바르지 않아 인증서 저장소를 찾을 수 없습니다.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>경로 {0}이(가) 올바른 인증서 공급자 경로가 아니므로 경로를 처리할 수 없습니다.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>인증서 이동</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>인증서 제거</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>인증서와 프라이빗 키를 제거합니다.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>인증서 관리자 호출</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>항목: {0} 대상: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>인증서 컨테이너를 이동할 수 없습니다. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>사용자 저장소와 컴퓨터 저장소 간에는 인증서를 이동할 수 없습니다. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>인증서를 동일한 저장소로 이동할 수 없습니다. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>인증서 저장소 외의 항목은 만들 수 없습니다. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser 아래에 인증서 저장소를 만들 수 없습니다. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser 아래의 인증서 저장소는 삭제할 수 없습니다. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>대상이 올바른 저장소가 아닙니다. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>항목: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>저장소 {0}은(는) 기본 제공 시스템 저장소이므로 삭제할 수 없습니다.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>인증서 컨테이너를 제거할 수 없습니다. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>개인 키를 건너뜁니다. 이 인증서에는 개인 키 연결이 없습니다. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>작업이 사용자 루트 저장소에서 수행 중이므로 UI를 사용할 수 없습니다. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. 다음 오류는 원격 컴퓨터에 사용자 자격 증명이 필요해서 발생할 수 있습니다. PowerShell 원격에서 위임에 CredSSP를 사용하도록 설정하고 사용하는 방법은 Enable-WSManCredSSP Cmdlet 도움말을 참조하세요. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ko/ExecutionPolicyCommands.ko.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ko/ExecutionPolicyCommands.ko.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell에서 실행 정책을 업데이트했지만, 더 구체적인 범위에 정의된 정책이 이 설정을 재정의합니다.  재정의로 인해 셸은 현재 유효한 실행 정책 {0}을(를) 유지합니다. 실행 정책 설정을 보려면 "Get-ExecutionPolicy -List"를 입력하세요. 자세한 내용은 "Get-Help Set-ExecutionPolicy"를 참조하세요.</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>시스템 관리자에게 문의하세요.</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>실행 정책을 가져올 수 없습니다. List 또는 Scope 매개 변수만 지정하세요.</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>실행 정책을 설정할 수 없습니다. MachinePolicy 또는 UserPolicy 범위의 실행 정책은 그룹 정책을 통해 설정해야 합니다.</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>실행 정책 변경</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>실행 정책은 신뢰하지 않는 스크립트로부터 보호하는 데 도움이 됩니다. 실행 정책을 변경하면 https://go.microsoft.com/fwlink/?LinkID=135170의 about_Execution_Policies 도움말 항목에 설명된 보안 위험에 노출될 수 있습니다. 실행 정책을 변경하시겠습니까?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+기본(LocalMachine) 범위에 대한 실행 정책을 변경하려면 "관리자 권한으로 실행" 옵션으로 PowerShell을 시작합니다. 현재 사용자의 실행 정책을 변경하려면 "Set-ExecutionPolicy -Scope CurrentUser"를 실행하세요.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ko/SecureStringCommands.ko.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ko/SecureStringCommands.ko.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewSecureString_Prompt" xml:space="preserve">
-    <value>Enter secret: </value>
+    <value>비밀 입력: </value>
   </data>
   <data name="ForceRequired" xml:space="preserve">
-    <value>The system cannot protect plain text input. To suppress this warning and convert the plain text to a SecureString, reissue the command specifying the Force parameter. For more information, type: get-help ConvertTo-SecureString.</value>
+    <value>시스템은 일반 텍스트 입력을 보호할 수 없습니다. 이 경고를 표시하지 않고 일반 텍스트를 SecureString으로 변환하려면 Force 매개 변수를 지정해 명령을 다시 실행하세요. 자세한 내용은 get-help ConvertTo-SecureString을 입력하세요.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ko/UtilsStrings.ko.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ko/UtilsStrings.ko.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="FileSmallerThan4Bytes" xml:space="preserve">
-    <value>Cannot digitally sign file because file {0} is smaller than 4 bytes in size. Files must be at least 4 bytes in order to be digitally signed.</value>
+    <value>파일 {0}의 크기가 4바이트보다 작아 파일에 디지털 서명을 할 수 없습니다. 디지털 서명을 하려면 Files가 최소 4바이트여야 합니다.</value>
   </data>
   <data name="OperationNotSupportedOnPath" xml:space="preserve">
-    <value>Cannot perform the operation because it is not supported on the object found in path {0}.</value>
+    <value>경로 {0}에서 찾은 개체는 지원되지 않으므로 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="GetMethodNotFound" xml:space="preserve">
-    <value>Cannot get the ACL because the necessary method, GetSecurityDescriptor, does not exist.</value>
+    <value>필요한 메서드인 GetSecurityDescriptor가 없으므로 ACL을 가져올 수 없습니다.</value>
   </data>
   <data name="SetMethodNotFound" xml:space="preserve">
-    <value>Cannot set the ACL because the method that it needs to invoke, SetSecurityDescriptor, does not exist.</value>
+    <value>호출해야 하는 메서드인 SetSecurityDescriptor가 없으므로 ACL을 설정할 수 없습니다.</value>
   </data>
   <data name="MethodInvokeFail" xml:space="preserve">
-    <value>Could not perform operation because an exception was thrown during method invoke.</value>
+    <value>메서드를 호출하는 동안 예외가 발생하여 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="GetSaclWithCapIdFail" xml:space="preserve">
-    <value>Could not create a SACL with the specified central access policy.</value>
+    <value>지정된 중앙 액세스 정책으로 SACL을 만들 수 없습니다.</value>
   </data>
   <data name="GetEmptySaclFail" xml:space="preserve">
-    <value>Could not create an empty SACL.</value>
+    <value>빈 SACL을 만들 수 없습니다.</value>
   </data>
   <data name="GetTokenWithEnabledPrivilegeFail" xml:space="preserve">
-    <value>Could not enable SeSecurityPrivilege.</value>
+    <value>SeSecurityPrivilege를 사용하도록 설정할 수 없습니다.</value>
   </data>
   <data name="SetCentralAccessPolicyFail" xml:space="preserve">
-    <value>Could not set central access policy.</value>
+    <value>중앙 액세스 정책을 설정할 수 없습니다.</value>
   </data>
   <data name="InvalidCentralAccessPolicyParameters" xml:space="preserve">
-    <value>ClearCentralAccessPolicy and CentralAccessPolicy parameters cannot be used at the same time.</value>
+    <value>ClearCentralAccessPolicy와 CentralAccessPolicy 매개 변수는 동시에 사용할 수 없습니다.</value>
   </data>
   <data name="InvalidCentralAccessPolicyIdentifier" xml:space="preserve">
-    <value>Central Access Policy identifier or name is not valid. If specifying an identifier, it must begin with S-1-17. If specifying a name, the policy must be applied on the target machine.</value>
+    <value>중앙 액세스 정책 식별자 또는 이름이 올바르지 않습니다. 식별자를 지정하는 경우 S-1-17로 시작해야 합니다. 이름을 지정하는 경우 대상 컴퓨터에 정책이 적용되어 있어야 합니다.</value>
   </data>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request</value>
+    <value>PowerShell 자격 증명 요청</value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>자격 증명을 입력합니다.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/pl/CertificateCommands.pl.resx
+++ b/src/Microsoft.PowerShell.Security/resources/pl/CertificateCommands.pl.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>Wprowadź hasło: </value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>Polecenie nie może odnaleźć żadnego z określonych plików.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>Nie można odnaleźć następującego pliku: {0}.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/pl/CertificateProviderStrings.pl.resx
+++ b/src/Microsoft.PowerShell.Security/resources/pl/CertificateProviderStrings.pl.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>Dostawca certyfikatów X509</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>Nie można odnaleźć certyfikatu X509 w ścieżce {0}.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>Nie można odnaleźć magazynu certyfikatów X509 w ścieżce {0}.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Nie można odnaleźć magazynu certyfikatów, ponieważ określona lokalizacja magazynu X509 {0} jest nieprawidłowa.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>Nie można przetworzyć ścieżki, ponieważ ścieżka {0} nie jest prawidłową ścieżką dostawcy certyfikatów.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Przenieś certyfikat</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Usuń certyfikat</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Usuń certyfikat i jego klucz prywatny.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Wywoływanie Menedżera certyfikatów</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Element: {0} Miejsce docelowe: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Nie można przenieść kontenera certyfikatów. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Nie można przenieść certyfikatu z magazynu użytkownika na komputer ani z komputera do magazynu użytkownika. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Nie można przenieść certyfikatu do tego samego magazynu. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Nie można utworzyć elementu innego niż magazyn certyfikatów. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>Tworzenie magazynów certyfikatów w obszarze CurrentUser nie jest obsługiwane. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>Usuwanie magazynów certyfikatów w obszarze CurrentUser nie jest obsługiwane. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>Miejsce docelowe nie jest prawidłowym magazynem. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Element: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>Magazyn {0} jest wbudowanym magazynem systemowym i nie można go usunąć.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Nie można usunąć kontenera certyfikatów. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Pominięto klucz prywatny. Certyfikat nie ma skojarzonego klucza prywatnego. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>Operacja dotyczy głównego magazynu użytkownika i nie można użyć interfejsu użytkownika. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. Następujący błąd może wynikać z poświadczeń użytkownika wymaganych na komputerze zdalnym. Zobacz pomoc polecenia cmdlet Enable-WSManCredSSP, aby dowiedzieć się, jak włączyć i używać CredSSP do delegowania w zdalnym programie PowerShell. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/pl/ExecutionPolicyCommands.pl.resx
+++ b/src/Microsoft.PowerShell.Security/resources/pl/ExecutionPolicyCommands.pl.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>Program PowerShell pomyślnie zaktualizował zasady wykonywania, ale ustawienie to zostało zastąpione przez zasady zdefiniowane w bardziej szczegółowym zakresie.  Ze względu na to zastąpienie Twoja powłoka zachowa bieżącą efektywną zasadę wykonywania {0}. Wpisz „Get-ExecutionPolicy -List”, aby wyświetlić ustawienia zasad wykonywania. Aby uzyskać więcej informacji, zobacz „Get-Help Set-ExecutionPolicy”.</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>Skontaktuj się z administratorem systemu.</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>Nie można pobrać zasad wykonywania. Określ tylko parametry List lub Scope.</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>Nie można ustawić zasad wykonywania. Zasady wykonywania w zakresach MachinePolicy lub UserPolicy trzeba ustawić za pomocą Zasad grupy.</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>Zmiana zasad wykonywania</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>Zasady wykonywania pomagają chronić Cię przed skryptami, którym nie ufasz. Zmiana zasad wykonywania może narazić Cię na zagrożenia bezpieczeństwa opisane w temacie pomocy about_Execution_Policies pod adresem https://go.microsoft.com/fwlink/?LinkID=135170. Czy chcesz zmienić zasady wykonywania?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+Aby zmienić zasady wykonywania dla domyślnego zakresu (LocalMachine), uruchom program PowerShell, wybierając opcję „Uruchom jako administrator”. Aby zmienić zasady wykonywania dla bieżącego użytkownika, uruchom polecenie „Set-ExecutionPolicy -Scope CurrentUser”.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/pl/SecureStringCommands.pl.resx
+++ b/src/Microsoft.PowerShell.Security/resources/pl/SecureStringCommands.pl.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewSecureString_Prompt" xml:space="preserve">
-    <value>Enter secret: </value>
+    <value>Wprowadź wpis tajny: </value>
   </data>
   <data name="ForceRequired" xml:space="preserve">
-    <value>The system cannot protect plain text input. To suppress this warning and convert the plain text to a SecureString, reissue the command specifying the Force parameter. For more information, type: get-help ConvertTo-SecureString.</value>
+    <value>System nie może chronić danych wejściowych w postaci zwykłego tekstu. Aby wyłączyć to ostrzeżenie i przekonwertować zwykły tekst na obiekt SecureString, ponownie wydaj polecenie, określając parametr Force. Aby uzyskać więcej informacji, wpisz: get-help ConvertTo-SecureString.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ru/CertificateProviderStrings.ru.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ru/CertificateProviderStrings.ru.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>Поставщик сертификата X509</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>Не удается найти сертификат X509 на пути {0}.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>Не удается найти хранилище сертификатов X509 на пути {0}.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Невозможно найти хранилище сертификатов, так как указанное расположение хранилища X509 {0} недопустимо.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>Невозможно обработать путь, так как путь {0} не является допустимым путем поставщика сертификатов.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Переместить сертификат</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Удалить сертификат</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Удалить сертификат и его закрытый ключ.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Вызвать диспетчер сертификатов</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Элемент: {0} Назначение: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Невозможно переместить контейнер сертификата. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Нельзя переместить сертификат из хранилища пользователя на компьютер или обратно. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Невозможно переместить сертификат в то же хранилище. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Невозможно создать элемент, отличный от хранилища сертификатов. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>Создание хранилищ сертификатов в CurrentUser не поддерживается. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>Удаление хранилищ сертификатов в CurrentUser не поддерживается. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>Место назначения не является допустимым хранилищем. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Элемент: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>Хранилище {0} является встроенным системным хранилищем и не может быть удалено.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Невозможно удалить контейнер сертификата. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Закрытый ключ пропущен. У сертификата нет связей закрытого ключа. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>Операция выполняется в корневом хранилище пользователя, и использование пользовательского интерфейса не допускается. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. Следующая ошибка может быть вызвана тем, что учетные данные пользователя необходимы на удаленном компьютере. См. "Справка по командлету Enable-WSManCredSSP", чтобы узнать, как включить и использовать CredSSP для делегирования при удаленном взаимодействии PowerShell. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ru/ExecutionPolicyCommands.ru.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ru/ExecutionPolicyCommands.ru.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell обновил политику выполнения, но этот параметр переопределяется политикой, заданной в более конкретной области.  Из-за этого переопределения оболочка сохранит текущую действующую политику выполнения {0}. Введите "Get-ExecutionPolicy -List", чтобы просмотреть параметры политики выполнения. Подробнее см. в разделе "Get-Help Set-ExecutionPolicy".</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>Обратитесь к администратору.</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>Невозможно получить политику выполнения. Укажите только параметры List или Scope.</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>Невозможно настроить политику выполнения. Политики выполнения в областях MachinePolicy или UserPolicy нужно настраивать с помощью групповой политики.</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>Изменение политики выполнения</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>Политика выполнения помогает защитить вас от сценариев, которым вы не доверяете. Изменение политики выполнения может подвергнуть вас рискам безопасности, описанным в разделе справки о политиках выполнения по адресу https://go.microsoft.com/fwlink/?LinkID=135170. Изменить политику выполнения?</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+Чтобы изменить политику выполнения для области по умолчанию (LocalMachine), запустите PowerShell с помощью параметра "Запуск от имени администратора". Чтобы изменить политику выполнения для текущего пользователя, выполните команду "Set-ExecutionPolicy -Scope CurrentUser".</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/ru/SecureStringCommands.ru.resx
+++ b/src/Microsoft.PowerShell.Security/resources/ru/SecureStringCommands.ru.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewSecureString_Prompt" xml:space="preserve">
-    <value>Enter secret: </value>
+    <value>Введите секрет: </value>
   </data>
   <data name="ForceRequired" xml:space="preserve">
-    <value>The system cannot protect plain text input. To suppress this warning and convert the plain text to a SecureString, reissue the command specifying the Force parameter. For more information, type: get-help ConvertTo-SecureString.</value>
+    <value>Система не может защитить ввод в виде обычного текста. Чтобы подавить это предупреждение и преобразовать обычный текст в SecureString, повторите команду, указав параметр Force. Для получения дополнительных сведений введите: get-help ConvertTo-SecureString.</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/tr/CertificateProviderStrings.tr.resx
+++ b/src/Microsoft.PowerShell.Security/resources/tr/CertificateProviderStrings.tr.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 Sertifika Sağlayıcısı</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>X509 sertifikası {0} yolunda bulunamıyor.</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>X509 sertifika depolama alanı {0} yolunda bulunamıyor.</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>Belirtilen {0} X509 depolama alanı konumu geçerli olmadığından sertifika depolama alanı bulunamıyor.</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>{0} yolu geçerli bir sertifika sağlayıcısı yolu olmadığından yol işlenemiyor.</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>Sertifikayı taşı</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>Sertifikayı kaldır</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>Sertifikayı ve özel anahtarını kaldırın.</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>Sertifika Yöneticisini Çağır</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>Öğe: {0} Hedef: {1} </value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>Sertifika kapsayıcısını taşıyamazsınız. </value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>Bir sertifikayı kullanıcı deposundan makineye ya da makineden kullanıcı deposuna taşıyamazsınız. </value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>Sertifikayı aynı depolama alanına taşıyamazsınız. </value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>Sertifika depolama alanı dışında bir öğe oluşturamazsınız. </value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser altındaki sertifika depolama alanlarının oluşturulması desteklenmiyor. </value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>CurrentUser altındaki sertifika depolama alanlarının silinmesi desteklenmiyor. </value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>Hedef geçerli bir depolama alanı değil. </value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>Öğe: {0} </value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>{0} depolama alanı yerleşik bir sistem deposudur ve silinemez.</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>Sertifika kapsayıcısını kaldıramazsınız. </value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>Özel anahtar atlandı. Sertifikanın özel anahtar ilişkisi yok. </value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>İşlem kullanıcı kök deposunda ve kullanıcı arabirimine izin verilmiyor. </value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>. Aşağıdaki hata, uzak makinede gerekli olan kullanıcı kimlik bilgilerinden kaynaklanıyor olabilir. PowerShell uzaktan iletişimiyle temsilci seçimi için CredSSP'yi etkinleştirme ve kullanma hakkında Enable-WSManCredSSP Cmdlet'i yardımına bakın. </value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/zh-Hans/CertificateProviderStrings.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Security/resources/zh-Hans/CertificateProviderStrings.zh-Hans.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 证书提供程序</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>在路径 {0} 处找不到 X509 证书。</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>在路径 {0} 处找不到 X509 证书。</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>找不到证书存储，因为指定的 X509 存储位置 {0} 无效。</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>无法处理路径，因为路径 {0} 不是有效的证书提供程序路径。</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>移动证书</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>删除证书</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>删除证书及其私钥。</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>调用证书管理器</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>项: {0} 目标: {1}</value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>无法移动证书容器。</value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>不能将证书从用户存储移动到计算机存储，或从计算机存储移动到用户存储。</value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>不能将证书移动到同一存储区。</value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>除了证书存储之外，无法创建其他项。</value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>不支持在 CurrentUser 下创建证书存储。</value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>不支持删除 CurrentUser 下的证书存储。</value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>该目标不是有效的存储。</value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>项: {0}</value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>存储 {0} 是内置系统存储，无法删除。</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>无法删除证书容器。</value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>已跳过私钥。该证书没有关联的私钥。</value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>此操作针对用户根存储，不允许使用 UI。</value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>。以下错误可能是远程计算机上需要用户凭据所致。请参阅 Enable-WSManCredSSP Cmdlet 帮助，了解如何启用 CredSSP，并在 PowerShell 远程处理中将其用于委派操作。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/zh-Hans/ExecutionPolicyCommands.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Security/resources/zh-Hans/ExecutionPolicyCommands.zh-Hans.resx
@@ -118,25 +118,25 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExecutionPolicyOverridden" xml:space="preserve">
-    <value>PowerShell updated your execution policy successfully, but the setting is overridden by a policy defined at a more specific scope.  Due to the override, your shell will retain its current effective execution policy of {0}. Type "Get-ExecutionPolicy -List" to view your execution policy settings. For more information please see "Get-Help Set-ExecutionPolicy".</value>
+    <value>PowerShell 已成功更新你的执行策略，但该设置被在更具体作用域中定义的策略覆盖。 由于该覆盖，你的 shell 将保留当前生效的执行策略 {0}。键入“Get-ExecutionPolicy -List”以查看你的执行策略设置。有关详细信息，请参阅“Get-Help Set-ExecutionPolicy”。</value>
   </data>
   <data name="ExecutionPolicyOverriddenRecommendedAction" xml:space="preserve">
-    <value>Contact your system administrator.</value>
+    <value>请与你的系统管理员联系。</value>
   </data>
   <data name="ListAndScopeSpecified" xml:space="preserve">
-    <value>Cannot get execution policy. Specify only the List or Scope parameters.</value>
+    <value>无法获取执行策略。请仅指定 List 或 Scope 参数。</value>
   </data>
   <data name="CantSetGroupPolicy" xml:space="preserve">
-    <value>Cannot set execution policy. Execution policies at the MachinePolicy or UserPolicy scopes must be set through Group Policy.</value>
+    <value>无法设置执行策略。必须通过组策略设置 MachinePolicy 或 UserPolicy 范围的执行策略。</value>
   </data>
   <data name="SetExecutionPolicyCaption" xml:space="preserve">
-    <value>Execution Policy Change</value>
+    <value>执行策略更改</value>
   </data>
   <data name="SetExecutionPolicyQuery" xml:space="preserve">
-    <value>The execution policy helps protect you from scripts that you do not trust. Changing the execution policy might expose you to the security risks described in the about_Execution_Policies help topic at https://go.microsoft.com/fwlink/?LinkID=135170. Do you want to change the execution policy?</value>
+    <value>执行策略可帮助你防范不受信任的脚本。更改执行策略可能会使你面临 https://go.microsoft.com/fwlink/?LinkID=135170 中 about_Execution_Policies 帮助主题所述的安全风险。是否要更改执行策略？</value>
   </data>
   <data name="SetExecutionPolicyAccessDeniedError" xml:space="preserve">
     <value>{0}
-To change the execution policy for the default (LocalMachine) scope, start PowerShell with the "Run as administrator" option. To change the execution policy for the current user, run "Set-ExecutionPolicy -Scope CurrentUser".</value>
+若要更改默认 (LocalMachine) 范围的执行策略，请使用“以管理员身份运行”选项启动 PowerShell。若要更改当前用户的执行策略，请运行“Set-ExecutionPolicy -Scope CurrentUser”。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/zh-Hans/SecureStringCommands.zh-Hans.resx
+++ b/src/Microsoft.PowerShell.Security/resources/zh-Hans/SecureStringCommands.zh-Hans.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NewSecureString_Prompt" xml:space="preserve">
-    <value>Enter secret: </value>
+    <value>输入密钥:</value>
   </data>
   <data name="ForceRequired" xml:space="preserve">
-    <value>The system cannot protect plain text input. To suppress this warning and convert the plain text to a SecureString, reissue the command specifying the Force parameter. For more information, type: get-help ConvertTo-SecureString.</value>
+    <value>系统无法保护纯文本输入。若要取消显示此警告并将纯文本转换为 SecureString，请重新运行命令，并指定 Force 参数。有关详细信息，请输入 get-help ConvertTo-SecureString。</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/zh-Hant/CertificateCommands.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Security/resources/zh-Hant/CertificateCommands.zh-Hant.resx
@@ -118,12 +118,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="GetPfxCertPasswordPrompt" xml:space="preserve">
-    <value>Enter password: </value>
+    <value>輸入密碼:</value>
   </data>
   <data name="NoneOfTheFilesFound" xml:space="preserve">
-    <value>Command cannot find any of the specified files.</value>
+    <value>命令找不到任何指定的檔案。</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>The following file could not be found: {0}.</value>
+    <value>找不到下列檔案: {0}</value>
   </data>
 </root>

--- a/src/Microsoft.PowerShell.Security/resources/zh-Hant/CertificateProviderStrings.zh-Hant.resx
+++ b/src/Microsoft.PowerShell.Security/resources/zh-Hant/CertificateProviderStrings.zh-Hant.resx
@@ -118,72 +118,72 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CertProvidername" xml:space="preserve">
-    <value>X509 Certificate Provider</value>
+    <value>X509 憑證提供者</value>
   </data>
   <data name="CertificateNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate at path {0}.</value>
+    <value>在路徑 {0} 找不到 X509 憑證。</value>
   </data>
   <data name="CertificateStoreNotFound" xml:space="preserve">
-    <value>Cannot find the X509 certificate store at path {0}.</value>
+    <value>在路徑 {0} 找不到 X509 憑證存放區。</value>
   </data>
   <data name="CertificateStoreLocationNotFound" xml:space="preserve">
-    <value>Cannot find the certificate store because the specified X509 store location {0} is not valid.</value>
+    <value>找不到憑證存放區，因為指定的 X509 存放區位置 {0} 無效。</value>
   </data>
   <data name="InvalidPath" xml:space="preserve">
-    <value>Cannot process the path because path {0} is not a valid certificate provider path.</value>
+    <value>無法處理路徑，因為路徑 {0} 不是有效的憑證提供者路徑。</value>
   </data>
   <data name="Action_Move" xml:space="preserve">
-    <value>Move certificate</value>
+    <value>移動憑證</value>
   </data>
   <data name="Action_Remove" xml:space="preserve">
-    <value>Remove certificate</value>
+    <value>移除憑證</value>
   </data>
   <data name="Action_RemoveAndDeleteKey" xml:space="preserve">
-    <value>Remove certificate and its private key.</value>
+    <value>移除憑證及其私密金鑰。</value>
   </data>
   <data name="Action_Invoke" xml:space="preserve">
-    <value>Invoke Certificate Manager</value>
+    <value>叫用 [憑證管理員]</value>
   </data>
   <data name="MoveItemTemplate" xml:space="preserve">
-      <value>Item: {0} Destination: {1} </value>
+      <value>項目: {0} 目的地: {1}</value>
   </data>
   <data name="CannotMoveContainer" xml:space="preserve">
-      <value>You cannot move a certificate container. </value>
+      <value>您無法移動憑證容器。</value>
   </data>
   <data name="CannotMoveCrossContext" xml:space="preserve">
-      <value>You cannot move a certificate from user store to or from machine. </value>
+      <value>您無法將憑證從使用者存放區移至或移出電腦。</value>
   </data>
   <data name="CannotMoveToSameStore" xml:space="preserve">
-    <value>You cannot move a certificate to the same store. </value>
+    <value>您無法將憑證移至相同的存放區。</value>
   </data>
   <data name="CannotCreateItem" xml:space="preserve">
-    <value>You cannot create an item other than certificate store. </value>
+    <value>您無法建立憑證存放區以外的項目。</value>
   </data>
   <data name="CannotCreateUserStore" xml:space="preserve">
-    <value>Creating certificate stores under CurrentUser is not supported. </value>
+    <value>不支援在 CurrentUser 下建立憑證存放區。</value>
   </data>
   <data name="CannotDeleteUserStore" xml:space="preserve">
-    <value>Deleting certificate stores under CurrentUser is not supported. </value>
+    <value>不支援在 CurrentUser 下刪除憑證存放區。</value>
   </data>
   <data name="InvalidDestStore" xml:space="preserve">
-    <value>The destination is not a valid store. </value>
+    <value>目的地不是有效的存放區。</value>
   </data>
   <data name="RemoveItemTemplate" xml:space="preserve">
-    <value>Item: {0} </value>
+    <value>項目: {0}</value>
   </data>
   <data name="RemoveStoreTemplate" xml:space="preserve">
-    <value>The store {0} is a built-in system store and cannot be deleted.</value>
+    <value>存放區 {0} 是內建的系統存放區，因此無法刪除。</value>
   </data>
   <data name="CannotRemoveContainer" xml:space="preserve">
-    <value>You cannot remove a certificate container. </value>
+    <value>您無法移除憑證容器。</value>
   </data>
   <data name="VerboseNoPrivateKey" xml:space="preserve">
-    <value>Private key skipped. The certificate has no private key association. </value>
+    <value>已跳過私密金鑰。此憑證沒有私密金鑰關聯。</value>
   </data>
   <data name="UINotAllowed" xml:space="preserve">
-    <value>The operation is on user root store and UI is not allowed. </value>
+    <value>此作業在使用者根存放區上進行，因此不允許 UI。</value>
   </data>
   <data name="RemoteErrorMessage" xml:space="preserve">
-    <value>. The following error may be a result of user credentials required on the remote machine. See Enable-WSManCredSSP Cmdlet help on how to enable and use CredSSP for delegation with PowerShell remoting. </value>
+    <value>。下列錯誤可能是遠端電腦需要使用者認證所導致。請參閱 Enable-WSManCredSSP Cmdlet 說明，了解如何透過 PowerShell 遠端功能啟用及使用 CredSSP 進行委派。</value>
   </data>
 </root>

--- a/src/Microsoft.WSMan.Management/resources/de/WsManResources.de.resx
+++ b/src/Microsoft.WSMan.Management/resources/de/WsManResources.de.resx
@@ -183,7 +183,7 @@ Möchten Sie die CredSSP-Authentifizierung aktivieren?</value>
     <value>Dieser Computer ist nicht für den Empfang von Anmeldeinformationen von einem Remoteclientcomputer konfiguriert.</value>
   </data>
   <data name="DisconnectFailure" xml:space="preserve">
-    <value>This command cannot be used from the current path. Move to root path of the provider using cd\ and run your command again.</value>
+    <value>Dieser Befehl kann vom aktuellen Pfad aus nicht verwendet werden. Wechseln Sie mit „cd\“ zum Stammpfad des Anbieters, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="CmdletNotAvailable" xml:space="preserve">
     <value>Dieses PowerShell-Cmdlet ist für Windows XP und Windows Server 2003 nicht verfügbar.</value>
@@ -305,7 +305,7 @@ Möchten Sie fortfahren?</value>
     <value>Die von Ihnen vorgenommenen Konfigurationsänderungen werden erst wirksam, nachdem der WinRM-Dienst auf „{0}“ neu gestartet wurde.</value>
   </data>
   <data name="ConnectFailure" xml:space="preserve">
-    <value>This command cannot be used from the current path. Move to root path of the provider using cd\ and run your command again.</value>
+    <value>Dieser Befehl kann vom aktuellen Pfad aus nicht verwendet werden. Wechseln Sie mit „cd\“ zum Stammpfad des Anbieters, und führen Sie den Befehl erneut aus.</value>
   </data>
   <data name="Description" xml:space="preserve">
     <value>Dieses PowerShell-Snap-In enthält Cmdlets, z. B. Get-WSManInstance und Set-WSManInstance, die vom PowerShell-Host zum Verwalten von WSMan-Vorgängen verwendet werden.</value>

--- a/src/System.Management.Automation/resources/cs/CoreClrStubResources.cs.resx
+++ b/src/System.Management.Automation/resources/cs/CoreClrStubResources.cs.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentIllegalEnvVarName" xml:space="preserve">
-    <value>Environment variable name cannot contain equal character.</value>
+    <value>Název proměnné prostředí nemůže obsahovat znak rovná se.</value>
   </data>
   <data name="ArgumentLongEnvVarValue" xml:space="preserve">
-    <value>Environment variable name or value is too long.</value>
+    <value>Název nebo hodnota proměnné prostředí je příliš dlouhá.</value>
   </data>
   <data name="ArgumentStringFirstCharIsZero" xml:space="preserve">
-    <value>The first char in the string is the null character.</value>
+    <value>První znak v řetězci je nulový znak.</value>
   </data>
   <data name="ArgumentStringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
+    <value>Řetězec nemůže mít nulovou délku.</value>
   </data>
   <data name="CannotGetComputerName" xml:space="preserve">
-    <value>Computer name could not be obtained.</value>
+    <value>Název počítače se nepovedlo získat.</value>
   </data>
   <data name="CannotGetDomainName" xml:space="preserve">
-    <value>Current user's domain name could not be obtained.</value>
+    <value>Název domény aktuálního uživatele se nepovedlo získat.</value>
   </data>
   <data name="UnknownErrorNumber" xml:space="preserve">
-    <value>Unknown error "{0}".</value>
+    <value>Neznámá chyba {0}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/CredentialAttributeStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/CredentialAttributeStrings.cs.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CredentialAttribute_Prompt_Caption" xml:space="preserve">
-    <value>PowerShell credential request</value>
+    <value>Žádost o přihlašovací údaje k PowerShellu</value>
   </data>
   <data name="CredentialAttribute_Prompt" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Zadejte vaše přihlašovací údaje.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/ErrorCategoryStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/ErrorCategoryStrings.cs.resx
@@ -121,7 +121,7 @@
     <value>CloseError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>Bylo zjištěno zablokování: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
     <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
@@ -214,6 +214,6 @@
     <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>Nerozpoznaná kategorie chyby {4}: ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/EtwLoggingStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/EtwLoggingStrings.cs.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>Příkaz {0} je {1}.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>Stav prostředí se změnil z {0} na {1}.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>Plně kvalifikované ID chyby = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>Chybová zpráva = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>Doporučená akce = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>Zásady spouštění</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>Příkaz úlohy = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>ID úlohy = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>ID instance úlohy = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>Umístění úlohy = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>Název úlohy = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>Stav úlohy = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        Název příkazu = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        Cesta příkazu = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        Typ příkazu = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        Verze prostředí = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        ID hostitele = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        Název hostitele = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        Hostitelská aplikace = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        Verze hostitele = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        ID kanálu = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        ID runspace = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        Název skriptu = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        Pořadové číslo = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        Závažnost = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        ID prostředí Shell = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        Čas = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        Uživatel = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        Připojený uživatel = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>Úloha NULL</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>Název poskytovatele</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>Poskytovatel {0} změnil stav na {1}.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>Spouštění skriptů je {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>Proměnná {0} se změnila z {1} na {2}.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>Proměnná {0} se změnila na {1}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/ExperimentalFeatureStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/ExperimentalFeatureStrings.cs.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>Nenašla se žádná experimentální funkce, která by odpovídala názvu {0}.</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>Povolení a zakázání experimentálních funkcí se projeví až po příštím spuštění PowerShellu.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/FileSystemProviderStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/FileSystemProviderStrings.cs.resx
@@ -118,240 +118,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvokeItemAction" xml:space="preserve">
-    <value>Invoke Item</value>
+    <value>Vyvolat položku</value>
   </data>
   <data name="InvokeItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Položka: {0}</value>
   </data>
   <data name="RemoveItemActionFile" xml:space="preserve">
-    <value>Remove File</value>
+    <value>Odebrat soubor</value>
   </data>
   <data name="RemoveItemActionDirectory" xml:space="preserve">
-    <value>Remove Directory</value>
+    <value>Odebrat adresář</value>
   </data>
   <data name="CopyItemActionFile" xml:space="preserve">
-    <value>Copy File</value>
+    <value>Kopírovat soubor</value>
   </data>
   <data name="CopyItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Položka: {0} Cíl: {1}</value>
   </data>
   <data name="CopyItemActionDirectory" xml:space="preserve">
-    <value>Copy Directory</value>
+    <value>Kopírovat adresář</value>
   </data>
   <data name="RenameItemActionFile" xml:space="preserve">
-    <value>Rename File</value>
+    <value>Přejmenovat soubor</value>
   </data>
   <data name="RenameItemActionDirectory" xml:space="preserve">
-    <value>Rename Directory</value>
+    <value>Přejmenovat adresář</value>
   </data>
   <data name="RenameItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Položka: {0} Cíl: {1}</value>
   </data>
   <data name="MoveItemActionFile" xml:space="preserve">
-    <value>Move File</value>
+    <value>Přesunout soubor</value>
   </data>
   <data name="MoveItemActionDirectory" xml:space="preserve">
-    <value>Move Directory</value>
+    <value>Přesunout adresář</value>
   </data>
   <data name="MoveItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Položka: {0} Cíl: {1}</value>
   </data>
   <data name="SetPropertyActionFile" xml:space="preserve">
-    <value>Set Property File</value>
+    <value>Nastavit vlastnost souboru</value>
   </data>
   <data name="SetPropertyActionDirectory" xml:space="preserve">
-    <value>Set Property Directory</value>
+    <value>Nastavit vlastnost adresáře</value>
   </data>
   <data name="SetPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1} Value: {2}</value>
+    <value>Položka: {0} Vlastnost: {1} Hodnota: {2}</value>
   </data>
   <data name="ClearPropertyActionFile" xml:space="preserve">
-    <value>Clear Property File</value>
+    <value>Vymazat vlastnost souboru</value>
   </data>
   <data name="ClearPropertyActionDirectory" xml:space="preserve">
-    <value>Clear Property Directory</value>
+    <value>Vymazat vlastnost adresáře</value>
   </data>
   <data name="ClearPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1}</value>
+    <value>Položka: {0} Vlastnost: {1}</value>
   </data>
   <data name="NewItemActionFile" xml:space="preserve">
-    <value>Create File</value>
+    <value>Vytvořit soubor</value>
   </data>
   <data name="NewItemActionDirectory" xml:space="preserve">
-    <value>Create Directory</value>
+    <value>Vytvořit adresář</value>
   </data>
   <data name="NewItemActionTemplate" xml:space="preserve">
-    <value>Destination: {0}</value>
+    <value>Cíl: {0}</value>
   </data>
   <data name="ClearContentActionFile" xml:space="preserve">
-    <value>Clear Content</value>
+    <value>Vymazat obsah</value>
   </data>
   <data name="ClearContentesourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Položka: {0}</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>Could not find item {0}.</value>
+    <value>Položku {0} se nepovedlo najít.</value>
   </data>
   <data name="CannotRemoveItem" xml:space="preserve">
-    <value>Cannot remove item {0}: {1}</value>
+    <value>Položku {0} nejde odebrat: {1}</value>
   </data>
   <data name="CannotRestoreAttributes" xml:space="preserve">
-    <value>Cannot restore attributes on item {0}: {1}</value>
+    <value>Atributy položky {0} nejde obnovit: {1}</value>
   </data>
   <data name="ItemDoesNotExist" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist.</value>
+    <value>Objekt v zadané cestě {0} neexistuje.</value>
   </data>
   <data name="DirectoryNotEmpty" xml:space="preserve">
-    <value>Directory {0} cannot be removed because it is not empty.</value>
+    <value>Adresář {0} nejde odebrat, protože není prázdný.</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>Typ není známým typem pro systém souborů. Je možné zadat jen file, directory nebo symboliclink.</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
-    <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>
+    <value>Cestu nejde zpracovat, protože zadaná cesta odkazuje na položku mimo basePath.</value>
   </data>
   <data name="DriveRootError" xml:space="preserve">
-    <value>The specified drive root "{0}" either does not exist, or it is not a folder.</value>
+    <value>Zadaný kořen jednotky {0} buď neexistuje, nebo není složkou.</value>
   </data>
   <data name="DirectoryExist" xml:space="preserve">
-    <value>An item with the specified name {0} already exists.</value>
+    <value>Položka se zadaným názvem {0} už existuje.</value>
   </data>
   <data name="DelimiterError" xml:space="preserve">
-    <value>A delimiter cannot be specified when reading the stream one byte at a time.</value>
+    <value>Při čtení proudu po jednom bajtu nejde zadat oddělovač.</value>
   </data>
   <data name="CopyError" xml:space="preserve">
-    <value>Cannot overwrite the item {0} with itself.</value>
+    <value>Položku {0} nejde přepsat sama sebou.</value>
   </data>
   <data name="RenameError" xml:space="preserve">
-    <value>Cannot rename the specified target, because it represents a path or device name.</value>
+    <value>Zadaný cíl nejde přejmenovat, protože představuje cestu nebo název zařízení.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property {0} does not exist or was not found.</value>
+    <value>Vlastnost {0} neexistuje nebo nebyla nalezena.</value>
   </data>
   <data name="PermissionError" xml:space="preserve">
-    <value>You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.</value>
+    <value>K provedení této operace nemáte dostatečná přístupová práva nebo je položka skrytá, systémová či jen pro čtení.</value>
   </data>
   <data name="AttributesNotSupported" xml:space="preserve">
-    <value>The attribute cannot be set because attributes are not supported. Only the following attributes can be set: Archive, Hidden, Normal, ReadOnly, or System.</value>
+    <value>Atribut nejde nastavit, protože atributy nejsou podporované. Nastavit je možné jen tyto atributy: Archive, Hidden, Normal, ReadOnly nebo System.</value>
   </data>
   <data name="CannotClearProperty" xml:space="preserve">
-    <value>The property cannot be cleared because the property is not supported. Only the Attributes property can be cleared.</value>
+    <value>Vlastnost nejde vymazat, protože není podporovaná. Vymazat je možné jen vlastnost Attributes.</value>
   </data>
   <data name="TargetCannotContainDeviceName" xml:space="preserve">
-    <value>Cannot process path '{0}' because the target represents a reserved device name.</value>
+    <value>Cestu {0} nejde zpracovat, protože cíl představuje rezervovaný název zařízení.</value>
   </data>
   <data name="EncodingNotUsed" xml:space="preserve">
-    <value>Encoding not used when '-AsByteStream' specified.</value>
+    <value>Při zadání -AsByteStream se kódování nepoužívá.</value>
   </data>
   <data name="ByteEncodingError" xml:space="preserve">
-    <value>Cannot proceed with byte encoding. When using byte encoding the content must be of type byte.</value>
+    <value>S kódováním po bajtech nejde pokračovat. Při použití kódování po bajtech musí být obsah typu byte.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>Cannot process the file because the file {0} was not found.</value>
+    <value>Soubor nejde zpracovat, protože soubor {0} nebyl nalezen.</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
-    <value>    Directory: </value>
+    <value>    Adresář: </value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
-    <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>
+    <value>Kódování souboru nejde zjistit. Zadané kódování {0} není podporované při čtení obsahu v opačném pořadí.</value>
   </data>
   <data name="AlternateDataStreamNotFound" xml:space="preserve">
-    <value>Could not open the alternate data stream '{0}' of the file '{1}'.</value>
+    <value>Alternativní datový proud {0} souboru {1} se nepovedlo otevřít.</value>
   </data>
   <data name="StreamAction" xml:space="preserve">
-    <value>Stream '{0}' of file '{1}'.</value>
+    <value>Proud {0} souboru {1}.</value>
   </data>
   <data name="RawAndWaitCannotCoexist" xml:space="preserve">
-    <value>The Raw and Wait parameters cannot be specified in the same command.</value>
+    <value>Parametry Raw a Wait nejde zadat ve stejném příkazu.</value>
   </data>
   <data name="InvalidDriveName" xml:space="preserve">
-    <value>To use the Persist switch parameter, the drive name must be supported by the operating system (for example, drive letters A-Z).</value>
+    <value>Pokud chcete použít přepínací parametr Persist, musí operační systém podporovat název jednotky (například písmena jednotek A–Z).</value>
   </data>
   <data name="PersistNotSupported" xml:space="preserve">
-    <value>When you use the Persist parameter, the root must be a file system location on a remote computer.</value>
+    <value>Při použití parametru Persist musí být kořen umístění systému souborů ve vzdáleném počítači.</value>
   </data>
   <data name="NoFirstLastWaitForRaw" xml:space="preserve">
-    <value>The '{0}' and '{1}' parameters cannot be specified in the same command.</value>
+    <value>Parametry {0} a {1} nejde zadat ve stejném příkazu.</value>
   </data>
   <data name="ItemNotDirectory" xml:space="preserve">
-    <value>A directory is required for the operation. The item '{0}' is not a directory.</value>
+    <value>Pro tuto operaci je vyžadován adresář. Položka {0} není adresář.</value>
   </data>
   <data name="NewItemActionJunction" xml:space="preserve">
-    <value>Create Junction</value>
+    <value>Vytvořit spojovací bod</value>
   </data>
   <data name="NewItemActionSymbolicLink" xml:space="preserve">
-    <value>Create Symbolic Link</value>
+    <value>Vytvořit symbolický odkaz</value>
   </data>
   <data name="ElevationRequired" xml:space="preserve">
-    <value>Administrator privilege required for this operation.</value>
+    <value>Tato operace vyžaduje oprávnění správce.</value>
   </data>
   <data name="NewItemActionHardLink" xml:space="preserve">
-    <value>Create Hard Link</value>
+    <value>Vytvořit pevný odkaz</value>
   </data>
   <data name="ItemNotFile" xml:space="preserve">
-    <value>A file is required for the operation. The item '{0}' is not a file.</value>
+    <value>Pro tuto operaci je vyžadován soubor. Položka {0} není soubor.</value>
   </data>
   <data name="HardLinkNotSupported" xml:space="preserve">
-    <value>Hard links are not supported for the specified path.</value>
+    <value>Pro zadanou cestu nejsou podporované pevné odkazy.</value>
   </data>
   <data name="SymbolicLinkNotSupported" xml:space="preserve">
-    <value>Symbolic links are not supported for the specified path.</value>
+    <value>Pro zadanou cestu nejsou podporované symbolické odkazy.</value>
   </data>
   <data name="CopyItemRemotelyProgressActivity" xml:space="preserve">
     <value>Kopírování {0} do {1}</value>
   </data>
   <data name="CopyItemRemoteDestinationIsFile" xml:space="preserve">
-    <value>Destination path {0} is a file that already exists on the target destination.</value>
+    <value>Cílová cesta {0} je soubor, který už v cílovém umístění existuje.</value>
   </data>
   <data name="CopyItemRemotelyFailed" xml:space="preserve">
-    <value>Failed to copy file {0} to remote target destination.</value>
+    <value>Soubor {0} se nepovedlo zkopírovat do vzdáleného cílového umístění.</value>
   </data>
   <data name="CopyItemRemotelyStatusDescription" xml:space="preserve">
     <value>Z: {0} do: {1}</value>
   </data>
   <data name="CopyItemRemotelyDestinationIsFile" xml:space="preserve">
-    <value>Cannot copy a directory '{0}' to file '{0}'</value>
+    <value>Adresář {0} nejde zkopírovat do souboru {0}</value>
   </data>
   <data name="CopyItemRemotelyFailedToGetDirectoryChildItems" xml:space="preserve">
-    <value>Failed to get directory {0} child items.</value>
+    <value>Nepovedlo se získat podřízené položky adresáře {0}.</value>
   </data>
   <data name="CopyItemRemotelyFailedToReadFile" xml:space="preserve">
-    <value>Failed to read remote file '{0}'.</value>
+    <value>Vzdálený soubor {0} se nepovedlo přečíst.</value>
   </data>
   <data name="CopyItemRemotelyFailedToValidateIfDestinationIsFile" xml:space="preserve">
-    <value>Cannot validate if remote destination {0} is a file.</value>
+    <value>Nejde ověřit, jestli je vzdálený cíl {0} soubor.</value>
   </data>
   <data name="CopyItemRemotelyFailedToCreateDirectory" xml:space="preserve">
-    <value>Failed to create directory '{0}' on remote destination.</value>
+    <value>Adresář {0} se ve vzdáleném cíli nepovedlo vytvořit.</value>
   </data>
   <data name="DriveMaxSizeError" xml:space="preserve">
-    <value>Maximum size for drive has been exceeded: {0}.</value>
+    <value>Byla překročena maximální velikost jednotky: {0}.</value>
   </data>
   <data name="SymlinkItemExists" xml:space="preserve">
-    <value>Cannot create link because the path already exists: {0}.</value>
+    <value>Odkaz nejde vytvořit, protože cesta už existuje: {0}.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Skip already-visited directory {0}.</value>
+    <value>Přeskakuje se už navštívený adresář {0}.</value>
   </data>
   <data name="TargetCannotBeSubdirectoryOfSource" xml:space="preserve">
-    <value>Destination path cannot be a subdirectory of the source or the source itself: {0}.</value>
+    <value>Cílová cesta nemůže být podadresářem zdroje ani samotným zdrojem: {0}.</value>
   </data>
   <data name="NewItemTargetIsSameAsLink" xml:space="preserve">
-    <value>The target and path cannot be the same.</value>
+    <value>Cíl a cesta nemůžou být stejné.</value>
   </data>
   <data name="CopyingLocalFileActivity" xml:space="preserve">
-    <value>Copied {0} of {1} files</value>
+    <value>Zkopírováno {0} z {1} souborů</value>
   </data>
   <data name="CopyingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} z {1} ({2:0.0} MB/s)</value>
   </data>
   <data name="RemovingLocalFileActivity" xml:space="preserve">
-    <value>Removed {0} of {1} files</value>
+    <value>Odebráno {0} z {1} souborů</value>
   </data>
   <data name="RemovingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} z {1} ({2:0.0} MB/s)</value>
   </data>
   <data name="JunctionAbsolutePath" xml:space="preserve">
-    <value>Creating a junction requires an absolute path for the target.</value>
+    <value>Vytvoření spojovacího bodu vyžaduje absolutní cestu k cíli.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/FormatAndOut_out_xxx.cs.resx
+++ b/src/System.Management.Automation/resources/cs/FormatAndOut_out_xxx.cs.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConsoleLineOutput_PagingPrompt" xml:space="preserve">
-    <value>&lt;SPACE&gt; next page; &lt;CR&gt; next line; Q quit</value>
+    <value>&lt;SPACE&gt; další stránka, &lt;CR&gt; další řádek, Q konec</value>
   </data>
   <data name="OutLineOutput_NullLineOutputParameter" xml:space="preserve">
-    <value>The value of LineOutput should not be null.</value>
+    <value>Hodnota LineOutput nesmí být null.</value>
   </data>
   <data name="OutLineOutput_InvalidLineOutputParameterType" xml:space="preserve">
-    <value>The lineOutput type {0} was not expected; LineOutput expects type {1}.</value>
+    <value>Typ {0} pro LineOutput nebyl očekáván. LineOutput očekává typ {1}.</value>
   </data>
   <data name="OutLineOutput_OutOfSequencePacket" xml:space="preserve">
-    <value>The object of type "{0}" is not valid or not in the correct sequence. This is likely caused by a user-specified "{1}" command which is conflicting with the default formatting.</value>
+    <value>Objekt typu {0} není platný nebo není ve správném pořadí. Pravděpodobně je to způsobeno uživatelsky zadaným příkazem {1}, který je v konfliktu s výchozím formátováním.</value>
   </data>
   <data name="OutFile_FileOpenFailure" xml:space="preserve">
-    <value>Cannot open file "{0}".</value>
+    <value>Nelze otevřít soubor{0}.</value>
   </data>
   <data name="OutFile_Action" xml:space="preserve">
-    <value>Output to File</value>
+    <value>Výstup do souboru</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/GetErrorText.cs.resx
+++ b/src/System.Management.Automation/resources/cs/GetErrorText.cs.resx
@@ -118,30 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ResourceBaseNameFailure" xml:space="preserve">
-    <value>Cannot load a resource with base name "{0}".</value>
+    <value>Nelze načíst prostředek se základním názvem {0}.</value>
   </data>
   <data name="ResourceIdFailure" xml:space="preserve">
-    <value>Cannot load a resource string with ID "{0}".</value>
+    <value>Nelze načíst řetězec prostředku s ID {0}.</value>
   </data>
   <data name="ActionPreferenceStop" xml:space="preserve">
-    <value>Running commands is prevented by Stop policy settings.</value>
+    <value>Nastavení zásady zastavení brání spouštění příkazů.</value>
   </data>
   <data name="AssemblyNotRegistered" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}" because an assembly was not registered.</value>
+    <value>Nelze načíst zprávu {0} {1} {2}, protože sestavení nebylo zaregistrováno.</value>
   </data>
   <data name="BadTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string format is not valid in template string "{3}".</value>
+    <value>Nelze načíst zprávu {0} {1} {2}. Formát řetězce šablony není platný v řetězci šablony {3}.</value>
   </data>
   <data name="BlankTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string exists, but its value is empty or blank.</value>
+    <value>Nelze načíst zprávu {0} {1} {2}. Řetězec šablony existuje, ale jeho hodnota je prázdná nebo prázdná obsahuje jen mezery.</value>
   </data>
   <data name="PipelineStoppedException" xml:space="preserve">
-    <value>The pipeline has been stopped.</value>
+    <value>Kanál se zastavil.</value>
   </data>
   <data name="ScriptCallDepthException" xml:space="preserve">
-    <value>The script failed due to call depth overflow.</value>
+    <value>Skript selhal kvůli přetečení hloubky volání.</value>
   </data>
   <data name="PipelineDepthException" xml:space="preserve">
-    <value>The pipeline failed due to call depth overflow.</value>
+    <value>Kanál selhal kvůli přetečení hloubky volání.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/HistoryStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/HistoryStrings.cs.resx
@@ -118,36 +118,36 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidIdGetHistory" xml:space="preserve">
-    <value>The identifier {0} is not a valid value for a History identifier. Specify a positive number, and then try again.</value>
+    <value>Identifikátor {0} není platnou hodnotou identifikátoru historie. Zadejte kladné číslo a zkuste to znovu.</value>
   </data>
   <data name="NoHistoryForId" xml:space="preserve">
-    <value>Cannot locate the history for Id {0}.</value>
+    <value>Nepodařilo se najít historii pro ID {0}.</value>
   </data>
   <data name="NoCountWithMultipleIds" xml:space="preserve">
-    <value>The count cannot be combined with multiple Ids.</value>
+    <value>Parametr Count nelze kombinovat s více ID.</value>
   </data>
   <data name="NoHistoryForCommandline" xml:space="preserve">
-    <value>Cannot locate the history for command line {0}.</value>
+    <value>Nepodařilo se najít historii pro příkazový řádek {0}.</value>
   </data>
   <data name="NoLastHistoryEntryFound" xml:space="preserve">
-    <value>Cannot locate most recent history.</value>
+    <value>Nepodařilo se najít nejnovější historii.</value>
   </data>
   <data name="InvokeHistoryLoopDetected" xml:space="preserve">
-    <value>The Invoke-History cmdlet is called repeatedly, in a loop.</value>
+    <value>Rutina Invoke-History je opakovaně volána ve smyčce.</value>
   </data>
   <data name="InvokeHistoryMultipleCommandsError" xml:space="preserve">
-    <value>Cannot process multiple history commands. You can only run a single command by using Invoke-History.</value>
+    <value>Nelze zpracovat více příkazů historie. Pomocí Invoke-History můžete spustit pouze jeden příkaz.</value>
   </data>
   <data name="AddHistoryInvalidInput" xml:space="preserve">
-    <value>Cannot add history because the input object has a format that is not valid.</value>
+    <value>Historii nelze přidat, protože vstupní objekt nemá platný formát.</value>
   </data>
   <data name="InvalidCountValue" xml:space="preserve">
-    <value>The identifier {0} is not valid. Specify a positive number, and then try again.</value>
+    <value>Identifikátor {0} není platný. Zadejte kladné číslo a zkuste to znovu.</value>
   </data>
   <data name="ClearHistoryWarning" xml:space="preserve">
-    <value>This command will clear all the entries from the session history.</value>
+    <value>Tento příkaz vymaže všechny položky z historie relace.</value>
   </data>
   <data name="NoCountWithMultipleCmdLine" xml:space="preserve">
-    <value>The count cannot be combined with multiple CommandLine parameters.</value>
+    <value>Parametr Count nelze kombinovat s více parametry CommandLine.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/InternalHostUserInterfaceStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/InternalHostUserInterfaceStrings.cs.resx
@@ -118,106 +118,106 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteDebugLineStoppedError" xml:space="preserve">
-    <value>WriteDebug stopped because the value of the DebugPreference variable was 'Stop'.</value>
+    <value>WriteDebug se zastavilo, protože hodnota proměnné DebugPreference byla Stop.</value>
   </data>
   <data name="UnsupportedPreferenceError" xml:space="preserve">
-    <value>The value {0} is not a supported ActionPreference value.</value>
+    <value>Hodnota {0} není podporovaná hodnota ActionPreference.</value>
   </data>
   <data name="PromptEmptyDescriptionsError" xml:space="preserve">
-    <value>The "{0}" parameter must contain at least one value.</value>
+    <value>Parametr {0} musí obsahovat alespoň jednu hodnotu.</value>
   </data>
   <data name="ShouldContinueYesLabel" xml:space="preserve">
-    <value>&amp;Yes</value>
+    <value>&amp;Ano</value>
   </data>
   <data name="ShouldContinueYesHelp" xml:space="preserve">
-    <value>Continue.</value>
+    <value>Pokračovat.</value>
   </data>
   <data name="ShouldContinueYesToAllLabel" xml:space="preserve">
-    <value>Yes to &amp;All</value>
+    <value>An&amp;o pro všechny</value>
   </data>
   <data name="ShouldContinueYesToAllHelp" xml:space="preserve">
-    <value>Continue, and do not ask again whether to continue in this session.</value>
+    <value>Pokračovat a v této relaci se už znovu neptat, jestli chcete pokračovat.</value>
   </data>
   <data name="ShouldContinueNoLabel" xml:space="preserve">
-    <value>&amp;No</value>
+    <value>&amp;Ne</value>
   </data>
   <data name="ShouldContinueNoHelp" xml:space="preserve">
-    <value>End the operation with an error.</value>
+    <value>Ukončit operaci s chybou.</value>
   </data>
   <data name="ShouldContinueNoToAllLabel" xml:space="preserve">
-    <value>No to A&amp;ll</value>
+    <value>Ne pro vš&amp;echny</value>
   </data>
   <data name="ShouldContinueNoToAllHelp" xml:space="preserve">
-    <value>End the operation with an error. Do not request to resume operation for this session.</value>
+    <value>Ukončit operaci s chybou. V této relaci nepožadovat obnovení operace.</value>
   </data>
   <data name="ShouldContinueSuspendLabel" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Pozastavit</value>
   </data>
   <data name="ShouldContinueSuspendHelp" xml:space="preserve">
-    <value>Pause the current operation and enter a command prompt. Type "exit" to resume the paused operation.</value>
+    <value>Pozastavit aktuální operaci a přejít na příkazový řádek. Pozastavenou operaci obnovíte zadáním exit.</value>
   </data>
   <data name="ShouldContinuePromptMessage" xml:space="preserve">
-    <value>Continue with this operation?</value>
+    <value>Pokračovat v této operaci?</value>
   </data>
   <data name="DefaultChoice" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(výchozí hodnota je {0})</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(výchozí volby jsou {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Volba[{0}]: </value>
   </data>
   <data name="EmptyChoicesError" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>{0} musí mít alespoň jeden prvek.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>{0} musí být platný index do {1}. {2} není platný index.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Klávesovou zkratku nelze zpracovat, protože otazník (?) nelze použít jako klávesovou zkratku.</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>PODROBNÉ: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>UPOZORNĚNÍ: {0}</value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>LADIT: {0}</value>
   </data>
   <data name="HostNotTranscribing" xml:space="preserve">
-    <value>The host is not currently transcribing.</value>
+    <value>Hostitel momentálně nezaznamenává přepis.</value>
   </data>
   <data name="CommandStartTime" xml:space="preserve">
-    <value>Command start time: {0}</value>
+    <value>Čas spuštění příkazu: {0}</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username: {1}
-RunAs User: {2}
-Configuration Name: {3}
-Machine: {4} ({5})
-Host Application: {6}
-Process ID: {7}
+Začátek přepisu PowerShellu
+Čas zahájení: {0:yyyyMMddHHmmss}
+Uživatelské jméno: {1}
+Uživatel RunAs: {2}
+Název konfigurace: {3}
+Počítač: {4} ({5})
+Hostitelská aplikace: {6}
+ID procesu: {7}
 {8}
 **********************</value>
   </data>
   <data name="MinimalTranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
+Začátek přepisu PowerShellu
+Čas zahájení: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+Konec přepisu PowerShellu
+Čas ukončení: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InvalidTranscriptFilePath" xml:space="preserve">
-    <value>File path {0} resolves to a directory.</value>
+    <value>Cesta k souboru {0} odkazuje na adresář.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/Metadata.cs.resx
+++ b/src/System.Management.Automation/resources/cs/Metadata.cs.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>Atributy pro {0} nejde inicializovat: {1}</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>Argument nejde ověřit, protože jeho typ {0} není stejný typ ({1}) jako maximální a minimální limity parametru. Ověřte, že je argument typu {1}, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>Argument {0} nejde ověřit, protože jeho hodnota není větší než nula.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>Argument {0} nejde ověřit, protože jeho hodnota není větší nebo rovna nule.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>Argument {0} nejde ověřit, protože jeho hodnota není menší než nula.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>Argument {0} nejde ověřit, protože jeho hodnota není menší nebo rovna nule.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>Zadaný minimální rozsah ({0}) nejde přijmout, protože není stejného typu jako zadaný maximální rozsah ({1}). Aktualizujte atribut ValidateRange pro parametr.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>Typy parametrů MaxRange a MinRange nejde přijmout. Oba parametry musí být objekty implementující rozhraní IComparable.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>Zadaný maximální rozsah nejde přijmout, protože je menší než zadaný minimální rozsah. Aktualizujte atribut ValidateRange pro parametr.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>Argument {0} je větší než maximální povolený rozsah {1}. Zadejte argument menší nebo rovný {1} a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>Argument {0} je menší než minimální povolený rozsah {1}. Zadejte argument větší nebo rovný {1} a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>Argument {0} neodpovídá vzoru {1}. Zadejte argument odpovídající {1} a příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>Atribut ValidateCount nejde použít u parametru, který není pole. Buď atribut z parametru odeberte, nebo nastavte parametr jako pole.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>Požadovaný počet hodnot parametru: {0}. Počet zadaných hodnot: {1}.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>Parametr vyžaduje nejméně {0} a nejvýše {1} hodnot. Počet zadaných hodnot: {2}.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>Zadaný maximální počet argumentů parametru je menší než zadaný minimální počet argumentů. Aktualizujte atribut ValidateCount pro parametr.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>Zadaná maximální délka argumentu ve znacích je kratší než zadaná minimální délka argumentu ve znacích. Aktualizujte atribut ValidateLength pro parametr.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>Atribut ValidateLength nejde použít u parametru, který není typu string nebo string[]. Nastavte parametr jako typ string nebo string[].</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>Délka argumentu ve znacích ({1}) je příliš krátká. Zadejte argument s délkou větší nebo rovnou {0} a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>Délka argumentu ve znacích ({1}) je příliš dlouhá. Zadejte argument s délkou menší nebo rovnou {0} a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>Argument {0} nepatří do sady {1} zadané atributem ValidateSet. Zadejte argument, který je v sadě, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>Generátor platných hodnot vrátil hodnotu null.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>{0} selhalo u vlastnosti {1} {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>Příkaz nejde získat ani spustit. Byl překročen maximální počet sad parametrů pro tento příkaz.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>Argument nejde zpracovat, protože jeho hodnota není řetězec. Hodnoty argumentů parametrů se zadaným atributem ArgumentTransformationAttribute by měly být řetězce.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>Proměnnou nejde ověřit, protože hodnota {1} není platná hodnota pro proměnnou {0}.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>Atribut nejde přidat, protože proměnná {0} s hodnotou {1} by už nebyla platná.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>Argument je null. Zadejte platnou hodnotu argumentu a potom zkuste příkaz spustit znovu.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>Argument má hodnotu null nebo kolekce argumentů obsahuje prvek s hodnotou null. Zadejte kolekci, která neobsahuje žádné hodnoty null, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>Argument je null nebo prázdný. Zadejte argument, který není null ani prázdný, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>Argument je null, prázdný nebo kolekce argumentů obsahuje prvek s hodnotou null. Zadejte kolekci, která neobsahuje žádné hodnoty null, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>Argument je null, prázdný nebo obsahuje jen prázdné znaky. Zadejte argument, který obsahuje jiné než prázdné znaky, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Prvek kolekce argumentů je null, prázdný nebo obsahuje jen prázdné znaky. Zadejte kolekci, která neobsahuje žádnou z těchto hodnot, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>Parametr s názvem {0} byl pro příkaz definován několikrát.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>Alias parametru nejde zadat, protože alias s názvem {0} už byl pro příkaz definován několikrát.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>Parametr {0} nejde zadat, protože je v konfliktu s aliasem stejného názvu pro parametr {1}.</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>Ověřovací skript {1} pro argument s hodnotou {0} nevrátil výsledek True. Zjistěte, proč ověřovací skript selhal, a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>Argument {0} neobsahuje platnou verzi PowerShellu. Zadejte platné číslo verze a potom příkaz zkuste znovu.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>Argument {0} nejde ověřit, protože nejde o platný název proměnné.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>Typ převodu úlohy musí být odvozený z IAstToScriptBlockConverter.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>Argument cesty není platný. Zadejte argument cesty typu string.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>Jednotka {0} v argumentu cesty nepatří do sady schválených jednotek: {1}. Zadejte argument cesty se schválenou jednotkou.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>Argument cesty obsahuje neplatné znaky.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>Argument cesty nemá kořenovou jednotku.  Zadejte úplný argument cesty s kořenovou jednotkou.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>Argument parametru {0} nemůže mít hodnotu null ani prázdný řetězec.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Člen výčtu {0} není platná hodnota parametru {1}. Zadejte jednoho z těchto členů a zkuste to znovu: {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>Vstup nejde zpracovat. Argument {0} není důvěryhodný.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>Selhání kontroly atributu ValidateTrustedData</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>Argument parametru {0} není důvěryhodný a v režimu Constrained Language neprojde kontrolou atributu parametru ValidateTrustedData.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/MiniShellErrors.cs.resx
+++ b/src/System.Management.Automation/resources/cs/MiniShellErrors.cs.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UpdateNotSupportedForConfigurationCategory" xml:space="preserve">
-    <value>The update is not supported for the runspace configuration category {0}. </value>
+    <value>Aktualizace není podporována pro kategorii konfigurace prostředí runspace {0}. </value>
   </data>
   <data name="UpdateAssemblyErrors" xml:space="preserve">
-    <value>The following errors occurred when updating the assembly list for the runspace: {0}.</value>
+    <value>Při aktualizaci seznamu sestavení pro prostředí runspace došlo k následujícím chybám: {0}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/Modules.cs.resx
+++ b/src/System.Management.Automation/resources/cs/Modules.cs.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Zadaný modul {0} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Zadaný modul {0} verze {1} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Zadaná hodnota MaximumVersion {0} nebyla správná. Pokud používáte *, MaximumVersion podporuje jen jeden znak * a ten musí být vždy na konci hodnoty MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Zadaný modul {0} s MaximumVersion {1} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Zadaný modul {0} s MinimumVersion {1} a MaximumVersion {2} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion {0} by neměla být vyšší než MaximumVersion {1}.</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>Sestavení {0} nebylo načteno, protože nebylo nalezeno žádné sestavení s tímto názvem. Ověřte název sestavení a zkuste to znovu.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Modul ke zpracování {0}, uvedený v poli {1} manifestu modulu {2}, nebyl zpracován, protože v žádném adresáři modulů nebyl nalezen platný modul.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Pro modul {0} nebyl vrácen žádný vlastní objekt, protože parametr -AsCustomObject je možné použít jen s moduly skriptů.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Manifest modulu {0} se nepovedlo zpracovat, protože nejde o platný soubor manifestu modulu PowerShellu. Odeberte nepovolené prvky: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Zpracováním souboru manifestu modulu {0} nevznikl platný objekt manifestu. Upravte soubor tak, aby obsahoval platný manifest modulu PowerShellu. Platný manifest můžete vytvořit pomocí rutiny New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Modul {0} nejde importovat, protože jeho manifest obsahuje jednoho nebo více neplatných členů. Platní členové manifestu jsou ({1}). Odeberte neplatné členy ({2}) a potom zkuste modul importovat znovu.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>Tabulka hash popisující modul obsahuje jednoho nebo více neplatných členů. Platní členové jsou ({0}). Odeberte neplatné členy ({1}) a zkuste to znovu.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Modul {0} nejde načíst, protože byl překročen limit vnoření modulů. Moduly je možné vnořit jen do {1} úrovní. Vyhodnoťte a změňte pořadí načítání modulů, aby se nepřekročil limit vnoření, a potom zkuste skript spustit znovu.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Člen ModuleVersion není v manifestu modulu přítomný. Tento člen musí existovat a musí mu být přiřazeno číslo verze ve tvaru :n.n.n.n:. Přidejte chybějící člen do souboru {0}.</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Člen {0} není v souboru manifestu modulu {2} platný: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>Verze {0} modulu {1} nesplňuje požadavek na minimální verzi {2}. Ověřte, že je číslo verze podporované, a potom zkuste modul znovu načíst.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>Verze PowerShellu v tomto počítači je {0}. Modul {1} vyžaduje ke spuštění minimálně PowerShell verze {2}. Ověřte, že máte nainstalovanou minimální požadovanou verzi PowerShellu, a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Člen NestedModules manifestu modulu nejde použít, pokud je člen ModuleToProcess binární modul. Upravte soubor manifestu modulu v umístění {0} a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Člen {0} v manifestu modulu není platný: {1}. Ověřte, že je pro toto pole v souboru {2} zadaná platná hodnota.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Cesta k manifestu modulu {0} není platná. Hodnota argumentu Path musí odkazovat na jeden soubor s příponou .psd1. Změňte hodnotu argumentu Path tak, aby odkazovala na platný soubor psd1, a potom to zkuste znovu.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>Klíč ModuleVersion v manifestu modulu {0} určuje verzi modulu {1}, která neodpovídá názvu složky verze v umístění {2}. Změňte hodnotu klíče ModuleVersion tak, aby odpovídala názvu složky verze.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Zadaná položka NestedModule {0} v manifestu modulu {1} není platná. Po aktualizaci této položky platnými hodnotami to zkuste znovu.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Zadaná položka RequiredAssemblies {0} v manifestu modulu {1} není platná. Po aktualizaci této položky platnými hodnotami to zkuste znovu.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Zadaná položka FileList {0} v manifestu modulu {1} není platná. Po aktualizaci této položky platnými hodnotami to zkuste znovu.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Zadaná položka RequiredModules {0} v manifestu modulu {1} není platná. Po aktualizaci této položky platnými hodnotami to zkuste znovu.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Zadaná položka ModuleList {0} v manifestu modulu {1} není platná. Po aktualizaci této položky platnými hodnotami to zkuste znovu.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Manifest modulu {0} je zadaný s klíčem CompatiblePSEditions, který se podporuje jen v PowerShellu verze 5.1 nebo novější. Aktualizujte hodnotu klíče PowerShellVersion na 5.1 nebo novější a zkuste to znovu.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>Zadaná hodnota {0} pro CompatiblePSEditions obsahuje duplicitní názvy edic PowerShellu. Po odebrání duplicitních názvů edic PowerShellu to zkuste znovu.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>Verze zadaná v klíči ModuleVersion se shoduje s názvem složky verze.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Složka verze {0} pod modulem {1} se přeskakuje, protože neobsahuje platný soubor manifestu modulu.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Člen ModuleName v tabulce hash popisující tento modul neexistuje.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Členy ModuleVersion, MaximumVersion a RequiredVersion v tabulce hash popisující tento modul neexistují. Jeden z těchto tří členů musí existovat a musí mu být přiřazeno číslo verze ve formátu n.n.n.n.</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Požadovaný modul {1} není načtený. Načtěte modul nebo ho odeberte z RequiredModules v souboru {0}.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Požadovaný modul {1} s GUID {2} není načtený. Načtěte modul nebo ho odeberte z RequiredModules v souboru {0}.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Požadovaný modul {1} verze {2} není načtený. Načtěte modul nebo ho odeberte z RequiredModules v souboru {0}.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Požadovaný modul {1} s MaximumVersion {2} není načtený. Načtěte modul nebo ho odeberte z RequiredModules v souboru {0}.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Požadovaný modul {1} s MinimumVersion {2} a MaximumVersion {3} není načtený. Načtěte modul nebo ho odeberte z RequiredModules v souboru {0}.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Modul {0} s ModuleVersion {1} nejde najít.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Modul {0} s RequiredVersion {1} nejde najít.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Modul {0} s MaximumVersion {1} nejde najít.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Modul {0} s ModuleVersion {1} a MaximumVersion {2} nejde najít.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Modul {0} nejde najít.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Nebyly odebrány žádné moduly. Ověřte, že je zadání modulů k odebrání správné a že tyto moduly v runspace existují.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Člen {0}, který byl importován z modulu {1}, nejde odebrat z tohoto důvodu: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Modul {0} nejde odebrat, protože je jen pro čtení. Pokud chcete odebrat moduly jen pro čtení, přidejte do příkazu parametr Force.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Modul {0} nejde odebrat, protože je označený jako konstanta. Modul nejde odebrat, pokud je označený jako konstanta.</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Modul {0} nejde odebrat, protože ho vyžaduje {1}. Pokud chcete modul odebrat, přidejte do příkazu parametr Force.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Rutinu Export-ModuleMember je možné volat jen z modulu.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>Přípona {0} není platná přípona modulu. Podporované přípony modulů jsou .dll, .ps1, .psm1, .psd1 a .cdxml. Opravte příponu a potom zkuste soubor {1} přidat znovu.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Tuto operaci nejde provést s binárním modulem. Je možné ji provést jen s modulem skriptu.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Soubor {0} není povolený, protože nemá příponu .ps1.</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Neznámá</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Všechna práva vyhrazena.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Odebírá se importovaná funkce {0}.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Odebírá se importovaný alias {0}.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Odebírá se importovaná proměnná {0}.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Načítá se modul z cesty {0}.</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Načítá se {0} z cesty {1}.</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Načítá se soubor skriptu {0} pomocí operátoru dot-source.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Importuje se funkce {0}.</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Importuje se rutina {0}.</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Importuje se alias {0}.</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Importuje se proměnná {0}.</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Exportuje se rutina {0}.</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Exportuje se funkce {0}.</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Exportuje se alias {0}.</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Exportuje se proměnná {0}.</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Názvy některých importovaných příkazů z modulu {0} obsahují neschválená slovesa, takže se můžou hůř vyhledávat. Příkazy s neschválenými slovesy najdete tak, že znovu spustíte příkaz Import-Module s parametrem Verbose. Seznam schválených sloves zobrazíte zadáním Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Příkaz {0} v modulu {1} byl importován, ale protože jeho název neobsahuje schválené sloveso, může se obtížně hledat. Seznam schválených sloves zobrazíte zadáním Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Příkaz {0} v modulu {2} byl importován, ale protože jeho název neobsahuje schválené sloveso, může se obtížně hledat. Navrhovaná alternativní slovesa jsou {1}.</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Některé názvy importovaných příkazů obsahují jeden nebo více z těchto zakázaných znaků: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Název příkazu {0} z modulu {1} obsahuje jeden nebo více z těchto zakázaných znaků: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Vytváří se soubor manifestu modulu {0}.</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (Cesta: {1})</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>Aktuální architektura procesoru je: {0}. Modul {1} vyžaduje tuto architekturu: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Název aktuálního hostitele PowerShellu je: {0}. Modul {1} vyžaduje tohoto hostitele PowerShellu: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>Aktuální hostitel PowerShellu je: {0} (verze {1}). Modul {2} vyžaduje ke spuštění minimálně hostitele PowerShellu verze {3}.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Manifest modulu pro modul {0}</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Vygeneroval(a): {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Vygenerováno: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Soubor modulu skriptu nebo binárního modulu přidružený k tomuto manifestu.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Moduly, které se mají importovat jako vnořené moduly modulu zadaného v RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>ID sloužící k jedinečné identifikaci tohoto modulu</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Autor tohoto modulu</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Společnost nebo dodavatel tohoto modulu</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Prohlášení o autorských právech k tomuto modulu</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Číslo verze tohoto modulu.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Popis funkcí poskytovaných tímto modulem</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Minimální verze prostředí PowerShell, kterou tento modul vyžaduje</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Minimální verze prostředí Common Language Runtime (CLR), kterou tento modul vyžaduje. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Moduly, které se musí importovat do globálního prostředí před importem tohoto modulu</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Soubory skriptů (.ps1), které se spustí v prostředí volajícího před importem tohoto modulu.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Soubory typů (.ps1xml), které se mají načíst při importu tohoto modulu</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Soubory formátu (.ps1xml), které se mají načíst při importu tohoto modulu</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Sestavení, která se musí načíst před importem tohoto modulu</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Seznam všech souborů zahrnutých v tomto modulu</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Soukromá data, která se mají předat modulu zadanému v RootModule/ModuleToProcess. Můžou obsahovat také tabulku hash PSData s dalšími metadaty modulu používanými PowerShellem.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Značky použité na tento modul. Pomáhají s vyhledáváním modulů v online galeriích.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>Adresa URL hlavního webu tohoto projektu.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>Adresa URL licence pro tento modul.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>Adresa URL ikony představující tento modul.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Poznámky k verzi tohoto modulu</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Řetězec předběžné verze tohoto modulu</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Příznak určující, jestli modul vyžaduje výslovný souhlas uživatele s instalací, aktualizací nebo uložením</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Externí závislé moduly tohoto modulu</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Konec tabulky hash {0}</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>Pokud chcete vytvořit manifest modulu s hodnotami parametrů Tags, ProjectUri, LicenseUri, IconUri nebo ReleaseNotes, musí být hodnota parametru PrivateData tabulka hash. Odeberte hodnoty parametrů Tags, ProjectUri, LicenseUri, IconUri nebo ReleaseNotes, nebo obsah PrivateData uzavřete do tabulky hash.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData by měla být definována jako tabulka hash, ale tento manifest modulu ji definuje jako objekt. Zvažte uzavření obsahu PrivateData do tabulky hash. Díky tomu budete moct později přidat do manifestu modulu vlastnosti Tags, ProjectUri, LicenseUri, IconUri a ReleaseNotes.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Zadaná hodnota {0} není platná. Zkuste to znovu s platnou hodnotou.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Funkce, které se mají z tohoto modulu exportovat. Kvůli nejlepšímu výkonu nepoužívejte zástupné znaky ani položku neodstraňujte. Pokud se nemají exportovat žádné funkce, použijte prázdné pole.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Aliasy, které se mají z tohoto modulu exportovat. Kvůli nejlepšímu výkonu nepoužívejte zástupné znaky ani položku neodstraňujte. Pokud se nemají exportovat žádné aliasy, použijte prázdné pole.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Rutiny, které se mají z tohoto modulu exportovat. Kvůli nejlepšímu výkonu nepoužívejte zástupné znaky ani položku neodstraňujte. Pokud se nemají exportovat žádné rutiny, použijte prázdné pole.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Proměnné, které se mají z tohoto modulu exportovat</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Prostředky DSC, které se mají z tohoto modulu exportovat</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Podporované PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Architektura procesoru (None, X86, Amd64) vyžadovaná tímto modulem</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Seznam všech modulů zahrnutých v tomto modulu</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Minimální verze Microsoft .NET Frameworku, kterou tento modul vyžaduje. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Název hostitele PowerShellu vyžadovaného tímto modulem</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Minimální verze hostitele PowerShellu vyžadovaná tímto modulem</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>Identifikátor URI HelpInfo tohoto modulu</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Protože modul {0} poskytuje v aktuální relaci PowerShellu jednotku PSDrive, nebyly odebrány žádné moduly. Změňte aktuálního poskytovatele PSDrive a potom zkuste moduly odebrat znovu.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Rutina {0} nebyla importována, protože v aktuálním oboru existuje člen se stejným názvem.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Alias {0} nebyl importován, protože v aktuálním oboru existuje člen se stejným názvem.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Funkce {0} nebyla importována, protože v aktuálním oboru existuje člen se stejným názvem.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Proměnná {0} nebyla importována, protože v aktuálním oboru existuje člen se stejným názvem.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>Zástupné znaky nejsou v členech ModuleToProcess, RootModule ani NestedModules v manifestu modulu {0} povolené.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Modul {0} je základní modul PowerShellu. Pokud chcete odebrat základní moduly, přidejte do příkazu parametr Force.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Manifest modulu nemůže obsahovat současně členy ModuleToProcess a RootModule. V souboru manifestu modulu v umístění {0} odeberte jeden z těchto členů a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Člen ModuleToProcess manifestu modulu je zastaralý. Místo něj použijte člen RootModule.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Výchozí předpona pro příkazy exportované z tohoto modulu. Výchozí předponu můžete přepsat pomocí Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Parametry Global a Scope nejde zadat současně. Odeberte jeden z těchto parametrů a potom zkuste příkaz spustit znovu.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Požadovaný modul {0} není načtený. Modul {0} má požadovaný modul {1} uvedený v manifestu modulu {2}, který odkazuje na cyklickou závislost.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Požadovaný modul {0} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Některé příkazy z modulu {0} nejde importovat přes CimSession. Pokud chcete získat všechny příkazy, ověřte, že je na vzdáleném serveru povolená vzdálená správa PowerShellu, a potom zkuste přidat parametr PSSession do rutiny Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Modul {0} je načtený ve Windows PowerShellu pomocí vzdálené relace {1}. Upozorňujeme, že veškerý vstup a výstup příkazů z tohoto modulu bude ve formě deserializovaných objektů. Pokud chcete tento modul načíst do PowerShellu, použijte syntaxi Import-Module -SkipEditionCheck.</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Byla zjištěna verze Windows PowerShellu {0}. K načítání modulů pomocí funkce kompatibility s Windows PowerShellem je vyžadován Windows PowerShell 5.1. Nainstalujte Windows Management Framework (WMF) 5.1 z adresy https://aka.ms/WMF5Download a povolte tak tuto funkci.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Načtení modulu {0} pomocí funkce kompatibility s Windows PowerShellem blokuje nastavení WindowsPowerShellCompatibilityModuleDenyList v konfiguračním souboru PowerShellu.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Modul {0} nejde importovat přes CimSession. Zkuste použít parametr PSSession rutiny Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>Hodnota architektury procesoru {0} není podporovaná. Spusťte příkaz New-ModuleManifest znovu a pro architekturu procesoru zadejte jednu z těchto podporovaných hodnot výčtu: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>Rutina Get-Module spuštěná vůči vzdálenému počítači může jen vypsat dostupné moduly. Přidejte do příkazu parametr ListAvailable a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Modul {0} nebyl importován, protože modul snap-in {0} už byl importován.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>Zástupné znaky nejsou v členu RequiredAssemblies v manifestu modulu {0} povolené.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>Hodnota klíče {0} v {1} je {2} a modul má vnořené moduly. Když je kořenovým modulem soubor CDXML, příkaz Import-Module selže, protože příkazy ve vnořených modulech nejde exportovat. Přesuňte soubor CDXML do klíče NestedModules a zkuste příkaz znovu.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Chyba vzdáleného příkazu: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Nepovedlo se vygenerovat proxy pro vzdálený modul {0}. {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Nepovedlo se zpracovat vzdálený modul {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Nepovedlo se přijmout data modulu ze vzdálené relace CimSession. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Požadovaný modul {0} s GUID {1} a verzí {2} nebyl načten, protože v žádném adresáři modulů nebyl nalezen platný soubor modulu.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Na serveru CIM nebyl nalezen poskytovatel CIM pro zjišťování modulů. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Verzi Microsoft .NET Frameworku {0} nejde ověřit, protože není uvedená v seznamu povolených verzí.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Analyzuje se {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Připravují se moduly pro první použití.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Hledají se dostupné moduly</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Prohledává se sdílená složka UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Rutinu Get-Module je možné spustit vůči vzdálenému počítači jen pro názvy modulů, které neobsahují cestu. Parametr Name obsahuje prvek {0}, který se překládá na cestu. Aktualizujte parametr Name tak, aby neobsahoval prvky cesty, a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Spuštění rutiny Get-Module bez parametru ListAvailable není podporováno u názvů modulů, které obsahují cestu. Parametr Name obsahuje prvek {0}, který se překládá na cestu. Aktualizujte parametr Name tak, aby neobsahoval prvky cesty, a potom to zkuste znovu.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Zadaný modul {0} nebyl nalezen. Aktualizujte parametr Name tak, aby odkazoval na platnou cestu, a potom to zkuste znovu. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Vyplňuje se vlastnost RepositorySourceLocation pro modul {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Modul ke zpracování {0}, uvedený v poli {1} manifestu modulu {2}, nebyl zpracován. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Tento předpoklad platí jen pro edici PowerShell Desktop.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Modul {0} nepodporuje aktuální edici PowerShellu {1}. Podporované edice jsou {2}. Kompatibilitu tohoto modulu můžete ignorovat pomocí Import-Module -SkipEditionCheck.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Modul {0} podporuje edici PowerShellu {1} a nejde ho implicitně načíst pomocí funkce Kompatibilita s Windows, protože je v souboru nastavení zakázaná. Tento modul můžete načíst s Windows PowerShellem pomocí Import-Module -UseWindowsPowerShell nebo se ho pokusit načíst v aktuálním PowerShellu pomocí Import-Module -SkipEditionCheck.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Pro experimentální funkci deklarovanou v manifestu modulu zadejte neprázdnou řetězcovou hodnotu.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Byl nalezen jeden nebo více neplatných názvů experimentálních funkcí: {0}. Název experimentální funkce modulu by měl dodržovat tento formát: ModuleName.FeatureName.</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Přepínací parametr -SkipEditionCheck nejde použít bez přepínacího parametru -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>Import souborů *.ps1 jako modulů není v režimu ConstrainedLanguage povolený.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Při načítání modulu skriptu {0} došlo k chybě, protože má jiný jazykový režim než manifest modulu. Jazykový režim manifestu je {1} a jazykový režim modulu je {2}. Ověřte, že jsou všechny soubory modulu podepsané nebo jinak zahrnuté v konfiguraci seznamu povolených aplikací.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Tento modul při exportu funkcí pomocí zástupných znaků používá operátor dot-source. To není povolené, pokud systém vynucuje ověřování aplikací.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Členy modulu nejde exportovat z modulu, který má jiný jazykový režim než spuštěná relace.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>V režimu ConstrainedLanguage nejde vytvořit nový modul.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Nejde najít předdefinovaný modul {0}, který je kompatibilní s edicí Core. Ověřte, že jsou předdefinované moduly PowerShellu dostupné. Obvykle jsou součástí balíčku PowerShellu v cestě modulu $PSHOME a PowerShell je potřebuje ke správnému fungování.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Rutina Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>Export členů modulu v režimu Constrained Language selže, protože modul {0} má jazykový režim {1}, který se liší od aktuální relace {2}.</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Implicitní export funkcí modulu</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>Implicitní export funkcí modulu {0} bude zamítnut, protože modul je důvěryhodný (běží v režimu Full Language), ale relace důvěryhodná není (běží v režimu Constrained Language). Osvědčeným postupem je vždy exportovat funkce modulu jednotlivě pod úplným názvem.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Import souboru skriptu jako modulu</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>Import souboru skriptu {0} jako modulu nebude v režimu ConstrainedLanguage povolený.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Modul obsahuje operátor dot-source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>Import modulu {0} v režimu ConstrainedLanguage selže, protože modul exportuje funkce pomocí zástupných znaků a zároveň používá operátor dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>Funkce exportované modulem</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Modul {0} exportuje funkce pomocí zástupných znaků v názvech. Při spuštění v režimu Constrained Language se odeberou všechny názvy funkcí vnořených modulů.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>Rutina New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Novému modulu z nedůvěryhodné relace Constrained Language bude zablokováno poskytování bloku skriptu FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>Neshodné jazykové režimy modulu</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Načítá se závislý modul, který má jiný jazykový režim než nadřazený modul. V režimu Constrained Language to nebude povolené.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/NativeCP.cs.resx
+++ b/src/System.Management.Automation/resources/cs/NativeCP.cs.resx
@@ -118,30 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="IncorrectValueForCommandParameter" xml:space="preserve">
-    <value>ScriptBlock should only be specified as a value of the Command parameter.</value>
+    <value>ScriptBlock by měl být zadaný jen jako hodnota parametru Command.</value>
   </data>
   <data name="NoValueForCommandParameter" xml:space="preserve">
-    <value>No value was specified for the Command parameter.</value>
+    <value>Pro parametr Command nebyla zadána žádná hodnota.</value>
   </data>
   <data name="IncorrectValueForFormatParameter" xml:space="preserve">
-    <value>A value that is not valid ({6}) was specified for the {7} parameter. Valid values are Text and Xml.</value>
+    <value>Neplatná hodnota ({6}) byla zadána pro parametr {7}. Platné hodnoty jsou Text a Xml.</value>
   </data>
   <data name="NoValueForInputFormatParameter" xml:space="preserve">
-    <value>No value was specified for the InputFormat parameter. Valid values are Text and Xml.</value>
+    <value>Pro parametr InputFormat nebyla zadána žádná hodnota. Platné hodnoty jsou Text a Xml.</value>
   </data>
   <data name="NoValueForOutputFormatParameter" xml:space="preserve">
-    <value>No value was specified for the OutputFormat parameter. Valid values are text and XML.</value>
+    <value>Pro parametr OutputFormat nebyla zadána žádná hodnota. Platné hodnoty jsou text a XML.</value>
   </data>
   <data name="StringValueExpectedForFormatParameter" xml:space="preserve">
-    <value>The {6} parameter requires a string value.</value>
+    <value>Parametr {6} vyžaduje řetězcovou hodnotu.</value>
   </data>
   <data name="NoValuesSpecifiedForArgs" xml:space="preserve">
-    <value>No value was specified for the Args parameter.</value>
+    <value>Pro parametr Args nebyla zadána žádná hodnota.</value>
   </data>
   <data name="ParameterSpecifiedAlready" xml:space="preserve">
-    <value>The {6} parameter was already specified.</value>
+    <value>Parametr {6} už byl zadaný.</value>
   </data>
   <data name="CliXmlError" xml:space="preserve">
-    <value>Cannot process the XML from the '{0}' stream of '{1}': {2}</value>
+    <value>XML z proudu {0} objektu {1} nejde zpracovat: {2}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/PSConfigurationStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/PSConfigurationStrings.cs.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell přestal fungovat kvůli problému se zabezpečením: Konfigurační soubor nejde přečíst: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/SessionStateProviderBaseStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/SessionStateProviderBaseStrings.cs.resx
@@ -118,39 +118,39 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetItemAction" xml:space="preserve">
-    <value>Set Item</value>
+    <value>Nastavit položku</value>
   </data>
   <data name="SetItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Value: {1}</value>
+    <value>Položka: {0} Hodnota: {1}</value>
   </data>
   <data name="ClearItemAction" xml:space="preserve">
-    <value>Clear Item</value>
+    <value>Vymazat položku</value>
   </data>
   <data name="ClearItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Položka: {0}</value>
   </data>
   <data name="RemoveItemAction" xml:space="preserve">
-    <value>Remove Item</value>
+    <value>Odebrat položku</value>
   </data>
   <data name="RemoveItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Položka: {0}</value>
   </data>
   <data name="NewItemAction" xml:space="preserve">
-    <value>New Item</value>
+    <value>Nová položka</value>
   </data>
   <data name="NewItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Type: {1} Value: {2}</value>
+    <value>Položka: {0} Typ: {1} Hodnota: {2}</value>
   </data>
   <data name="CopyItemAction" xml:space="preserve">
-    <value>Copy Item</value>
+    <value>Kopírovat položku</value>
   </data>
   <data name="CopyItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Položka: {0} Cíl: {1}</value>
   </data>
   <data name="RenameItemAction" xml:space="preserve">
-    <value>Rename Item</value>
+    <value>Přejmenovat položku</value>
   </data>
   <data name="RenameItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} NewName: {1}</value>
+    <value>Položka: {0} Nový název: {1}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/SubsystemStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/SubsystemStrings.cs.resx
@@ -118,42 +118,42 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MultipleRegistrationNotAllowed" xml:space="preserve">
-    <value>The subsystem '{0}' does not allow more than one implementation to be registered.</value>
+    <value>Subsystém {0} neumožňuje registrovat více než jednu implementaci.</value>
   </data>
   <data name="ImplementationAlreadyRegistered" xml:space="preserve">
-    <value>The implementation with Id '{0}' was already registered for the subsystem '{1}'.</value>
+    <value>Implementace s ID {0} už je pro subsystém {1} zaregistrovaná.</value>
   </data>
   <data name="UnregistrationNotAllowed" xml:space="preserve">
-    <value>The subsystem '{0}' does not allow the unregistration of an implementation.</value>
+    <value>Subsystém {0} neumožňuje zrušení registrace implementace.</value>
   </data>
   <data name="NoImplementationRegistered" xml:space="preserve">
-    <value>No implementation was registered for the subsystem '{0}'.</value>
+    <value>Pro subsystém {0} nebyla zaregistrována žádná implementace.</value>
   </data>
   <data name="ImplementationNotFound" xml:space="preserve">
-    <value>A registered implementation with the Id '{0}' was not found.</value>
+    <value>Registrovaná implementace s ID {0} nebyla nalezena.</value>
   </data>
   <data name="SubsystemTypeUnknown" xml:space="preserve">
-    <value>The specified subsystem type '{0}' is unknown.</value>
+    <value>Zadaný typ subsystému {0} není znám.</value>
   </data>
   <data name="MustUseConcreteSubsystemType" xml:space="preserve">
-    <value>You must specify a concrete subsystem type instead of the base interface 'ISubsystem'.</value>
+    <value>Místo základního rozhraní ISubsystem musíte zadat konkrétní typ subsystému.</value>
   </data>
   <data name="SubsystemKindUnknown" xml:space="preserve">
-    <value>The specified subsystem kind '{0}' is unknown.</value>
+    <value>Zadaný druh subsystému {0} není znám.</value>
   </data>
   <data name="ConcreteSubsystemNotImplemented" xml:space="preserve">
-    <value>For the target subsystem kind '{0}', the specified subsystem instance needs to implement the corresponding concrete interface or abstract class '{1}'.</value>
+    <value>Pro cílový druh subsystému {0} musí zadaná instance subsystému implementovat odpovídající konkrétní rozhraní nebo abstraktní třídu {1}.</value>
   </data>
   <data name="InvalidSubsystemInfo" xml:space="preserve">
-    <value>The declared metadata for subsystem kind '{0}' is invalid. A subsystem that requires cmdlets or functions to be defined cannot allow multiple registrations because that would result in one implementation overwriting the commands defined by another implementation.</value>
+    <value>Deklarovaná metadata pro druh subsystému {0} nejsou platná. Subsystém, který vyžaduje definování rutin nebo funkcí, nemůže povolit více registrací, protože by to vedlo k tomu, že by jedna implementace přepsala příkazy definované jinou implementací.</value>
   </data>
   <data name="EmptyImplementationId" xml:space="preserve">
-    <value>The 'Id' property of an implementation for the subsystem '{0}' cannot be an empty GUID.</value>
+    <value>Vlastnost Id implementace pro subsystém {0} nesmí být prázdný identifikátor GUID.</value>
   </data>
   <data name="NullOrEmptyImplementationName" xml:space="preserve">
-    <value>The 'Name' property of an implementation for the subsystem '{0}' cannot be null or an empty string.</value>
+    <value>Vlastnost Name implementace pro subsystém {0} nesmí mít hodnotu null ani být prázdným řetězcem.</value>
   </data>
   <data name="NullOrEmptyImplementationDescription" xml:space="preserve">
-    <value>The 'Description' property of an implementation for the subsystem '{0}' cannot be null or an empty string.</value>
+    <value>Vlastnost Description implementace pro subsystém {0} nesmí mít hodnotu null ani být prázdným řetězcem.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/cs/TransactionStrings.cs.resx
+++ b/src/System.Management.Automation/resources/cs/TransactionStrings.cs.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>Transakci nelze použít. Žádná transakce není aktivní.</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>Transakci nelze potvrdit. Žádná transakce není aktivní.</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>Transakci nelze vrátit zpět, protože není aktivní žádná transakce.</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>Transakci nelze vrátit zpět. Transakce již byla potvrzena.</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>Transakci nelze potvrdit. Transakce již byla potvrzena.</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Transakci nelze potvrdit. Transakce byla vrácena zpět nebo vypršel časový limit.</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>Transakci nelze vrátit zpět. Transakce již byla vrácena zpět nebo vypršel časový limit.</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>Nelze nastavit aktivní transakci. Nebyla vytvořena žádná transakce.</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>Nelze nastavit aktivní transakci. Aktivní transakce byla vrácena zpět nebo vypršel časový limit.</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>Tato rutina vyžaduje aktivní transakci. Aktuální transakce již byla potvrzena nebo vrácena zpět.</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>Tato rutina vyžaduje transakci. Spusťte příkaz znovu s parametrem -UseTransaction.</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>Transakci nelze použít. Nebyla spuštěna žádná transakce.</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>Transakci nelze použít. Transakce byla potvrzena.</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Transakci nelze použít. Transakce byla vrácena zpět nebo vypršel časový limit.</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>Transakci nelze použít. Vypršel časový limit transakce.</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>Základní transakce nebyla nastavena.</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>Základní transakce není aktivní.</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>Základní transakci nelze nastavit po vytvoření jiných transakcí.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/Authenticode.de.resx
+++ b/src/System.Management.Automation/resources/de/Authenticode.de.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>Die Datei {0} kann nicht geladen werden, weil Sie sich entschieden haben, diese Software jetzt nicht auszuführen.</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>Die Datei {0} kann nicht geladen werden, weil Sie sich entschieden haben, keine Software von diesem Herausgeber auszuführen.</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>Die Datei {0} wird von {1} veröffentlicht. Dieser Herausgeber ist auf Ihrem System explizit nicht vertrauenswürdig. Das Skript wird nicht auf dem System ausgeführt. Führen Sie den Befehl „get-help about_signing“ aus, um weitere Informationen zu erhalten.</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>Die Datei {0} kann nicht geladen werden, weil das Ausführen von Skripten auf diesem System deaktiviert ist. Weitere Informationen finden Sie unter about_Execution_Policies unter https://go.microsoft.com/fwlink/?LinkID=135170.</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>Die Datei {0} kann nicht geladen werden. {1}.</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>Die Datei {0} kann nicht geladen werden, da ihr Vorgang durch Richtlinien für Softwareeinschränkungen blockiert wird, z. B. durch Richtlinien, die mithilfe der Gruppenrichtlinie erstellt wurden.</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>Die Datei {0} kann nicht geladen werden, da ihr Inhalt nicht gelesen werden konnte.</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>Code kann nicht signiert werden. Das angegebene Zertifikat ist nicht zum Codesignieren geeignet.</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>Code kann nicht signiert werden. Die TimeStamp-Server-URL muss im Format http://&lt;server url&gt; oder https://&lt;server url&gt; vollqualifiziert sein.</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>Code kann nicht signiert werden. Der Hashalgorithmus wird nicht unterstützt.</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>Möchten Sie Software von diesem nicht vertrauenswürdigen Herausgeber ausführen?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>Die Datei {0} wird von {1} veröffentlicht und ist in Ihrem System nicht vertrauenswürdig. Führen Sie nur Skripte von vertrauenswürdigen Herausgebern aus.</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>Software {0} wird von einem unbekannten Herausgeber veröffentlicht. Es wird empfohlen, diese Software nicht auszuführen.</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>Sicherheitswarnung</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>Nur Skripte ausführen, denen Sie vertrauen. Skripte aus dem Internet können zwar nützlich sein, aber dieses Skript kann ihren Computer möglicherweise beschädigen. Wenn Sie diesem Skript vertrauen, verwenden Sie das Cmdlet „Unblock-File“, um die Ausführung des Skripts ohne diese Warnmeldung zuzulassen. Möchten Sie {0} ausführen?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>Ni&amp;e ausführen</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>Skript jetzt nicht von diesem Herausgeber ausführen und mich in Zukunft nicht auffordern, dieses Skript auszuführen. Zukünftige Versuche, dieses Skript auszuführen, führen zu einem stillen Fehler.</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>Nicht &amp;ausführen</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Skript jetzt nicht von diesem Herausgeber ausführen und mich in Zukunft weiterhin auffordern, dieses Skript auszuführen.</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>Einmal &amp;ausführen</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Skript jetzt von diesem Herausgeber ausführen und mich in Zukunft weiterhin auffordern, dieses Skript auszuführen.</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>&amp;Immer ausführen</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>Skript jetzt von diesem Herausgeber ausführen und mich in Zukunft nicht auffordern, dieses Skript auszuführen.</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Anhalten</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>Halten Sie die aktuelle Pipeline an, und kehren Sie zur Eingabeaufforderung zurück. Geben Sie „Beenden“ ein, um den Vorgang fortzusetzen, wenn Sie fertig sind.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/CoreClrStubResources.de.resx
+++ b/src/System.Management.Automation/resources/de/CoreClrStubResources.de.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentIllegalEnvVarName" xml:space="preserve">
-    <value>Environment variable name cannot contain equal character.</value>
+    <value>Der Name der Umgebungsvariable darf kein Gleichheitszeichen enthalten.</value>
   </data>
   <data name="ArgumentLongEnvVarValue" xml:space="preserve">
-    <value>Environment variable name or value is too long.</value>
+    <value>Der Name oder Wert der Umgebungsvariable ist zu lang.</value>
   </data>
   <data name="ArgumentStringFirstCharIsZero" xml:space="preserve">
-    <value>The first char in the string is the null character.</value>
+    <value>Das erste Zeichen in der Zeichenfolge ist das Null-Zeichen.</value>
   </data>
   <data name="ArgumentStringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
+    <value>Die Länge der Zeichenfolge darf nicht Null sein.</value>
   </data>
   <data name="CannotGetComputerName" xml:space="preserve">
-    <value>Computer name could not be obtained.</value>
+    <value>Der Computername konnte nicht abgerufen werden.</value>
   </data>
   <data name="CannotGetDomainName" xml:space="preserve">
-    <value>Current user's domain name could not be obtained.</value>
+    <value>Der Domänenname des aktuellen Benutzers konnte nicht abgerufen werden.</value>
   </data>
   <data name="UnknownErrorNumber" xml:space="preserve">
-    <value>Unknown error "{0}".</value>
+    <value>Unbekannter Fehler „{0}“.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/DebuggerStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/DebuggerStrings.de.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>Variablenhaltepunkt bei „${0}“ (Zugriff auf {1})</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>Variablenhaltepunkt bei „{0}:${1}“ (Zugriff auf {2})</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>Zeilenhaltepunkt auf „{0}:{1}“</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>Zeilenhaltepunkt auf „{0}:{1}, {2}“</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>Befehlshaltepunkt auf „{0}“</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>Befehlshaltepunkt auf „{0}:{1}“</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>Haltepunkt „{0}“ wird nicht erreicht</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Einzelschritt (in Funktionen, Skripts usw. hinein)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Zur nächsten Anweisung springen (Funktionen, Skripts usw. überspringen)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Aus der aktuellen Funktion, dem Skript usw. herausspringen</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} Vorgang fortsetzen</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} Vorgang beenden und den Debugger schließen</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Aufrufliste „Get-PSCallStack“ anzeigen</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Quellcode für das aktuelle Skript auflisten.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Verwenden Sie „list“, um ab der aktuellen Zeile zu beginnen, „&lt;m&gt; auflisten“  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     , um ab Zeile &lt;m&gt; zu beginnen, und „&lt;m&gt; &lt;n&gt; auflisten“, um &lt;n&gt;  aufzulisten </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     Zeilen ab Zeile &lt;m&gt;</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Letzten Befehl wiederholen, wenn er {0}, {1} oder {2} war</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} zeigt diese Hilfemeldung an.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Anweisungen zum Anpassen der Debuggeraufforderung erhalten Sie mit „help about_prompt“.</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+Die aktuelle Sitzung unterstützt kein Debugging, der Vorgang wird fortgesetzt.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: Zeile {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>Der Quellcode ist nicht verfügbar.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>Die Startzeile muss eine positive ganze Zahl sein, die nicht größer als {0} ist.</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>Die Zeilenanzahl muss eine positive ganze Zahl sein.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
     <value>&lt;No file&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>bei {0}, {1}: Zeile {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>Der Debugger kann nur Befehle verarbeiten, wenn er sich im Zustand Stopped befindet.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>SetDebugAction ist für den lokalen Skriptdebugger nicht implementiert.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>Der Debugger kann keine Fortsetzungsaktion festlegen, da sich der Debugger in der Remotesitzung nicht im Zustand Stopped befindet.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>Der Job kann nicht debuggt werden, da der Debugger derzeit ausgelastet ist.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Der angegebene Auftrag und alle untergeordneten Aufträge wurden geprüft, aber es wurden keine Aufträge gefunden, die debuggt werden konnten.  Um einen Auftrag oder untergeordneten Auftrag zu debuggen, muss der Auftrag Debuggen unterstützen und sich im Ausführungszustand befinden.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>Der Debugger kann für den Schrittmodus nicht aktiviert werden, da der Debugmodus auf None festgelegt ist und der Debugger deaktiviert ist.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>Der Runspace kann nicht debuggt werden, da der Hostdebugger derzeit ausgelastet ist.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>Runspace kann nicht debuggt werden. Der Runspace-Debugger ist derzeit deaktiviert (DebugMode ist „None“).</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>Runspace kann nicht debuggt werden, wenn es sich nicht im Zustand Opened befindet. Dieser Runspace-Zustand ist „{0}“.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>Runspace kann nicht debuggt werden. Dem Runspace „{0}“ ist kein Debugger zugeordnet.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>Der Debugger wurde bereits außer Kraft gesetzt.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>Ein Debuggerobjekt kann nicht auf sich selbst gepusht werden.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>Der {0}-Befehl wird in der PowerShell-Version, die im Remoterunspace ausgeführt wird, für die Remoteverwendung nicht unterstützt.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>Prozess</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} Vorgang fortsetzen und Debugger trennen.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>Der Debuggerbefehl zum Trennen ist nicht anwendbar.  Der Trennbefehl gilt nur beim Debuggen von Aufträgen und Runspaces mit den Cmdlets „Debug-Job“ oder „Debug-Runspace“.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>Ungültige Runspace-ID: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>Runspace kann nicht abgerufen werden.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Ein Haltepunkt oder eine Haltepunktliste muss angegeben werden.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>Die BreakpointList enthielt ein Element, das kein Haltepunkt war.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/EtwLoggingStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/EtwLoggingStrings.de.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>Befehl {0} ist {1}.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>Der Engine-Zustand wurde von {0} in {1} geändert.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>Vollqualifizierte Fehler-ID = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>Fehlermeldung = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>Empfohlene Aktion = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>Ausführungsrichtlinie</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>Auftragsbefehl = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>Auftrags-ID = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>Auftragsinstanz-ID = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>Auftragsspeicherort = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>Auftragsname = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>Auftragszustand = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        Befehlsname = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        Befehlspfad = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        Befehlstyp = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        Engine-Version = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        Host-ID = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        Hostname = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        Hostanwendung = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        Hostversion = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        Pipeline-ID = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        Runspace-ID = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        Skriptname = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        Sequenznummer = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        Schweregrad = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        Shell-ID = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        Zeit = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        Benutzer = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        Verbundener Benutzer = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>NULL-Auftrag</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>Anbietername</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>Der Status des Anbieters {0} wurde in {1} geändert.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>Skriptausführung ist {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>Die Variable {0} wurde von {1} in {2} geändert.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>Die Variable {0} wurde in {1} geändert.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/ExtendedTypeSystem.de.resx
+++ b/src/System.Management.Automation/resources/de/ExtendedTypeSystem.de.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>Der Member „{0}“ ist bereits vorhanden.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>Der Member „{0}“ ist bereits in der Datei mit den erweiterten Typdaten vorhanden.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>Der Member „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>Ausnahme beim Festlegen von „{0}“: „{1}“</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>Ausnahme beim Abrufen von „{0}“: „{1}“</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>Die folgende Ausnahme ist beim Versuch aufgetreten, die Sammlung „{0}“ aufzulisten.</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>Auf den Member „{0}“ kann außerhalb eines PSObject nicht zugegriffen werden.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>Das aus der Typkonfiguration „{0}“ erstellte Element kann nicht geändert werden.</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>Der Membername „{0}“ ist reserviert.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>„{0}“ kann nicht geändert werden.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>Ausnahme beim Aufrufen von „{0}“ mit „{1}“ Argument(en): „{2}“</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>Beim Versuch, „{0}“ aufzurufen, um den Inhalt eines Objekts vom Typ „{1}“ zu extrahieren, ist eine Ausnahme aufgetreten: „{2}“</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>Für „{0}“ konnte keine Überladung mit der Argumentanzahl „{1}“ gefunden werden.</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>Es wurde keine geeignete generische Methodenüberladung für „{0}“ mit „{1}“ Typparametern und der Argumentanzahl „{2}“ gefunden.</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>Es wurden mehrere mehrdeutige Überladungen für „{0}“ und die Argumentanzahl „{1}“ gefunden.</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>Das Argument „{0}“ mit dem Wert „{1}“ für „{2}“ kann nicht in den Typ „{3}“ konvertiert werden: „{4}“</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>Der Get-Accessor für die Eigenschaft „{0}“ ist nicht verfügbar.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>Der Set-Accessor für die Eigenschaft „{0}“ ist nicht verfügbar.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>Die Setter-Methode muss „public“, „void“ und „static“ sein und zwei Parameter haben. Der erste Parameter sollte den PSObject-Typ aufweisen. Ein zweiter Parameter ist erforderlich, wenn auch eine Getter-Methode verfügbar ist, und sollte denselben Typ wie der Rückgabetyp der Getter-Methode haben.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>Die Getter-Methode muss „public“, „not void“, „static“ und mit einem Parameter vom Typ „PSObject“ versehen sein.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>CodeProperty sollte eine Getter- oder Setter-Methode verwenden.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>Aufgrund des Methodenformats kann keine Codemethode erstellt werden. Die Methode muss öffentlich und statisch sein und einen Parameter vom Typ PSObject haben.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>Der Alias mit dem Namen „{0}“ enthält einen Zyklus.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>Der Wert „{0}“ vom Typ „{1}“ kann nicht in den Typ „{2}“ konvertiert werden.</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>Der Wert vom Typ „{0}“ kann nicht in den Typ „{1}“ konvertiert werden.</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>Der Wert „{0}“ kann nicht in den Typ „{1}“ konvertiert werden. Fehler: „{2}“</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>Der Wert „{0}“ kann nicht in den Typ „{1}“ konvertiert werden, da für diese Aufzählung keine Kommas zulässig sind.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>Der Wert „{0}“ kann wegen ungültiger Enumerationswerte nicht in den Typ „{1}“ konvertiert werden. Geben Sie einen der folgenden Enumerationswerte an, und versuchen Sie es erneut. Die möglichen Enumerationswerte sind „{2}“.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>NULL kann wegen ungültiger Enumerationswerte nicht in den Typ „{0}“ konvertiert werden. Geben Sie einen der folgenden Enumerationswerte an, und versuchen Sie es erneut. Die möglichen Enumerationswerte sind „{1}“.</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>NULL kann nicht in den Typ „{0}“ konvertiert werden.</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>Der Wert kann nicht in den Typ „{0}“ konvertiert werden.  Fehler: „{1}“</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>Der Wert kann nicht in den Typ „System.String“ konvertiert werden.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>Ein Verweistyp wird als Argument erwartet.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>„{0}“ kann nicht verglichen werden, da es nicht IComparable implementiert.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>„{0}“ konnte nicht mit „{1}“ verglichen werden. Fehler: „{2}“</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>„{0}“ kann nicht mit „{1}“ verglichen werden, da die Objekte nicht denselben Typ haben oder das Objekt „{0}“ „{2}“ nicht implementiert.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>Der Wert „{0}“ kann nicht in den Typ „{1}“ konvertiert werden, da mindestens zwei Übereinstimmungen gefunden wurden ({2}, {3}) und für diese Enumeration nur eine Übereinstimmung zulässig ist.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>Der Wert „{0}“ kann nicht in den Typ „{1}“ konvertiert werden. Boolesche Parameter akzeptieren nur boolesche Werte und Zahlen wie $True, $False, 1 oder 0.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>Der Eigenschaftswert kann nicht abgerufen werden, da „{0}“ eine schreibgeschützte Eigenschaft ist.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>„{0}“ ist eine schreibgeschützte Eigenschaft.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>„{0}“ kann nicht festgelegt werden, da für das Festlegen von XmlNode-Eigenschaften nur Zeichenfolgen als Werte verwendet werden können.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>„{0}“ kann nicht festgelegt werden, da nur eindeutige Attribute oder eindeutige, nicht attributierte Blattknoten festgelegt werden können.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>Ein PSProperty- oder PSMethod-Objekt kann dieser Sammlung nicht hinzugefügt werden.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>Beim Laden der Datei mit den erweiterten Typdaten ist der folgende Fehler aufgetreten: {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Zeichenfolge „{0}“ aufgetreten.</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>Das Feld oder die Eigenschaft „{0}“ für den Typ „{1}“ unterscheidet sich von dem Feld oder der Eigenschaft „{2}“ nur durch die Groß- und Kleinschreibung. Der Typ muss der Common Language Specification (CLS) entsprechen.</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Typnamenhierarchie „{0}“ aufgetreten.</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>Beim Abrufen des Members „{1}“ ist die folgende Ausnahme aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>Beim Abrufen von Membern ist die folgende Ausnahme aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Lesestatus für die Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Schreibstatus für die Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Typs für die Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Zeichenfolgendarstellung für die Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Attribute für die Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Definitionen für die Methode „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Zeichenfolgendarstellung für die Methode „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Typs für die parametrisierte Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Lesestatus für die parametrisierte Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen des Schreibstatus für die parametrisierte Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Definitionen für die parametrisierte Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Abrufen der Zeichenfolgendarstellung für die parametrisierte Eigenschaft „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>Die Value-Eigenschaft für das PSMemberInfo-Objekt vom Typ „{0}“ kann nicht festgelegt werden.</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>Argument: „{0}“ sollte ein „{1}“ sein. Verwenden Sie „{2}“.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>Argument: „{0}“ darf kein {1} sein. {2} darf nicht verwendet werden.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>Die {0}-Eigenschaft wurde nicht gefunden.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>Der Eigenschaftswert kann nicht abgerufen oder festgelegt werden. Der Typ des Arguments „{0}“ sollte „{1}“ oder „{2}“ sein.</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>Der Wert für die Eigenschaft „{0}“ kann nicht festgelegt werden, da das Objekt den Typ „{1}“ statt „{2}“ aufweist.</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>Ausnahme beim Aufruf von „{0}“: „{1}“</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>„{0}“ ist kein gültiger Klassenpfad.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} ist kein gültiger Pfad.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>Der Adapter kann nicht feststellen, ob die Eigenschaft „{0}“ geändert werden kann.</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>Der Adapter kann nicht feststellen, ob die Eigenschaft „{0}“ abrufbar ist.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>Der Adapter kann den Wert der Eigenschaft „{0}“ nicht abrufen.</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>Der Adapter kann den Wert der Eigenschaft „{0}“ nicht festlegen.</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>Der Adapter kann den Typ der Eigenschaft „{0}“ nicht abrufen.</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>Der Adapter kann den Typ der Hierarchie von „{0}“ nicht abrufen.</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>Der Adapter kann die Eigenschaften von „{0}“ nicht abrufen.</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>Der Adapter kann die Eigenschaft „{0}“ für „{1}“ nicht abrufen.</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>Von „{0}“ wurde ein Null-Wert zurückgegeben.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>Die Eigenschaft „{0}“ wurde für das Objekt „{1}“ nicht gefunden. Die festlegbaren Eigenschaften sind: {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>Die Eigenschaft „{0}“ wurde für das Objekt „{1}“ nicht gefunden. Es ist keine festlegbare Eigenschaft verfügbar.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>Das Objekt vom Typ „{0}“ kann nicht erstellt werden. {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>Für den offenen generischen Typ „{0}“ können keine statischen Methoden aufgerufen und keine statischen Eigenschaften abgerufen werden.  Geben Sie die Typparameter an, und versuchen Sie es erneut.  Verwenden Sie zum Beispiel statt [System.Collections.Generic.HashSet``1]::CreateSetComparer() [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>Die folgende Ausnahme ist beim Erstellen des Attributs „{1}“ aufgetreten: „{0}“</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>Der Wert „{0}“ kann nicht in ein Zeichenfolgenarray konvertiert werden.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>Der Wert kann nicht in den Typ „{0}“ konvertiert werden. In diesem Sprachmodus werden nur Kerntypen unterstützt.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Eine Konvertierung in den ByRef-ähnlichen Typ „{0}“ ist nicht möglich. ByRef-ähnliche Typen werden in PowerShell nicht unterstützt.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Die Eigenschaft oder das Feld „{0}“ des ByRef-ähnlichen Typs „{1}“ kann nicht abgerufen oder festgelegt werden. ByRef-ähnliche Typen werden in PowerShell nicht unterstützt.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Die Methode „{0}“ des ByRef-ähnlichen Rückgabetyps „{1}“ kann nicht aufgerufen werden. ByRef-ähnliche Typen werden in PowerShell nicht unterstützt.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Es kann keine Instanz des ByRef-ähnlichen Typs „{0}“ erstellt werden. ByRef-ähnliche Typen werden in PowerShell nicht unterstützt.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Erweiterte Typsystem-Hashtabellenkonvertierung</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Die Typkonvertierung von „HashTable“ in „{0}“ ist im ConstrainedLanguage-Modus nicht zulässig.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Erweiterte Typsystem-Hashtabellenkonvertierung</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Die Typkonvertierung von „{0}“ in „{1}“ ist im ConstrainedLanguage-Modus nicht zulässig.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/Modules.de.resx
+++ b/src/System.Management.Automation/resources/de/Modules.de.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das angegebene Modul „{0}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das angegebene Modul „{0}“ mit MaximumVersion „{1}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Der angegebene Wert für MaximumVersion „{0}“ war falsch. Wenn Sie „*“ verwenden, unterstützt MaximumVersion nur ein „*“ und es muss immer am Ende von MaximumVersion stehen.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das angegebene Modul „{0}“ mit MaximumVersion „{1}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das angegebene Modul „{0}“ mit MinimumVersion „{1}“ und MaximumVersion „{2}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>Die MinimumVersion „{0}“ darf nicht größer als MaximumVersion „{1}“ sein.</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>Die Assembly „{0}“ wurde nicht geladen, da keine Assembly mit diesem Namen gefunden wurde. Überprüfen Sie den Assemblynamen, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Das zu verarbeitende Modul „{0}“, das im Feld „{1}“ des Modulmanifests „{2}“ aufgeführt ist, wurde nicht verarbeitet, da in keinem Modulverzeichnis ein gültiges Modul gefunden wurde.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Für das Modul „{0}“ wurde kein benutzerdefiniertes Objekt zurückgegeben, da der Parameter „-AsCustomObject“ nur mit Skriptmodulen verwendet werden kann.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Das Modulmanifest „{0}“ konnte nicht verarbeitet werden, da es keine gültige PowerShell-Modulmanifestdatei ist. Entfernen Sie die nicht zulässigen Elemente: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Die Verarbeitung der Modulmanifestdatei „{0}“ hat kein gültiges Manifestobjekt ergeben. Aktualisieren Sie die Datei so, dass sie ein gültiges PowerShell-Modulmanifest enthält. Ein gültiges Manifest kann mit dem New-ModuleManifest-Cmdlet erstellt werden.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Das „{0}“-Modul kann nicht importiert werden, da das zugehörige Manifest ein oder mehrere ungültige Elemente enthält. Die gültigen Manifestelemente sind ({1}). Entfernen Sie die ungültigen Elemente ({2}), und versuchen Sie dann erneut, das Modul zu importieren.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>Die Hashtabelle, die ein Modul beschreibt, enthält ein oder mehrere ungültige Elemente. Die gültigen Elemente sind ({0}). Entfernen Sie die ungültigen Elemente ({1}), und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Das Modul „{0}“ kann nicht geladen werden, da der Grenzwert für die Moduldarstellung überschritten wurde. Module können nur bis zu {1} Ebenen geschachtelt werden. Überprüfen Sie die Reihenfolge, in der Sie Module laden, und ändern Sie sie, um eine Überschreitung des Grenzwerts für die Schachtelung zu verhindern, und führen Sie dann Ihr Skript erneut aus.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Das Element „ModuleVersion“ ist im Modulmanifest nicht vorhanden. Dieses Element muss vorhanden sein und einer Versionsnummer im Format „n.n.n.n“ zugewiesen werden. Fügen Sie das fehlende Element der Datei „{0}“ hinzu.</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Das Element „{0}“ ist in der Modulmanifestdatei „{2}“ nicht gültig: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>Die Version „{0}“ des Moduls „{1}“ erfüllt die erforderliche Mindestversion „{2}“ nicht. Überprüfen Sie, ob die Versionsnummer unterstützt wird, und laden Sie das Modul dann erneut.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>Die PowerShell-Version auf diesem Computer ist „{0}“. Für die Ausführung des Moduls „{1}“ ist mindestens PowerShell-Version „{2}“ erforderlich. Vergewissern Sie sich, dass die erforderliche Mindestversion von PowerShell installiert ist, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Das Modulmanifestelement „NestedModules“ kann nicht verwendet werden, wenn das Element „ModuleToProcess“ ein Binärmodul ist. Bearbeiten Sie die Modulmanifestdatei unter „{0}“, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Das Element „{0}“ im Modulmanifest ist ungültig: {1}. Überprüfen Sie, ob in der Datei „{2}“ für dieses Feld ein gültiger Wert angegeben ist.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Der Pfad des Modulmanifests „{0}“ ist ungültig. Der Wert des Path-Arguments muss zu einer einzelnen Datei mit der Erweiterung „.psd1“ aufgelöst werden. Ändern Sie den Wert des Path-Arguments so, dass er auf eine gültige psd1-Datei verweist, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>Der Schlüssel ModuleVersion im Modulmanifest „{0}“ gibt die Modulversion „{1}“ an, die nicht mit dem Namen des Versionsordners unter „{2}“ übereinstimmt. Ändern Sie den Wert des Schlüssels „ModuleVersion“ so, dass er mit dem Namen des Versionsordners übereinstimmt.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Der angegebene NestedModule-Eintrag „{0}“ im Modulmanifest „{1}“ ist ungültig. Versuchen Sie es erneut, nachdem Sie diesen Eintrag mit gültigen Werten aktualisiert haben.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Der angegebene RequiredAssemblies-Eintrag „{0}“ im Modulmanifest „{1}“ ist ungültig. Versuchen Sie es erneut, nachdem Sie diesen Eintrag mit gültigen Werten aktualisiert haben.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Der angegebene NestedModule-Eintrag „{0}“ im Modulmanifest „{1}“ ist ungültig. Versuchen Sie es erneut, nachdem Sie diesen Eintrag mit gültigen Werten aktualisiert haben.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Der angegebene RequiredModules-Eintrag „{0}“ im Modulmanifest „{1}“ ist ungültig. Versuchen Sie es erneut, nachdem Sie diesen Eintrag mit gültigen Werten aktualisiert haben.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Der angegebene ModuleList-Eintrag „{0}“ im Modulmanifest „{1}“ ist ungültig. Versuchen Sie es erneut, nachdem Sie diesen Eintrag mit gültigen Werten aktualisiert haben.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Das Modulmanifest „{0}“ verwendet den Schlüssel CompatiblePSEditions, der nur in PowerShell Version 5.1 oder höher unterstützt wird. Aktualisieren Sie den Wert des Schlüssels PowerShellVersion auf „5.1“ oder höher, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>Der angegebene Wert „{0}“ für CompatiblePSEditions enthält doppelte PowerShell-Editionsnamen. Versuchen Sie es erneut, nachdem Sie die doppelten PowerShell-Editionsnamen entfernt haben.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>Die in der Schlüsselzeile „ModuleVersion“ angegebene Version entspricht dem Namen des Versionsordners.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Der Versionsordner „{0}“ unter Modul „{1}“ wird übersprungen, da er keine gültige Modulmanifestdatei enthält.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Das Element „ModuleName“ ist in der Hashtabelle, die dieses Modul beschreibt, nicht vorhanden.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Die Elemente „ModuleVersion“, „MaximumVersion“ und „RequiredVersion“ sind in der Hashtabelle, die dieses Modul beschreibt, nicht vorhanden. Mindestens eines dieser drei Elemente muss vorhanden sein und einer Versionsnummer im Format „n.n.n.n“ zugewiesen werden.</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Das erforderliche Modul „{1}“ wurde nicht geladen. Laden Sie das Modul, oder entfernen Sie es aus „RequiredModules“ in der Datei „{0}“.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Das erforderliche Modul „{1}“ mit der GUID „{2}“ ist nicht geladen. Laden Sie das Modul, oder entfernen Sie es aus „RequiredModules“ in der Datei „{0}“.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Das erforderliche Modul „{1}“ mit der Version „{2}“ ist nicht geladen. Laden Sie das Modul, oder entfernen Sie es aus „RequiredModules“ in der Datei „{0}“.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Das erforderliche Modul „{1}“ mit MaximumVersion „{2}“ ist nicht geladen. Laden Sie das Modul, oder entfernen Sie es aus „RequiredModules“ in der Datei „{0}“.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Das erforderliche Modul „{1}“ mit MinimumVersion „{2}“ und MaximumVersion „{3}“ wurde nicht geladen. Laden Sie das Modul, oder entfernen Sie es aus „RequiredModules“ in der Datei „{0}“.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Das Modul „{0}“ kann mit ModuleVersion „{1}“ nicht gefunden werden.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Das Modul „{0}“ kann mit RequiredVersion „{1}“ nicht gefunden werden.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Das Modul „{0}“ kann mit MaximumVersion „{1}“ nicht gefunden werden.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Das Modul „{0}“ mit ModuleVersion „{1}“ und MaximumVersion „{2}“ wurde nicht gefunden.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Das Modul „{0}“ kann nicht gefunden werden.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Es wurden keine Module entfernt. Stellen Sie sicher, dass die angegebenen zu entfernenden Module korrekt sind und dass diese Module im Runspace vorhanden sind.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Das Element „{0}“, das aus dem Modul „{1}“ importiert wurde, kann aus folgendem Grund nicht entfernt werden: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Das Modul „{0}“ kann nicht entfernt werden, da es schreibgeschützt ist. Fügen Sie Ihrem Befehl den Parameter „Erzwingen“ hinzu, um schreibgeschützte Module zu entfernen.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Das Modul „{0}“ kann nicht entfernt werden, da es als „Konstante“ gekennzeichnet ist. Ein Modul kann nicht entfernt werden, wenn es als „Konstante“ gekennzeichnet ist.</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Das Modul „{0}“ kann nicht entfernt werden, da es von „{1}“ benötigt wird. Fügen Sie dem Befehl den Parameter „Erzwingen“ hinzu, um das Modul zu entfernen.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Das Export-ModuleMember-Cmdlet kann nur innerhalb eines Moduls aufgerufen werden.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>Die Erweiterung „{0}“ ist keine gültige Modulerweiterung. Die unterstützten Modulerweiterungen sind „.dll“, „.ps1“, „.psm1“, „.psd1“ und „.cdxml“. Korrigieren Sie die Erweiterung, und versuchen Sie dann erneut, die Datei „{1}“ hinzuzufügen.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Dieser Vorgang kann nicht für ein Binärmodul ausgeführt werden. Er kann nur für ein Skriptmodul ausgeführt werden.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Die Datei „{0}“ ist nicht zulässig, da sie nicht die Erweiterung „.ps1“ hat.</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Unbekannt</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Alle Rechte vorbehalten.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Die importierte Funktion „{0}“ wird entfernt.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Das importierte Alias „{0}“ wird entfernt.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Die importierte Variable „{0}“ wird entfernt.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Das Modul wird aus dem Pfad „{0}“ geladen.</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>„{0}“ wird aus dem Pfad „{1}“ geladen.</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Die Skriptdatei „{0}“ wird per Dot-Sourcing geladen.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Die Funktion „{0}“ wird importiert.</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Das Cmdlet „{0}“ wird importiert.</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Das Alias „{0}“ wird importiert.</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Die Variable „{0}“ wird importiert.</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Das Cmdlet „{0}“ wird exportiert.</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Die Funktion „{0}“ wird exportiert.</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Das Alias „{0}“ wird exportiert.</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Die Variable „{0}“ wird exportiert.</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Die Namen einiger importierter Befehle aus dem Modul „{0}“ enthalten nicht genehmigte Verben, wodurch sie möglicherweise schwerer auffindbar sind. Um die Befehle mit nicht genehmigten Verben zu finden, führen Sie den Befehl „Import-Module“ erneut mit dem Parameter „Ausführlich“ aus. Geben Sie Get-Verb ein, um eine Liste der genehmigten Verben anzuzeigen.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Der Befehl „{0}“ im Modul „{1}“ wurde importiert, aber da sein Name kein genehmigtes Verb enthält, ist er möglicherweise schwer zu finden. Geben Sie Get-Verb ein, um eine Liste der genehmigten Verben anzuzeigen.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Der Befehl „{0}“ im Modul „ {2}“ wurde importiert, aber da sein Name kein genehmigtes Verb enthält, ist er möglicherweise schwer zu finden. Die vorgeschlagenen Alternativverben sind „{1}“.</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Einige importierte Befehlsnamen enthalten mindestens eines der folgenden eingeschränkten Zeichen: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Der Befehlsname „{0}“ aus dem Modul „{1}“ enthält mindestens eines der folgenden eingeschränkten Zeichen: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Die Modulmanifestdatei „{0}“ wird erstellt.</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (Pfad: „{1}“)</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>Die aktuelle Prozessorarchitektur ist: {0}. Das Modul „{1}“ erfordert die folgende Architektur: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Der Name des aktuellen PowerShell-Hosts ist: „{0}“. Das Modul „{1}“ erfordert den folgenden PowerShell-Host: „{2}“.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>Der aktuelle PowerShell-Host ist: „{0}“ (Version {1}). Das Modul „{2}“ erfordert zum Ausführen mindestens die PowerShell-Hostversion „{3}“.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Modulmanifest für das Modul „{0}“</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Generiert von: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Generiert am: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Skriptmodul- oder Binärmoduldatei, die diesem Manifest zugeordnet ist.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Module, die als geschachtelte Module des in RootModule/ModuleToProcess angegebenen Moduls importiert werden sollen</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>ID zum eindeutigen Identifizieren dieses Moduls</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Autor dieses Moduls</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Unternehmen oder Hersteller dieses Moduls</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Urheberrechtserklärung für dieses Modul</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Versionsnummer dieses Moduls</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Beschreibung der von diesem Modul bereitgestellten Funktionalität</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Von diesem Modul erforderliche Mindestversion der PowerShell-Engine</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Die für dieses Modul mindestens erforderliche Version der Common Language Runtime (CLR). {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Module, die vor dem Importieren dieses Moduls in die globale Umgebung importiert werden müssen</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Skriptdateien (.ps1), die vor dem Importieren dieses Moduls in der Umgebung des Aufrufenden ausgeführt werden.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Typdateien (.ps1xml), die beim Importieren dieses Moduls geladen werden sollen</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Formatdateien (.ps1xml), die beim Importieren dieses Moduls geladen werden sollen</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Assemblys, die vor dem Importieren dieses Moduls geladen werden müssen</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Liste aller mit diesem Modul paketierten Dateien</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Private Daten, die an das in RootModule/ModuleToProcess angegebene Modul übergeben werden. Diese können auch eine PSData-Hashtabelle mit zusätzlichen Modulmetadaten enthalten, die von PowerShell verwendet werden.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Tags, die auf dieses Modul angewendet werden Diese helfen bei der Modulermittlung in Onlinekatalogen.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>Eine URL zur Hauptwebsite für dieses Projekt.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>Eine URL zur Lizenz für dieses Modul.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>Eine URL zu einem Symbol, das dieses Modul darstellt.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>ReleaseNotes dieses Moduls</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Vorabversionszeichenfolge dieses Moduls</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Kennzeichen, das angibt, ob das Modul für die Installation/Aktualisierung/Speicherung eine explizite Zustimmung erfordert.</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Externe abhängige Module dieses Moduls</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Ende der {0}-Hashtabelle</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>Der Parameterwert „PrivateData“ muss eine Hashtabelle sein, um das Modulmanifest mit den folgenden Parameterwerten zu erstellen: Tags, ProjectUri, LicenseUri, IconUri oder ReleaseNotes. Entfernen Sie entweder die Parameterwerte Tags, ProjectUri, LicenseUri, IconUri oder ReleaseNotes, oder schließen Sie den Inhalt von PrivateData in eine Hashtabelle ein.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData sollte als Hashtabelle definiert werden, aber dieses Modulmanifest definiert es als Objekt. Erwägen Sie, den Inhalt von PrivateData in eine Hashtabelle einzuschließen. So können Sie dem Modulmanifest die Eigenschaften Tags, ProjectUri, LicenseUri, IconUri und ReleaseNotes später hinzufügen.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Der angegebene Wert „{0}“ ist ungültig. Wiederholen Sie den Vorgang mit einem gültigen Wert.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Zu exportierende Funktionen aus diesem Modul. Für optimale Leistung verwenden Sie keine Platzhalter, und löschen Sie den Eintrag nicht. Verwenden Sie ein leeres Array, wenn keine Funktionen exportiert werden sollen.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Zu exportierende Aliase aus diesem Modul. Verwenden Sie für eine optimale Leistung keine Platzhalter, und löschen Sie den Eintrag nicht. Verwenden Sie ein leeres Array, wenn keine Aliase exportiert werden sollen.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Zu exportierende Cmdlets aus diesem Modul. Für optimale Leistung verwenden Sie keine Platzhalter, und löschen Sie den Eintrag nicht. Verwenden Sie ein leeres Array, wenn keine Cmdlets exportiert werden sollen.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Aus diesem Modul zu exportierende Variablen</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Aus diesem Modul zu exportierende DSC-Ressourcen</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Unterstützte PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Von diesem Modul benötigte Prozessorarchitektur (None, X86, Amd64)</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Liste aller in diesem Modul enthaltenen Module</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Mindestversion von Microsoft .NET Framework, die von diesem Modul benötigt wird. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Name des PowerShell-Hosts, der von diesem Modul benötigt wird</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Von diesem Modul erforderliche Mindestversion des PowerShell-Hosts</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>HelpInfo-URI dieses Moduls</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Da das {0}-Modul das PSDrive in der aktuellen PowerShell-Sitzung bereitstellt, wurden keine Module entfernt. Ändern Sie den aktuellen PSDrive-Anbieter, und versuchen Sie dann erneut, Module zu entfernen.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Das Cmdlet „{0}“ wurde nicht importiert, da im aktuellen Bereich ein Element mit demselben Namen vorhanden ist.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Der Alias „{0}“ wurde nicht importiert, da im aktuellen Bereich ein Element mit demselben Namen vorhanden ist.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Die Funktion „{0}“ wurde nicht importiert, da im aktuellen Bereich ein Element mit demselben Namen vorhanden ist.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Die Variable „{0}“ wurde nicht importiert, da im aktuellen Bereich ein Element mit demselben Namen vorhanden ist.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>Platzhalterzeichen sind in den Elementen „ModuleToProcess“, „RootModule“ oder „NestedModules“ im Modulmanifest „{0}“ nicht zulässig.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Das Modul „{0}“ ist ein Kernmodul für PowerShell. Fügen Sie Ihrem Befehl den Parameter „Erzwingen“ hinzu, um Kernmodule zu entfernen.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Das Modulmanifest darf nicht gleichzeitig die Elemente „ModuleToProcess“ und „RootModule“ enthalten. Entfernen Sie eines dieser Elemente in der Modulmanifestdatei unter „{0}“, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Das Modulmanifestelement „ModuleToProcess“ ist veraltet. Verwenden Sie stattdessen das Element „RootModule“.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Standardpräfix für aus diesem Modul exportierte Befehle. Überschreiben Sie das Standardpräfix mit dem Import-Module-Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Die Parameter „Global“ und „Bereich“ können nicht zusammen angegeben werden. Entfernen Sie einen dieser Parameter, und führen Sie den Befehl dann erneut aus.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Das erforderliche Modul „{0}“ ist nicht geladen. Das Modul „{0}“ enthält im Modulmanifest „{1}“ ein requiredModule „{2}“, das auf eine zyklische Abhängigkeit verweist.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das erforderliche Modul „{0}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Einige Befehle aus dem Modul „{0}“ können nicht über eine CimSession importiert werden. Um alle Befehle zu erhalten, überprüfen Sie, ob die Remoteverwaltung von PowerShell auf dem Remoteserver aktiviert ist, und fügen Sie dann den Parameter „PSSession“ dem Import-Module-Cmdlet hinzu.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Das Modul „{0}“ wird in Windows PowerShell mit einer {1}-Remotesitzung geladen. Beachten Sie, dass alle Eingaben und Ausgaben von Befehlen aus diesem Modul deserialisierte Objekte sind. Wenn Sie dieses Modul in PowerShell laden möchten, verwenden Sie die Syntax „Import-Module -SkipEditionCheck“.</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Windows PowerShell-Version {0} erkannt. Zum Laden von Modulen mit der Windows PowerShell-Kompatibilitätsfunktion ist Windows PowerShell 5.1 erforderlich. Installieren Sie Windows Management Framework (WMF) 5.1 von https://aka.ms/WMF5Download, um diese Funktion zu aktivieren.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Das Modul „{0}“ ist vom Laden über die Windows PowerShell-Kompatibilitätsfunktion blockiert. Ursache ist die Einstellung „WindowsPowerShellCompatibilityModuleDenyList“ in der PowerShell-Konfigurationsdatei.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Das Modul {0} kann nicht über eine CimSession importiert werden. Verwenden Sie den Parameter „PSSession“ des Import-Module-Cmdlets.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>Der Wert von {0} für die Prozessorarchitektur wird nicht unterstützt. Führen Sie den New-ModuleManifest-Befehl erneut aus, und geben Sie einen der folgenden unterstützten Enumerationswerte für die Prozessorarchitektur an: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>Beim Ausführen des Get-Module-Cmdlets auf einem Remotecomputer können nur verfügbare Module aufgelistet werden. Fügen Sie dem Befehl den Parameter „ListAvailable“ hinzu, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Das Modul „{0}“ wurde nicht importiert, da das Snap-In „{0}“ bereits importiert wurde.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>Platzhalterzeichen sind im Element „RequiredAssemblies“ im Modulmanifest „{0}“ nicht zulässig.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>Der Wert des Schlüssels {0} in {1} ist {2}, und das Modul enthält geschachtelte Module. Wenn eine CDXML-Datei das Stammmodul ist, schlägt der Import-Module-Befehl fehl, da die Befehle in geschachtelten Modulen nicht exportiert werden können. Verschieben Sie die CDXML-Datei in den Schlüssel „NestedModules“, und versuchen Sie den Befehl erneut.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Fehler vom Remotebefehl: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Fehler beim Generieren von Proxys für das Remotemodul „{0}“. {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Fehler beim Verarbeiten des Remotemoduls {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Fehler beim Empfangen von Moduldaten aus der Remote-CimSession. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Das erforderliche Modul „{0}“ mit der GUID „{1}“ und der Version „{2}“ wurde nicht geladen, da in keinem Modulverzeichnis eine gültige Moduldatei gefunden wurde.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Auf dem CIM-Server wurde kein CIM-Anbieter für die Modulermittlung gefunden. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Die Microsoft .NET Framework-Version {0} kann nicht überprüft werden, da sie nicht in der Liste der zulässigen Versionen enthalten ist.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>{0} wird analysiert.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Die Module werden für die erste Verwendung vorbereitet.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Es wird nach verfügbaren Modulen gesucht.</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Die UNC-Freigabe „{0}“ wird durchsucht.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Das Ausführen des Get-Module-Cmdlets für einen Remotecomputer ist nur für Modulnamen möglich, die keinen Pfad enthalten. Der Name-Parameter enthält dieses Element „{0}“, das in einen Pfad aufgelöst wird. Aktualisieren Sie den Name-Parameter so, dass keine Pfadelemente enthalten sind, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Das Ausführen des Get-Module-Cmdlets ohne den ListAvailable-Parameter wird für Modulnamen, die einen Pfad enthalten, nicht unterstützt. Der Name-Parameter enthält dieses Element „{0}“, das in einen Pfad aufgelöst wird. Aktualisieren Sie den Name-Parameter so, dass keine Pfadelemente enthalten sind, und versuchen Sie es dann erneut.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Das angegebene Modul „{0}“ wurde nicht gefunden. Aktualisieren Sie den Name-Parameter, sodass er auf einen gültigen Pfad verweist, und versuchen Sie es dann erneut. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Die Eigenschaft „RepositorySourceLocation“ für das Modul „{0}“ wird aufgefüllt.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Das zu verarbeitende Modul „{0}“, das im Feld „{1}“ des Modulmanifests „{2}“ aufgeführt ist, wurde nicht verarbeitet. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Diese Voraussetzung gilt nur für die PowerShell Desktop-Edition.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Das Modul „{0}“ unterstützt die aktuelle PowerShell-Edition „{1}“ nicht. Die unterstützten Editionen sind „{2}“. Verwenden Sie „Import-Module -SkipEditionCheck“, um die Kompatibilität dieses Moduls zu ignorieren.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Das Modul „{0}“ unterstützt die PowerShell-Edition „{1}“ und kann nicht implizit mit der Windows Compatibility-Funktion geladen werden, da es in der Einstellungsdatei deaktiviert ist. Verwenden Sie „Import-Module -UseWindowsPowerShell“, um dieses Modul mit Windows PowerShell zu laden, oder „Import-Module -SkipEditionCheck“, um zu versuchen, das Modul mit der aktuellen PowerShell zu laden.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Für eine experimentelle Funktion, die im Modulmanifest deklariert ist, sollte ein nicht leerer Zeichenfolgenwert angegeben werden.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Es wurden ein oder mehrere ungültige Namen für experimentelle Funktionen gefunden: {0}. Ein Name für eine experimentelle Funktion eines Moduls sollte dieser Konvention folgen: „ModuleName.FeatureName“.</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Der Switch-Parameter „-SkipEditionCheck“ kann nicht ohne den Switch-Parameter „-ListAvailable“ verwendet werden.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>Das Importieren von *.ps1-Dateien als Module ist im ConstrainedLanguage-Modus nicht zulässig.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Beim Laden des Skriptmoduls „{0}“ ist ein Fehler aufgetreten, da es einen anderen Sprachmodus als das Modulmanifest hat. Der Sprachmodus des Manifests ist „{1}“, und der Sprachmodus des Moduls ist „{2}“. Stellen Sie sicher, dass alle Moduldateien signiert sind oder anderweitig Teil der Konfiguration der Zulassungsliste der App sind.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Dieses Modul verwendet den dot-source-Operator beim Exportieren von Funktionen mit Platzhalterzeichen, und dies ist nicht zulässig, wenn für das System die Anwendungsüberprüfung erzwungen wird.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Elemente eines Moduls können nicht exportiert werden, wenn das Modul einen anderen Sprachmodus als die ausführende Sitzung aufweist.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Es kann kein neues Modul erstellt werden, während sich die Sitzung im ConstrainedLanguage-Modus befindet.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Das integrierte Modul „{0}“, das mit der „Core“-Edition kompatibel ist, wurde nicht gefunden. Stellen Sie sicher, dass die integrierten PowerShell-Module verfügbar sind. Sie werden in der Regel mit dem PowerShell-Paket unter dem Modulpfad $PSHOME bereitgestellt und sind erforderlich, damit PowerShell ordnungsgemäß funktioniert.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Export-ModuleMember-Cmdlet</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>Das Exportieren von Modulelementen schlägt im Eingeschränkten Sprachmodus fehl, da das Modul „{0}“ einen Sprachmodus „{1}“ aufweist, der sich von der aktuellen Sitzung „{2}“ unterscheidet.</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Export impliziter Modulfunktionen</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>Der implizite Funktionsexport für das Modul „{0}“ wird verweigert, da es vertrauenswürdig ist (wird im Uneingeschränkten Sprachmodus ausgeführt), die Sitzung jedoch nicht vertrauenswürdig ist (wird im Eingeschränkten Sprachmodus ausgeführt). Es hat sich bewährt, Modulfunktionen immer einzeln unter dem vollständigen Namen zu exportieren.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Die Skriptdatei wird als Modul importiert.</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>Das Importieren der Skriptdatei „{0}“ als Modul ist im ConstrainedLanguage-Modus nicht zulässig.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Modul enthält dot-source-Operator</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>Der Import des Moduls „{0}“ schlägt im Eingeschränkten Sprachmodus fehl, da Funktionen mit Platzhalterzeichen exportiert werden und gleichzeitig der dot-source-Operator verwendet wird.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"Modulexportfunktionen</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Modul „{0}“ exportiert Funktionen mit Namensplatzhaltern. Alle Funktionsnamen aus geschachtelten Modulen werden im Eingeschränkten Sprachmodus entfernt.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"New-Module-Cmdlet</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Ein neues Modul aus einer nicht vertrauenswürdigen Eingeschränkten Sprachsitzung wird daran gehindert, den FullLanguage-Skriptblock bereitzustellen.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"Nicht übereinstimmende Modulsprachmodi</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Ein abhängiges Modul wird geladen, das einen anderen Sprachmodus als das übergeordnete Modul verwendet. Dies ist im Eingeschränkten Sprachmodus nicht zulässig.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/PSConfigurationStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/PSConfigurationStrings.de.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell funktioniert aufgrund eines Sicherheitsproblems nicht mehr: Die Konfigurationsdatei kann nicht gelesen werden: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/PathUtilsStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/PathUtilsStrings.de.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>Die Codierung „UTF-7“ ist veraltet. Verwenden Sie UTF-8.</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>Die Datei {0} ist bereits vorhanden und {1} wurde angegeben.</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Die Datei kann nicht geöffnet werden, da der aktuelle Anbieter ({0}) keine Datei öffnen kann.</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Der Vorgang kann nicht ausgeführt werden, da der Pfad in mehrere Dateien aufgelöst wurde. Dieser Befehl kann nicht für mehrere Dateien verwendet werden.</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Der Vorgang kann nicht ausgeführt werden, da der Wildcardpfad „{0}“ nicht in eine Datei aufgelöst wurde.</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>Unbekannte Codierung {0}; gültige Werte sind {1}.</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>Das Verzeichnis „{0}“ ist bereits vorhanden.  Verwenden Sie den -Force-Parameter, wenn Sie das Verzeichnis und die Dateien innerhalb des Verzeichnisses überschreiben möchten.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>Der Benutzermodulpfad ist nicht vorhanden, weshalb kein Modulordner für den angegebenen Modulnamen „{0}“ erstellt werden kann.</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>Das Modul {0} kann aufgrund der folgenden Ursachen nicht erstellt werden: {1}. Verwenden Sie ein anderes Argument für den Parameter „-OutputModule“ und wiederholen Sie den Vorgang.</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>Das Modul kann nicht geladen werden, da es mit einer inkompatiblen Version des {0} cmdlets generiert wurde. Generieren Sie das Modul mit dem {0} cmdlet aus der aktuellen Sitzung, und versuchen Sie erneut, das Modul zu laden.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/RemotingErrorIdStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/RemotingErrorIdStrings.de.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>Platzhalterzeichen werden für den FilePath-Parameter nicht unterstützt. Geben Sie einen Pfad ohne Platzhalterzeichen an.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>Ein {0}-Wert muss für die Sitzungsoption „{1}“ angegeben werden.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>Die maximale Anzahl von WS-Man-URI-Umleitungen, die beim Herstellen einer Verbindung mit einem Remotecomputer zulässig sind</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>Der WriteEvents-Parameter kann nicht ohne den Wait-Parameter verwendet werden.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>PowerShell-Remoting wird in der Windows Preinstallation Environment (WinPE) nicht unterstützt.</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>Von „{0}“ vorgenommene Änderungen werden erst wirksam, nachdem der WinRM-Dienst neu gestartet wurde.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0} muss möglicherweise den WinRM-Dienst neu starten, wenn eine Konfiguration mit diesem Namen kürzlich nicht registriert war. Bestimmte Systemdatenstrukturen sind dann möglicherweise noch zwischengespeichert. In diesem Fall kann ein Neustart von WinRM erforderlich sein.
+Alle WinRM-Sitzungen, die mit PowerShell-Sitzungskonfigurationen verbunden sind, z. B. Microsoft.PowerShell und Sitzungskonfigurationen, die mit dem Cmdlet „Register-PSSessionConfiguration“ erstellt wurden, werden getrennt.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>Sie befinden sich in einer Remotesitzung und haben die Force-Option ausgewählt. Dadurch kann der WinRM-Dienst neu gestartet werden. Wenn der WinRM-Dienst neu gestartet wird, wird diese Remotesitzung beendet, und für die Fortsetzung ist eine neue Sitzung erforderlich.</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>Der Parameter „-WriteJobInResults“ kann nicht ohne den Parameter „-Wait“ verwendet werden.</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>Der angegebene Eingabestream ist ungültig. Nur „{0}“ wird als Eingabestream unterstützt.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>Der angegebene Ausgabestreamsatz ist ungültig. Nur „{0}“ wird als Ausgabestream unterstützt.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>Der angegebene WSMAN_SENDER_DETAILS ist ungültig. Ein NULL-Wert für WSMAN_SENDER_DETAILS kann nicht verarbeitet werden.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>Der angegebene Shellkontext ist ungültig.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Ein NULL-Wert ist für „{0}“ mit der Plug-In-Methode „{1}“ nicht zulässig.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>Ein NULL-Wert ist für Eingabe- und Ausgabestreamgruppen nicht zulässig. „{0}“ und „{1}“ sind die unterstützten Eingabe- und Ausgabestreams.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Ein NULL-Wert ist für „{0}“ mit der Plug-In-Methode „{1}“ nicht zulässig.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Ein NULL-Wert ist für „{0}“ mit der Plug-In-Methode „{1}“ nicht zulässig.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>Der PowerShell-Plug-In-Vorgang wird beendet. Dies kann passieren, wenn der Hostdienst oder die Hostanwendung beendet wird.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Das PowerShell-Plug-In versteht die {0}-Option nicht. Stellen Sie sicher, dass der Client mit dem Build {1} und der Protokollversion {2} von PowerShell kompatibel ist.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Vom Client wird eine Option mit dem Namen „{0}“ erwartet. Stellen Sie sicher, dass der Client mit dem Build {1} und der Protokollversion {2} von PowerShell kompatibel ist.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Das PowerShell-Plug-In unterstützt die vom Client angeforderte Protokollversion {2} nicht.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>Im PowerShell-Plug-In ist beim Melden des Kontexts an den WSMan-Dienst ein schwerwiegender Fehler aufgetreten.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>Die verwaltete Serversitzung kann nicht erstellt werden.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>Im PowerShell-Plug-In ist beim Registrieren eines Wait-Handles für die Herunterfahrbenachrichtigung ein schwerwiegender Fehler aufgetreten.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>Die ausführbare Datei „{0}“ wurde nicht gefunden. Überprüfen Sie, ob das WOW64-Feature installiert ist.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>Der Windows PowerShell-Prozess kann nicht erstellt werden, da Windows PowerShell auf diesem Computer nicht gefunden wurde.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/de/RunspaceStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/RunspaceStrings.de.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>Der Runspacezustand ist für diesen Vorgang ungültig.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>Der Runspace kann nicht geöffnet werden, da der Runspace sich nicht im Zustand „BeforeOpen“ befindet. Der aktuelle Zustand des Runspaces ist „{0}“.</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Der Vorgang kann nicht ausgeführt werden, da sich der Runspac nicht im Zustand „Geöffnet“ befindet. Der aktuelle Zustand des Runspaces ist „{0}“.</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Die Pipeline kann nicht aufgerufen werden, da sich der Runspace nicht im Zustand „Opened“ (geöffnet) befindet. Der aktuelle Zustand des Runspaces ist „{0}“.</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>Der Pipelinezustand ist für diesen Vorgang ungültig.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>Die Pipeline kann nicht aufgerufen werden, da sie bereits aufgerufen wurde.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>Der gültige Wert für den Parameter ist PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>Die Pipeline enthält keinen Befehl.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>Die Pipeline wurde nicht ausgeführt, da bereits eine Pipeline ausgeführt wird. Pipelines können nicht gleichzeitig ausgeführt werden.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>Eine geschachtelte Pipeline kann nicht asynchron aufgerufen werden. Verwenden Sie die Invoke-Methode.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>Sie sollten eine geschachtelte Pipeline nur innerhalb einer ausgeführten Pipeline ausführen.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>Runspace kann nicht geschlossen werden, während ein SessionStateProxy-Methodenaufruf ausgeführt wird.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>Die Pipeline kann nicht aufgerufen werden, während ein SessionStateProxy-Methodenaufruf ausgeführt wird.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Ein SessionStateProxy-Methodenaufruf wird ausgeführt. Gleichzeitige SessionStateProxy-Methodenaufrufe sind nicht zulässig.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Eine Pipeline wird bereits ausgeführt. Gleichzeitige SessionStateProxy-Methodenaufrufe sind nicht zulässig.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Diese Eigenschaft kann nicht mehr geändert werden, nachdem der Runspace geöffnet wurde.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Beim Verarbeiten des Moduls „{0}“, das im InitialSessionState-Objekt zum Erstellen dieses Runspaces angegeben wurde, ist mindestens ein Fehler aufgetreten. Eine vollständige Liste der Fehler finden Sie in der Eigenschaft „ErrorRecords“. Der erste Fehler war: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>Die Threadoptionen können nur geändert werden, wenn der Apartmentzustand Multithreaded Apartment (MTA) ist, die aktuellen Optionen UseNewThread oder UseCurrentThread sind und der neue Wert ReuseThread ist.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>„{0}“ darf nicht FALSE sein, wenn der Sprachmodus „{1}“ oder „{2}“ ist.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>Sie können einen nur lokalen Runspace nicht trennen.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>Der Verbindungsvorgang wird für lokale Runspaces nicht unterstützt.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>Die Sitzung ist ausgelastet. Sie werden mit der Sitzung verbunden, sobald sie verfügbar ist. Um den Enter-PSSession-Befehl abzubrechen, drücken Sie STRG + C.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>Der Befehl kann nicht abgeschlossen werden. Skriptaufrufe werden in dieser Sitzungskonfiguration nicht unterstützt. Dies kann vorkommen, wenn sich die Sitzungskonfiguration im Nur-Sprachmodus befindet.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>Für lokale Runspaces können keine Vorgänge zum Trennen und Verbinden verwendet werden.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>Die Pipeline kann nicht verbunden werden, da sich der Runspace nicht im Zustand „Opened“ befindet.  Der aktuelle Zustand des Runspaces ist „{0}“.</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>RemoteRunspace kann nicht erstellt werden. Das angegebene RunspacePool-Objekt ist ungültig.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>Diesem Runspace ist kein Befehl mit getrennter Verbindung zugeordnet.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>Der Trennungsvorgang wird auf dem Remotecomputer nicht unterstützt. Damit das Trennen unterstützt wird, muss auf dem Remotecomputer Windows PowerShell 3.0 oder eine höhere Version von Windows PowerShell ausgeführt werden und der WSMan-Transport verwendet werden.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>Die PSSession kann nicht verbunden werden, da sich die Sitzung nicht im Zustand „Disconnected“ (getrennt) befindet oder keine Verbindung möglich ist.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>Der Wert für den Parameter darf nicht PipelineResultTypes.None oder PipelineResultTypes.Output sein.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>Gültige Werte für den Parameter sind PipelineResultTypes.Output oder PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>Die Umleitung des Debugdatenstroms wird auf dem Zielremotecomputer nicht unterstützt.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>Die ausführliche Umleitung des Datenstroms wird auf dem Zielremotecomputer nicht unterstützt.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>Die Umleitung des Warnungsdatenstroms wird auf dem Zielremotecomputer nicht unterstützt.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>Die Umleitung des Informationsstreams wird auf dem Zielremotecomputer nicht unterstützt.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>Sie haben eine Sitzung geöffnet, in der gerade ein Befehl oder Skript ausgeführt wird.  Da die Ausgabe an den Auftrag „{0}“ weitergeleitet wird, wird in der Konsole keine Ausgabe angezeigt.  Sie können warten, bis der ausgeführte Befehl beendet ist, oder den Befehl abbrechen und mit STRG+C eine Eingabeaufforderung erhalten.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>Sie haben eine Sitzung geöffnet, in der gerade ein Befehl oder Skript ausgeführt wird. Die Ausgabe wird in der Konsole angezeigt.  Sie können warten, bis der ausgeführte Befehl beendet ist, oder ihn abbrechen und mit STRG+C eine Eingabeaufforderung erhalten.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>Sie haben eine Sitzung geöffnet, die derzeit an einem Debughaltepunkt in einem ausgeführten Befehl oder Skript angehalten ist.  Verwenden Sie den PowerShell-Befehlszeilendebugger, um mit dem Debuggen fortzufahren.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>Der DefaultRunspace muss ein LocalRunspace sein.</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>Die statische PrimaryRunspace-Eigenschaft kann nur einmal festgelegt werden und wurde bereits festgelegt.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/SessionStateStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/SessionStateStrings.de.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>Die zurückgegebenen Informationen können nicht verarbeitet werden, da die von der Start-Methode des Anbieters zurückgegebenen Informationen für einen anderen Anbieter als den übergebenen bestimmt waren.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>Die zurückgegebenen Informationen können nicht verarbeitet werden, da die von der Start-Methode des Anbieters zurückgegebenen Informationen NULL waren.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den SetItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den SetItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den ClearItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den InvokeDefaultAction-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den InvokeDefaultAction-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den ItemExists-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den ItemExists-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den IsValidPath-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den IsItemContainer-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den RemoveItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetChildItems-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetChildItems-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetChildNames-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetChildNames-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den RenameItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den RenameItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Der Versuch, den NewItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den NewItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Der Versuch, den HasChildItems-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den CopyItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den CopyItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetParentPath-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den NormalizeRelativePath-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den MakePath-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetChildName-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den MoveItem-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den MoveItem-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetProperty-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den SetProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den SetProperty-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den ClearProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den ClearProperty-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den NewProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den NewProperty-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den RemoveProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den RemoveProperty-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den CopyProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den CopyProperty-Vorgang können für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den MoveProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den MoveProperty-Vorgang können für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den RenameProperty-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Dynamische Parameter für RenameProperty können für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Der Inhaltsleser kann für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetContentReader-Vorgang können für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Der Inhaltswriter kann für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den GetContentWriter-Vorgang können für den Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>Der Inhalt kann nicht abgerufen werden, da es sich um ein Verzeichnis handelt: „{0}“. Verwenden Sie stattdessen „Get-ChildItem“.</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>Der Inhalt kann nicht geschrieben werden, da es sich um ein Verzeichnis handelt: „{0}“.</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>Es ist kein Standortverlauf mehr vorhanden, um rückwärts zu navigieren.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>Es ist kein Standortverlauf mehr vorhanden, um vorwärts zu navigieren.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>Der BoundedStack ist leer.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den ClearContent-Vorgang für den Anbieter „{0}“ auszuführen, ist für den Pfad „{1}“ fehlgeschlagen. {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>Der Inhalt von „{0}“ kann nicht gelöscht werden, da es sich um ein Verzeichnis handelt. Clear-Content wird nur für Dateien unterstützt.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Die dynamischen Parameter für den ClearContent-Vorgang können vom Anbieter „{0}“ für den Pfad „{1}“ nicht abgerufen werden. {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den GetSecurityDescriptor-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Der Versuch, den SetSecurityDescriptor-Vorgang beim Anbieter „{0}“ für den Pfad „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>Der Versuch, den Start-Vorgang beim Anbieter „{0}“ auszuführen, ist fehlgeschlagen. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>Der Versuch, den InitializeDefaultDrives-Vorgang für den Anbieter „{0}“ auszuführen, ist fehlgeschlagen.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>Der Versuch, den NewDrive-Vorgang beim Anbieter „{0}“ für das Laufwerk mit dem Stamm „{1}“ auszuführen, ist fehlgeschlagen. {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>Dynamische Parameter für „NewDrive“ können für den Anbieter „{0}“ nicht abgerufen werden. {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>Das Aufrufen von „RemoveDrive“ für den Anbieter „{0}“ ist fehlgeschlagen. {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>Das Laufwerk „{0}“ kann nicht entfernt werden, da der Anbieter „{1}“ dies verhindert hat.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>Der Pfad „{0}“ verweist auf ein Element, das sich außerhalb der Basis „{1}“ befindet.</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Der Aufruf von „Seek“ für den Inhaltswriter des Anbieters „{0}“ ist für den Pfad „{1}“ fehlgeschlagen. {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>Der Aufruf von „Close“ für den Inhaltsleser oder -writer des Anbieters „{0}“ ist für den Pfad „{1}“ fehlgeschlagen. {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>Der Aufruf von „Read“ für den Inhaltsleser des Anbieters „{0}“ ist für den Pfad „{1}“ fehlgeschlagen. {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Der Aufruf von „Write“ für den Inhaltswriter des Anbieters „{0}“ ist für den Pfad „{1}“ fehlgeschlagen. {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>Der Anbieter „{0}“ kann nicht verwendet werden, um mithilfe der Variablensyntax Daten abzurufen oder festzulegen. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>Die Variablensyntax kann nicht verwendet werden, um Daten im Anbieter abzurufen oder festzulegen. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>Der Alias kann nicht geschrieben werden, da der Alias „{0}“ schreibgeschützt oder konstant ist und daher nicht geschrieben werden kann.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>In Funktion „{0}“ kann nicht geschrieben werden, da sie schreibgeschützt oder konstant ist.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>Die Variable „{0}“ kann nicht überschrieben werden, da sie schreibgeschützt oder konstant ist.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>Auf die Variable „${0}“ kann nicht zugegriffen werden, da es sich um eine private Variable handelt.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>Auf den Befehl „{0}“ kann nicht zugegriffen werden, da es sich um einen privaten Befehl handelt.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>Auf den Befehl kann nicht zugegriffen werden, da es sich um einen privaten Befehl handelt.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>Auf die Ressource des Sitzungszustands kann nicht zugegriffen werden, da es sich um eine private Ressource handelt. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>Der Alias wurde nicht entfernt, da Alias „{0}“ konstant oder schreibgeschützt ist.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>Die Funktion „{0}“ kann nicht entfernt werden, da sie konstant ist.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>Die Variable „{0}“ kann nicht entfernt werden, da sie konstant oder schreibgeschützt ist. Wenn die Variable schreibgeschützt ist, wiederholen Sie den Vorgang mit der Option Force.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>Der Alias „{0}“ kann nicht geändert werden, da er konstant ist.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>Der Alias „{0}“ kann nicht geändert werden, da er schreibgeschützt ist.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>Die Funktion „{0}“ kann nicht geändert werden, da sie konstant ist.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>Die Funktion „{0}“ kann nicht geändert werden, da sie schreibgeschützt ist.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>Der Alias „{0}“ kann nach der Erstellung nicht als Konstante festgelegt werden. Aliase können nur bei der Erstellung als Konstante festgelegt werden.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>Eine vorhandene Funktion „{0}“ kann nicht als konstant festgelegt werden. Funktionen können nur bei der Erstellung als konstant festgelegt werden.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>Eine vorhandene Variable „{0}“ kann nicht konstant gemacht werden. Variablen können nur bei der Erstellung als konstant festgelegt werden.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>Die Option AllScope-Option kann nicht aus dem Alias „{0}“ entfernt werden.</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>Die Option AllScope-Option kann nicht aus der Funktion „{0}“ entfernt werden.</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>Die Option AllScope-Option kann nicht aus der Variable „{0}“ entfernt werden.</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>Die Funktionsdefinition „{0}“ enthielt einen Bereichsqualifizierer, aber keinen Funktionsnamen.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>Der Anbieter „{0}“ kann nicht entfernt werden. Alle Laufwerke, die dem Anbieter „{0}“ zugeordnet sind, müssen entfernt werden, bevor der Anbieter „{0}“ entfernt werden kann.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>Der Laufwerkname kann nicht verarbeitet werden, da er mindestens eines der folgenden ungültigen Zeichen enthält: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>Das Erstellen des neuen Laufwerks ist fehlgeschlagen, da der Anbieter das Erstellen des neuen Laufwerks nicht zulässt.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>Der angegebene Wert „{0}“ wurde in mehr als einen Speicherstapel aufgelöst.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>Der Speicherortstapel „{0}“ wurde nicht gefunden. Er ist nicht vorhanden oder kein Container.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>Der Pfad "{0}" wurde nicht gefunden, da er nicht vorhanden ist.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>Der Alias kann nicht gefunden werden, da der Alias „{0}“ nicht vorhanden ist.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>Der Speicherort kann nicht festgelegt werden, da der Pfad „{0}“ zu mehreren Containern aufgelöst wurde. Der Speicherort kann jeweils nur für einen einzelnen Container festgelegt werden.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>Die Variable kann nicht verarbeitet werden, da der Variablenpfad „{0}“ zu mehreren Elementen aufgelöst wurde. Sie können den Variablenwert jeweils nur für ein Element abrufen oder festlegen.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>Laufwerk wurde nicht gefunden. Ein Laufwerk mit dem Namen „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>Es wurde kein Anbieter mit dem Namen „{0}“ gefunden.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Es wurde kein Anbieter mit dem Namen „{0}“ gefunden. Der Name hat nicht das richtige Format. Ein Anbietername darf nur alphanumerische Zeichen oder einen PowerShell-Snap-In-Namen enthalten, auf den ein einzelner '\' und alphanumerische Zeichen folgen.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>„{0}“ wurde in mehr als einen Anbieternamen aufgelöst. Mögliche Übereinstimmungen sind:{1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Beim Erstellen einer Instanz des Anbieters ist ein Fehler aufgetreten. Der Anbietertypname „{0}“ wurde in der Assembly nicht gefunden.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>Der angegebene Anbietername „{0}“ kann nicht verwendet werden, da er mindestens eines der folgenden ungültigen Zeichen enthält: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>Beim Erstellen einer Instanz des Anbieters „{0}“ ist ein Fehler aufgetreten. {1}  </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>Es wurde keine Variable mit dem Namen „{0}“ gefunden.</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>Es wurde keine Ablaufverfolgungsquelle mit dem Namen „{0}“ gefunden.</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>Ein Laufwerk mit dem Namen „{0}“ ist bereits vorhanden.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>Eine Variable mit dem Namen „{0}“ ist bereits vorhanden.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>Der Alias ist nicht zulässig, da bereits ein Alias mit dem Namen „{0}“ vorhanden ist.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>Der Cmdlet-Anbieter kann nicht registriert werden, da bereits ein Cmdlet-Anbieter mit dem Namen „{0}“ vorhanden ist.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>Der Pfad verweist nicht auf einen Dateisystempfad.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>Der globale Bereich lässt sich nicht entfernen.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>Die Bereichsnummer „{0}“ überschreitet die Anzahl der aktiven Bereiche.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>PSDriveInfo kann nicht verglichen werden. Eine PSDriveInfo-Instanz kann nur mit einer anderen PSDriveInfo-Instanz verglichen werden.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Der Cmdlet-Anbieter kann die Ergebnisse nicht streamen, da kein Cmdlet angegeben wurde, über das die Ausgabe gestreamt werden kann.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Der Cmdlet-Anbieter kann die Ergebnisse nicht streamen, da kein Cmdlet angegeben wurde, über das der Fehler gestreamt werden kann.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>Der Startort für diesen Anbieter ist nicht festgelegt. Um den Startort festzulegen, rufen Sie „(get-psprovider '{0}').Home = 'path'“ auf.</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>Der Pfad weist nicht das richtige Format auf. Anbieterpfade müssen eine Anbieter-ID enthalten, gefolgt von "::" und einem anbieterspezifischen Pfad.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>Das Element kann nicht verschoben werden, da sich der Zielpfad nur in einen einzelnen Pfad auflösen lässt.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>Das Element kann nicht verschoben werden, da Quell- und Zielpfad nicht im selben Anbieter aufgelöst wurden.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>Das Element kann nicht verschoben werden, da der Quellpfad auf ein oder mehrere Elemente verweist und der Zielpfad kein Container ist. Überprüfen Sie, ob der Zielpfad ein Container ist, und versuchen Sie es erneut.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>Das Element kann nicht verschoben werden, da das Ziel in mehrere Pfade aufgelöst wurde. Geben Sie einen Zielpfad an, der in genau ein Ziel aufgelöst wird, und wiederholen Sie den Vorgang.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>Ein Container kann nicht auf ein vorhandenes Blattelement kopiert werden.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>Ein Container kann nicht in einen anderen Container kopiert werden. Der Parameter „-Recurse“ oder „-Container“ wurde nicht angegeben.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>Quell- und Zielpfad wurden nicht demselben Anbieter zugeordnet.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>Das Element kann nicht umbenannt werden, da der Pfad in mehrere Elemente aufgelöst wurde. Es kann jeweils nur ein Element umbenannt werden.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>Der Anbieter „{0}“ kann aufgrund eines Fehlers beim Anbieter nicht zum Auflösen des Pfads „{1}“ verwendet werden.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>Schnittstelle kann nicht verwendet werden. Die IContentCmdletProvider-Schnittstelle wird von diesem Anbieter nicht implementiert.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>Schnittstelle kann nicht verwendet werden. Die IPropertyCmdletProvider-Schnittstelle wird von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>Schnittstelle kann nicht verwendet werden. Die IDynamicPropertyCmdletProvider-Schnittstelle wird von diesem Anbieter nicht implementiert.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>Die NavigationCmdletProvider-Methoden werden von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Anbietermethoden wurden nicht verarbeitet. Die ContainerCmdletProvider-Methoden werden von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>Die Methoden können nicht aufgerufen werden. Die ItemCmdletProvider-Methoden werden von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>Die DriveCmdletProvider-Methoden werden von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>Der Anbietervorgang wurde beendet, da der Anbieter diesen Vorgang nicht unterstützt.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>Der Anbietervorgang wurde beendet, da der Anbieter den Parameter „Depth“ nicht unterstützt.</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>Die Methode kann nicht aufgerufen werden. Die Methode „Content Seek“ wird von diesem Anbieter nicht unterstützt.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>Der ClearContent-Vorgang kann nicht ausgeführt werden. Dieser Anbieter unterstützt den Vorgang ClearContent nicht.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>Der Anbieter unterstützt die Verwendung von Anmeldeinformationen nicht. Führen Sie den Vorgang erneut aus, ohne Anmeldeinformationen anzugeben.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>Der Dateisystemanbieter unterstützt Anmeldeinformationen nur mit dem Cmdlet „New-PSDrive“. Führen Sie den Vorgang erneut aus, ohne Anmeldeinformationen anzugeben.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>Die Transaktionen werden vom Anbieter nicht unterstützt. Führen Sie den Vorgang erneut ohne den Parameter „-UseTransaction“ aus.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>Die Methode kann nicht aufgerufen werden. Der Anbieter unterstützt die Verwendung von Filtern nicht.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>Das Laufwerk kann nicht erstellt werden. Der Anbieter unterstützt die Verwendung von Anmeldeinformationen nicht.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>Das Element im Pfad „{0}“ existiert bereits.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>Das Element kann nicht kopiert werden. Das Element im Pfad „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>Das Element im Pfad „{0}“ ist nicht vorhanden.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Laufwerk mit einer Ansicht der in einem Sitzungszustand gespeicherten Aliase</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>Laufwerk mit einer Ansicht der Umgebungsvariablen für den Prozess</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Laufwerk mit einer Ansicht der in einem Sitzungszustand gespeicherten Funktionen</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Laufwerk mit einer Ansicht der in einem Sitzungszustand gespeicherten Variablen</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Laufwerk, das dem Pfad des temporären Verzeichnisses für die aktuelle Benutzerperson zugeordnet ist</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>Die Verknüpfung „{0}“ kann nicht erstellt werden, da der Zielwert nicht angegeben wurde.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Verweise auf die NULL-Variable geben immer den NULL-Wert zurück. Zuweisungen haben keine Auswirkungen.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Maximale Anzahl von Verlaufsobjekten, die in einer Sitzung beibehalten werden</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>Die Funktion kann nicht umbenannt werden, da Funktion „{0}“ schreibgeschützt oder konstant ist.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>Der Alias kann nicht umbenannt werden, da Alias „{0}“ schreibgeschützt oder konstant ist.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>Die Variable kann nicht umbenannt werden, da die Variable „{0}“ schreibgeschützt oder konstant ist.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>Für die lokale Variable „{0}“ können keine Optionen festgelegt werden. Verwenden Sie „New-Variable“, um eine Variable zu erstellen, bei der Optionen festgelegt werden können.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Das Cmdlet „{0}“ kann nicht geändert werden, da er schreibgeschützt ist.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>Die Variable „{0}“ kann nicht entfernt werden, da sie optimiert wurde und nicht entfernt werden kann. Verwenden Sie das Cmdlet „Remove-Variable“ (ohne Aliase), oder dot-sourcen Sie den Befehl, den Sie zum Entfernen der Variablen verwenden.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>Die Variable „{0}“ kann nicht überschrieben werden, da sie optimiert wurde. Verwenden Sie das Cmdlet „New-Variable“ oder „Set-Variable“ (ohne Aliase), oder dot-sourcen Sie den Befehl, den Sie zum Festlegen der Variablen verwenden.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>Die Parameter „{0}“ und „{1}“ können nicht zusammen verwendet werden. Geben Sie nur einen Parameter an.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Der Tail-Parameter wird derzeit nur für den Dateisystemanbieter unterstützt.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>Der Alias ist nicht zulässig, da bereits ein Befehl mit dem Namen „{0}“ und dem Befehlstyp „{1}“ vorhanden ist.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>Software kann nicht ausgeführt werden. Der Zugriff wurde verweigert.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>„-{0}“ und „-{1}“ schließen sich gegenseitig aus und können nicht gleichzeitig angegeben werden.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>Der Pfad „{0}“ ist ungültig. Bei Remotekopiervorgängen werden nur absolute Pfade unterstützt.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>Der Remotepfad „{0}“ kann nicht überprüft werden.</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>Der Vorgang kann nicht ausgeführt werden, da die Sitzung „{0}“ auf „{1}“ festgelegt ist.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>Der Parameter „{0}“ darf nicht NULL oder leer sein.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Sitzungszustandsvariablen</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>Das Ändern oder Erstellen des Bereichs der Variablen „{0}“ in AllScope wird im ConstrainedLanguage-Modus verhindert.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/de/TabCompletionStrings.de.resx
+++ b/src/System.Management.Automation/resources/de/TabCompletionStrings.de.resx
@@ -118,154 +118,154 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>Das Ergebnis der TAB-Vervollständigung kann nicht ordnungsgemäß deserialisiert werden, da der Remotesitzungsbereich keine TypeTable-Instanz enthält.</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>Auf Eigenschaften einer NULL-Instanz vom Typ CompletionResult kann nicht zugegriffen werden.</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>Bitweises NOT</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>Logisches "Nicht" Negiert die darauf folgende Anweisung.</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Gleich – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die gleich dem rechten Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand gleich dem rechten Operand ist.</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Gleich – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die gleich dem rechten Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand gleich dem rechten Operand ist.</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die gleich dem rechten Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand gleich dem rechten Operand ist.</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Ungleich – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Ungleich – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Ungleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Größer als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die größer oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand größer oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Größer als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die größer oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand größer oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Größer als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die größer oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand größer oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Größer als – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die größer als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand größer als der rechte Operand ist.</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Größer als – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die größer als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand größer als der rechte Operand ist.</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Größer als – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die größer als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand größer als der rechte Operand ist.</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Kleiner als – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die kleiner als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand kleiner als der rechte Operand ist.</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Kleiner als – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die kleiner als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand kleiner als der rechte Operand ist.</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Kleiner als – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, werden Werte aus der Auflistung zurückgegeben, die kleiner als der rechte Operand sind. Andernfalls wird TRUE zurückgegeben, wenn der linke Operand kleiner als der rechte Operand ist.</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Kleiner als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die kleiner oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand kleiner oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Kleiner als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die kleiner oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand kleiner oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Kleiner als oder gleich – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die kleiner oder gleich dem rechten Operanden sind. Andernfalls gibt er TRUE zurück, wenn der linke Operand kleiner oder gleich dem rechten Operanden ist.</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Platzhalterabgleichsoperator – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung nicht beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator für den Abgleich regulärer Ausdrücke – Groß-/Kleinschreibung beachten. Wenn der linke Operand eine Auflistung ist, gibt dieser Operator Werte aus der Auflistung zurück, die dem rechten Operanden nicht entsprechen. Andernfalls gibt er TRUE zurück, wenn der linke Operand nicht mit dem rechten Operanden übereinstimmt.</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Ersetzungsoperator – Groß-/Kleinschreibung nicht beachten. Ändert den linken Operanden. Beispiel: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Ersetzungsoperator – Groß-/Kleinschreibung nicht beachten. Ändert den linken Operanden. Beispiel: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Ersetzungsoperator – Groß-/Kleinschreibung beachten. Ändert den linken Operanden. Beispiel: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (rechter Operand) genau mit mindestens einem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (rechter Operand) genau mit mindestens einem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung beachten. Gibt nur TRUE zurück, wenn der Testwert (rechter Operand) genau mit mindestens einem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (rechter Operand) genau mit keinem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (rechter Operand) genau mit keinem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung beachten. Gibt TRUE zurück, wenn der Testwert (rechter Operand) genau mit keinem der Werte im linken Operanden übereinstimmt.</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit mindestens einem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit mindestens einem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit mindestens einem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit keinem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung nicht beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit keinem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Enthaltenheitsoperator – Groß-/Kleinschreibung beachten. Gibt TRUE zurück, wenn der Testwert (linker Operand) genau mit keinem der Werte im rechten Operanden übereinstimmt.</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>Teilen – Groß-/Kleinschreibung nicht beachten. Teilt eine oder mehrere Zeichenfolgen in Teilzeichenfolgen auf.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -273,7 +273,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>Teilen – Groß-/Kleinschreibung nicht beachten. Teilt eine oder mehrere Zeichenfolgen in Teilzeichenfolgen auf.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -281,7 +281,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
+    <value>Split – Groß-/Kleinschreibung beachten. Teilt eine oder mehrere Zeichenfolgen in Teilzeichenfolgen auf.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -289,103 +289,103 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>Gibt TRUE zurück, wenn der linke Operand keine Instanz des angegebenen .NET Framework-Typs (rechter Operand) ist.</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>Gibt TRUE zurück, wenn der linke Operand eine Instanz des angegebenen .NET Framework-Typs (rechter Operand) ist.</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>Konvertiert den linken Operanden in den angegebenen .NET Framework-Typ (rechter Operand).</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>Formatiert Zeichenfolgen mithilfe der Formatmethode von Zeichenfolgenobjekten.</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>Logisches "Und" Gibt TRUE zurück, wenn beide Anweisungen TRUE sind.</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>Bitweises AND</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>Logisches "Oder" TRUE, wenn eine oder beide Anweisungen TRUE sind.</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>Bitweises OR (inklusiv)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>Logisches XODER. Gibt TRUE zurück, wenn eine der Anweisungen TRUE und die andere FALSE ist.</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>Bitweises OR (exklusiv)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
+    <value>Verknüpfen – mehrere Zeichenfolgen zu einer einzelnen Zeichenfolge kombinieren.
 -Join &lt;String[]&gt;
 &lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>Bitoperator „Nach links verschieben“. Fügt an der ganz rechten Bitposition eine Null ein.</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>Bitoperator „Nach rechts verschieben“. Fügt an der ganz linken Bitposition eine Null ein. Bei vorzeichenbehafteten Werten bleibt das Vorzeichenbit erhalten.</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Gibt den Namen der Eigenschaft an.</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Gibt den Namen der Eigenschaft an.</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
     <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+Ein Skriptblock zum Berechnen des Werts der neuen Eigenschaft.</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+Gibt an, wie die Werte in einer Spalte angezeigt werden.
+Gültige Werte sind „left“, „center“ oder „right“.</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+Gibt eine Formatzeichenfolge an, die definiert, wie der Wert für die Ausgabe formatiert wird.</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+Gibt die maximale Spaltenbreite in einer Tabelle an, wenn der Wert angezeigt wird.
+Der Wert muss größer als 0 sein.</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+Der Tiefenschlüssel gibt die Tiefe der Erweiterung pro Eigenschaft an.</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Gibt die Sortierreihenfolge für eine oder mehrere Eigenschaften an.</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Gibt die Sortierreihenfolge für eine oder mehrere Eigenschaften an.</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+Gibt die Protokollnamen an, aus denen Ereignisse abgerufen werden sollen.
+Unterstützt Platzhalter.</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+Gibt die Ereignisprotokollanbieter an, von denen Ereignisse abgerufen werden sollen.
+Unterstützt Platzhalter.</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+Gibt Dateipfade zu Protokolldateien an, aus denen Ereignisse abgerufen werden sollen.
+Gültige Dateiformate sind .etl, .evt und .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
     <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+Wählt Ereignisse mit der angegebenen Schlüsselwortbitmaske aus.
+Im Folgenden sind die Standardschlüsselwörter aufgeführt:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,213 +398,213 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+Wählt Ereignisse mit den angegebenen Ereignis-IDs aus.</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
-2: Error
-3: Warning
+Wählt Ereignisse mit den angegebenen Protokollebenen aus.
+Die folgenden Protokollebenen sind gültig:
+1: Kritisch
+2: Fehler
+3: Warnung
 4: Informational
-5: Verbose</value>
+5: Ausführlich</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created after the specified date and time.</value>
+Wählt Ereignisse aus, die nach dem angegebenen Datum und der angegebenen Uhrzeit erstellt wurden.</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created before the specified date and time.</value>
+Wählt Ereignisse aus, die vor dem angegebenen Datum und der angegebenen Uhrzeit erstellt wurden.</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+Wählt Ereignisse aus, die vom angegebenen Benutzer generiert wurden.
+Dies kann entweder eine Zeichenfolgendarstellung einer SID oder eine Domäne und ein Benutzername im Format DOMÄNE\BENUTZERNAME oder USERNAME@DOMAIN sein.</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
     <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+Wählt Ereignisse mit einem der angegebenen Werte im Abschnitt „EventData“ aus.</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
     <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+Schließt Ereignisse aus, die mit den in der Hashtabelle angegebenen Werten übereinstimmen.</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[string] oder [hashtable]
+Gibt ein Array von PowerShell-Modulen an, die das Skript erfordert.
+Jedes Element kann entweder eine Zeichenfolge mit dem Modulnamen als Wert oder eine Hashtabelle mit den folgenden Schlüsseln sein:
+Name: Der Name des Moduls
+GUID: GUID des Moduls
+Eine der folgenden Optionen:
+ModuleVersion: Gibt eine minimal zulässige Version des Moduls an.
+RequiredVersion: Gibt eine exakte, erforderliche Version des Moduls an.
+MaximumVersion: Gibt die maximal zulässige Version des Moduls an.</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
     <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+Gibt eine PowerShell-Edition an, die das Skript erfordert.
+Gültige Werte sind „Core“ und „Desktop“.</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
     <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+Gibt an, dass PowerShell unter Windows als Admin ausgeführt werden muss.
+Dies muss der letzte Parameter in der Zeile mit der #requires-Anweisung sein.</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
     <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+Gibt die mindestens erforderliche PowerShell-Version für das Skript an.</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>Gibt an, dass für die Ausführung des Skripts PowerShell 7+ erforderlich ist.</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>Gibt an, dass für die Ausführung des Skripts Windows PowerShell 5.1 erforderlich ist.</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
     <value>[string]
-Required. Specifies the module name.</value>
+Obligatorisch Gibt den Namen des Moduls an.</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
     <value>[string]
-Optional. Specifies the GUID of the module.</value>
+Optional Gibt den GUID des Moduls an.</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+Gibt eine minimal zulässige Version des Moduls an.</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies an exact, required version of the module.</value>
+Gibt eine exakte, erforderliche Version des Moduls an.</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+Gibt die maximal zulässige Version des Moduls an.</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Eine kurze Beschreibung der Funktion oder des Skripts.
+Dieses Schlüsselwort kann nur einmal für jeden Inhalt verwendet werden.</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Eine detaillierte Beschreibung der Funktion oder des Skripts.
+Dieses Schlüsselwort kann nur einmal für jeden Inhalt verwendet werden.</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
     <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+Die Beschreibung eines Parameters.
+Fügen Sie für jeden Parameter in der Funktions- oder Skriptsyntax ein .PARAMETER-Schlüsselwort hinzu.</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>Ein Beispielbefehl, der die Funktion oder das Skript verwendet, optional gefolgt von einer Beispielausgabe und einer Beschreibung.
+Wiederholen Sie dieses Schlüsselwort für jedes Beispiel.</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>Die .NET-Typen von Objekten, die an die Funktion oder das Skript weitergeleitet werden können.
+Sie können auch eine Beschreibung der Eingabeobjekte einschließen.</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>Der .NET-Typ der Objekte, die vom Cmdlet zurückgegeben werden.
+Sie können auch eine Beschreibung der zurückgegebenen Objekte einschließen.</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>Zusätzliche Informationen zur Funktion oder zum Skript.</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>Der Name eines verwandten Themas.
+Wiederholen Sie das Schlüsselwort .LINK für jedes verwandte Thema.
+Der Inhalt des .LINK-Schlüsselworts kann auch einen URI zu einer Onlineversion des Hilfethemas enthalten.</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>Der Name der Technologie oder des Features, die bzw. das von der Funktion oder dem Skript verwendet wird oder mit dem bzw. der es verknüpft ist.</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>Der Name der Benutzerrolle für das Hilfethema.</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>Die Schlüsselwörter, die die beabsichtigte Verwendung der Funktion beschreiben.</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+Leitet zum Hilfethema für den angegebenen Befehl um.</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+Dieser Befehl gibt die Hilfekategorie des Elements in ForwardHelpTargetName an.</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+Gibt eine Sitzung an, die das Hilfethema enthält.
+Geben Sie eine Variable ein, die ein PSSession-Objekt enthält.</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+Das Schlüsselwort .ExternalHelp ist erforderlich, wenn eine Funktion oder ein Skript in XML-Dateien dokumentiert ist.</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>Gibt den Pfad zu einer .NET-Assembly an, die geladen werden soll.
 
 using assembly &lt;.NET-assembly-path&gt;</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>Gibt ein PowerShell-Modul an, aus dem Klassen geladen werden.
 
 using module &lt;ModuleName or Path&gt;
 
 using module &lt;ModuleSpecification hashtable&gt;</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>Gibt einen .NET-Namespace an, aus dem Typen aufgelöst werden sollen, oder einen Namespacealias.
 
 using namespace &lt;.NET-namespace&gt;
 
 using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>Gibt einen Alias für einen .NET-Typ an.
 
 using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>Eine normale Zeichenfolge.</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>Eine Zeichenfolge, die nicht erweiterte Verweise auf Umgebungsvariablen enthält, die beim Abrufen des Werts erweitert werden.</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>Binärdaten in beliebiger Form.</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>Eine 32-Bit-Binärzahl.</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>Ein Array der Zeichenfolgen.</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>Eine 64-Bit-Binärzahl.</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>Ein nicht unterstützter Registrierungsdatentyp.</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
-    <value>',' - Comma</value>
+    <value>',' – Komma</value>
   </data>
   <data name="SeparatorCommaSpaceToolTip" xml:space="preserve">
-    <value>', ' - Comma-Space</value>
+    <value>', ' – Komma-Leerzeichen</value>
   </data>
   <data name="SeparatorSemiColonToolTip" xml:space="preserve">
-    <value>';' - Semi-Colon</value>
+    <value>';' – Semikolon</value>
   </data>
   <data name="SeparatorSemiColonSpaceToolTip" xml:space="preserve">
-    <value>'; ' - Semi-Colon-Space</value>
+    <value>'; ' – Semikolon-Leerzeichen</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
-    <value>{0} - Newline</value>
+    <value>{0} – Zeilenumbruch</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
-    <value>'-' - Dash</value>
+    <value>'-' – Gedankenstrich</value>
   </data>
   <data name="SeparatorSpaceToolTip" xml:space="preserve">
-    <value>' ' - Space</value>
+    <value>' ' – Leerzeichen</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/Authenticode.es.resx
+++ b/src/System.Management.Automation/resources/es/Authenticode.es.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>No se puede cargar el archivo {0} porque optó por no ejecutar este software ahora.</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>No se puede cargar el archivo {0} porque optó por no ejecutar nunca software desde este publicador.</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>El archivo {0} está publicado por {1}. Este editor no es de confianza explícita en el sistema. El script no se ejecutará en el sistema. Para obtener más información, ejecute el comando "get-help about_signing".</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>El archivo {0} no se puede cargar porque la ejecución de scripts está deshabilitada en este sistema. Para obtener más información, consulte about_Execution_Policies en https://go.microsoft.com/fwlink/?LinkID=135170.</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>El archivo {0} no se puede cargar {1}.</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>No se puede cargar el archivo {0} porque su operación está bloqueada por directivas de restricción de software, como las creadas mediante directiva de grupo.</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>No se puede cargar el archivo {0} porque no se pudo leer su contenido.</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>No se puede firmar el código. El certificado especificado no es adecuado para la firma de código.</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>No se puede firmar el código. La dirección URL del servidor de marca de tiempo debe ser completa y tener el formato http://&lt;server url&gt; o https://&lt;server url&gt;.</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>No se puede firmar el código. No se admite el algoritmo hash.</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>¿Desea ejecutar software de este editor que no es de confianza?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>El archivo {0} está publicado por {1} y no es de confianza en su sistema. Ejecute solo scripts de editores de confianza.</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>Un editor desconocido publica el software {0}. Se recomienda no ejecutar este software.</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>Advertencia de seguridad</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>Ejecute solo los scripts en los que confíe. Aunque los scripts de Internet pueden ser útiles, este script puede dañar el equipo. Si confía en este script, use el cmdlet Unblock-File para permitir que se ejecute sin mostrar este mensaje de advertencia. ¿Desea ejecutar {0}?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>Nunc&amp;a ejecutar</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>No ejecute el script de este publicador ahora y no me pida que lo ejecute en el futuro. Los intentos futuros de ejecutar este script producirán un error silencioso.</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>&amp;No ejecutar</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>No ejecute ahora el script de este editor y siga preguntándome si deseo ejecutarlo en el futuro.</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>&amp;Ejecutar una vez</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Ejecute el script de este editor ahora y siga preguntándome si deseo ejecutar este script en el futuro.</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>&amp;Ejecutar siempre</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>Ejecute ahora el script de este publicador y no me pida que lo ejecute en el futuro.</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Suspender</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>Ponga en pausa la canalización actual y vuelva al símbolo del sistema. Escriba salir para reanudar la operación cuando haya terminado.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/CredUI.es.resx
+++ b/src/System.Management.Automation/resources/es/CredUI.es.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>Solicitud de credenciales de PowerShell </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>Escriba sus credenciales. </value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Escriba sus credenciales.</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>La longitud máxima del título son {0} caracteres.</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>La longitud máxima del mensaje es de {0}caracteres.</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>La longitud máxima del valor UserName es de {0} caracteres.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/DebuggerStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/DebuggerStrings.es.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>Punto de interrupción variable en "${0}" (acceso de {1})</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>Punto de interrupción variable en "{0}:${1}" (acceso de {2})</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>Punto de interrupción de línea en "{0}:{1}"</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>Punto de interrupción de línea en "{0}:{1}, {2}"</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>Punto de interrupción de comando en "{0}"</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>Punto de interrupción de comando en "{0}:{1}"</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>No se alcanzará el punto de interrupción {0}</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Un solo paso (ir a funciones, scripts, etc.)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Ir a la siguiente instrucción (paso a paso por funciones, scripts, etc.)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Salga de la función, script, etc. actual.</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} Continuar la operación</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} Detener la operación y salir del depurador</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Mostrar la pila de llamadas Get-PSCallStack</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Muestre el código fuente del script actual.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Use "list" para empezar desde la línea actual, "list &lt;m&gt;"  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     para empezar desde la línea &lt;m&gt; y "list &lt;m&gt; &lt;n&gt;" para enumerar &lt;n&gt; </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     líneas a partir de la línea &lt;m&gt;</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Repita el último comando si fue {0}, {1} o {2}</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} muestra este mensaje de ayuda.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Para obtener instrucciones sobre cómo personalizar la indicación del depurador, escriba "help about_prompt".</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+La sesión actual no admite la depuración; la operación continuará.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: línea {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>No hay código fuente disponible.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>La línea inicial debe ser un entero positivo no mayor que {0}</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>El recuento de líneas debe ser un entero positivo.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
-    <value>&lt;No file&gt;</value>
+    <value>&lt;No hay ningún archivo&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>en {0}, {1}: línea {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>El depurador no puede procesar comandos a menos que esté en estado Detenido.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>SetDebugAction no está implementado para el depurador de scripts local.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>El depurador no puede establecer una acción de reanudación porque el depurador de la sesión remota no está en estado Detenido.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>No se puede depurar el trabajo porque el depurador está ocupado actualmente.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Se examinó el trabajo proporcionado y todos los trabajos secundarios, pero no se encontró ningún trabajo que pudiera depurarse.  Para depurar un trabajo o un trabajo secundario, el trabajo debe admitir la depuración y estar en estado en ejecución.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>No se puede habilitar el depurador para el modo de paso porque el depurador está desactivado con el modo de depuración establecido en Ninguno.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>No se puede depurar el espacio de ejecución porque el depurador del host está ocupado actualmente.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>No se puede depurar el espacio de ejecución. El depurador del espacio de ejecución está desactivado actualmente (DebugMode es "None").</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>No se puede depurar un espacio de ejecución que no esté en el estado Abierto. Este espacio de ejecución está en el estado {0}.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>No se puede depurar el espacio de ejecución. El espacio de ejecución {0} no tiene ningún depurador asociado.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>El depurador ya está invalidado.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>No se puede insertar un objeto depurador sobre sí mismo.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>El comando {0} no se admite para uso remoto en la versión de PowerShell que se ejecuta en el espacio de ejecución remoto.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>Proceso</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} Continúe la operación y desasocie el depurador.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>El comando de desasociar el depurador no está disponible.  El comando de desasociar solo se aplica al depurar trabajos y espacios de ejecución con los cmdlets Debug-Job o Debug-Runspace.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>Id. de espacio de ejecución no válido: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>No se puede obtener el espacio de ejecución.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Se debe especificar Breakpoint o BreakpointList.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>BreakpointList contenía un elemento que no era un punto de interrupción.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/DiscoveryExceptions.es.resx
+++ b/src/System.Management.Automation/resources/es/DiscoveryExceptions.es.resx
@@ -186,7 +186,7 @@ La instrucción #requires debe tener uno de los siguientes formatos:
     <value>No se puede ejecutar el script "{0}" porque faltan los siguientes complementos especificados por las instrucciones "#requires" del script: {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell snap-in when running in PowerShell.</value>
+    <value>Una instrucción #requires solo ha especificado un shellID. Las instrucciones #Requires deben especificar un complemento de PowerShell necesario cuando se ejecutan en PowerShell.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
     <value>No se puede ejecutar el script "{0}" porque contiene una instrucción "#requires" para ejecutarse como administrador. La sesión actual de PowerShell no se está ejecutando como administrador. Inicie PowerShell con la opción Ejecutar como administrador e intente ejecutar el script de nuevo.</value>

--- a/src/System.Management.Automation/resources/es/ErrorCategoryStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/ErrorCategoryStrings.es.resx
@@ -118,102 +118,102 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CloseError" xml:space="preserve">
-    <value>CloseError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error al cerrar: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>Interbloqueo detectado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
-    <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error del dispositivo: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidArgument" xml:space="preserve">
-    <value>InvalidArgument: ({1}:{2}) [{0}], {3}</value>
+    <value>Argumento no válido: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidData" xml:space="preserve">
-    <value>InvalidData: ({1}:{2}) [{0}], {3}</value>
+    <value>Datos no válidos: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>InvalidOperation: ({1}:{2}) [{0}], {3}</value>
+    <value>Operación no válida: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidResult" xml:space="preserve">
-    <value>InvalidResult: ({1}:{2}) [{0}], {3}</value>
+    <value>Resultado no válido: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidType" xml:space="preserve">
-    <value>InvalidType: ({1}:{2}) [{0}], {3}</value>
+    <value>Tipo no válido: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="MetadataError" xml:space="preserve">
-    <value>MetadataError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de metadatos: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="NotImplemented" xml:space="preserve">
-    <value>NotImplemented: ({1}:{2}) [{0}], {3}</value>
+    <value>No implementado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="NotInstalled" xml:space="preserve">
-    <value>NotInstalled: ({1}:{2}) [{0}], {3}</value>
+    <value>No instalado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ObjectNotFound" xml:space="preserve">
-    <value>ObjectNotFound: ({1}:{2}) [{0}], {3}</value>
+    <value>Objeto no encontrado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="OpenError" xml:space="preserve">
-    <value>OpenError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error al abrir: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="OperationStopped" xml:space="preserve">
-    <value>OperationStopped: ({1}:{2}) [{0}], {3}</value>
+    <value>Operación detenida: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="OperationTimeout" xml:space="preserve">
-    <value>OperationTimeout: ({1}:{2}) [{0}], {3}</value>
+    <value>Tiempo de espera de la operación agotado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ParserError" xml:space="preserve">
-    <value>ParserError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error del analizador: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="PermissionDenied" xml:space="preserve">
-    <value>PermissionDenied: ({1}:{2}) [{0}], {3}</value>
+    <value>Permiso denegado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ReadError" xml:space="preserve">
-    <value>ReadError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de lectura: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceBusy" xml:space="preserve">
-    <value>ResourceBusy: ({1}:{2}) [{0}], {3}</value>
+    <value>Recurso ocupado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceExists" xml:space="preserve">
-    <value>ResourceExists: ({1}:{2}) [{0}], {3}</value>
+    <value>El recurso ya existe: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceUnavailable" xml:space="preserve">
-    <value>ResourceUnavailable: ({1}:{2}) [{0}], {3}</value>
+    <value>Recurso no disponible: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="SyntaxError" xml:space="preserve">
-    <value>SyntaxError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de sintaxis: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="WriteError" xml:space="preserve">
-    <value>WriteError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de escritura: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="FromStdErr" xml:space="preserve">
-    <value>FromStdErr: ({1}:{2}) [{0}], {3}</value>
+    <value>Desde StdErr: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="SecurityError" xml:space="preserve">
-    <value>SecurityError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de seguridad: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ProtocolError" xml:space="preserve">
-    <value>ProtocolError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de protocolo: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ConnectionError" xml:space="preserve">
-    <value>ConnectionError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de conexión: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="AuthenticationError" xml:space="preserve">
-    <value>AuthenticationError: ({1}:{2}) [{0}], {3}</value>
+    <value>Error de autenticación: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="LimitsExceeded" xml:space="preserve">
-    <value>LimitsExceeded: ({1}:{2}) [{0}], {3}</value>
+    <value>Se superaron los límites: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="QuotaExceeded" xml:space="preserve">
-    <value>QuotaExceeded: ({1}:{2}) [{0}], {3}</value>
+    <value>Se superó la cuota: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="NotEnabled" xml:space="preserve">
-    <value>NotEnabled: ({1}:{2}) [{0}], {3}</value>
+    <value>No habilitado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="NotSpecified" xml:space="preserve">
-    <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
+    <value>No especificado: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>Categoría de error no reconocida {4}: ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/ExperimentalFeatureStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/ExperimentalFeatureStrings.es.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>No se encontró ninguna característica experimental que coincida con el nombre "{0}".</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>La habilitación y deshabilitación de características experimentales no surtirán efecto hasta el próximo inicio de PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/HelpDisplayStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/HelpDisplayStrings.es.resx
@@ -121,172 +121,172 @@
     <value>NOMBRE</value>
   </data>
   <data name="Synopsis" xml:space="preserve">
-    <value>SYNOPSIS</value>
+    <value>SINOPSIS</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
-    <value>DESCRIPTION</value>
+    <value>DESCRIPCIÓN</value>
   </data>
   <data name="Syntax" xml:space="preserve">
-    <value>SYNTAX</value>
+    <value>SINTAXIS</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>PARÁMETROS</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>ENTRADAS</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>SALIDAS</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>ERRORES DE TERMINACIÓN</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>ERRORES DE NO TERMINACIÓN</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>NOTAS</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>EJEMPLOS</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>Ejemplo</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>EJEMPLO</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>OUTPUT</value>
+    <value>RESULTADO</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>VÍNCULOS RELACIONADOS</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>DESCRIPCIÓN BREVE</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>Título:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>Pregunta:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>Respuesta</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>Término:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>Definición:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>Contenido:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>NOMBRE DEL PROVEEDOR</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
+    <value>    Este cmdlet admite los parámetros comunes: Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
+    OutBuffer, PipelineVariable, y OutVariable. Para más información, consulte
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>¿Obligatorio?                    </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>¿Posición?                    </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>Tipo: </value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>Tipo de objeto de destino:   </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>Valor predeterminado                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>¿Aceptar la entrada de la canalización?       </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>¿Aceptar caracteres comodín?  </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(Categoría: </value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>Acción sugerida: </value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>Para obtener más información, escriba: </value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>Para obtener información técnica, escriba: </value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>Para ver los ejemplos, escriba: </value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>Para obtener ayuda en línea, escriba: </value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
   </data>
   <data name="RemarksSection" xml:space="preserve">
-    <value>REMARKS</value>
+    <value>COMENTARIOS</value>
   </data>
   <data name="TrueShort" xml:space="preserve">
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>Con nombre</value>
   </data>
   <data name="Drives" xml:space="preserve">
-    <value>DRIVES</value>
+    <value>UNIDADES</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>FUNCIONALIDADES</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>TAREAS</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>TAREA: </value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>FILTROS</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>PARÁMETROS DINÁMICOS</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>Cmdlets admitidos: </value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>ALIAS</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Get-Help no puede encontrar los archivos de Ayuda para este cmdlet en este equipo. Solo muestra ayuda parcial.
+    -- Para descargar e instalar los archivos de Ayuda del módulo que incluye este cmdlet, use Update-Help.
+    -- Para ver el tema de Ayuda de este cmdlet en línea, escriba: "Get-Help {0} -Online" o
+       vaya a {1}.</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>Ninguno</value>
   </data>
   <data name="ParameterAliases" xml:space="preserve">
-    <value>Aliases                      </value>
+    <value>Alias                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>¿Dinámico?                     </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>Nombre del conjunto de parámetros           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>No se puede recuperar el archivo XML de HelpInfo para el idioma de interfaz de usuario {0}. Asegúrese de que la propiedad HelpInfoUri del manifiesto del módulo es válida o compruebe la conexión de red e intente ejecutar el comando de nuevo.</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
@@ -298,176 +298,176 @@
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>No se admite la referencia cultural especificada: {0}. Especifique una referencia cultural de la lista siguiente: {{{1}}}.</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>Si se pospone el error y se prueban las referencias culturales de reserva, se mostrará como error si no se admite ninguna de las referencias de reserva:
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>No se encuentra el directorio ModuleBase. Compruebe el directorio e inténtelo de nuevo.</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>La ruta de acceso {0} no es un directorio válido. Asegúrese de que el directorio existe y vuelva a intentarlo.</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>Un URI de Ayuda no puede contener más de 10 redirecciones. Especifique un URI de Ayuda válido.</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>Actualización de Ayuda</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>Conectando con el contenido de Ayuda...</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>Descargando contenido de Ayuda...</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>Instalando contenido de Ayuda...</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>Buscando contenido de Ayuda...</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(Todos)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>No se encontraron módulos de PowerShell que coincidan con el siguiente patrón: {0}. Compruebe el patrón e intente de nuevo el comando.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>No se encontraron módulos de PowerShell que coincidan con el FullyQualifiedModule {0} especificado. Compruebe el valor de FullyQualifiedModule e intente ejecutar el comando de nuevo.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>No se encuentra el contenido de Ayuda. Asegúrese de que el servidor está disponible y de que la ubicación del contenido de Ayuda está definida correctamente en el XML de HelpInfo.</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>Se ha producido un error en el comando Update-Help porque el módulo especificado no admite ayuda que se pueda actualizar. Use Get-Help -Online o busque ayuda en línea para los comandos de este módulo.</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>El siguiente parámetro no debe ser null ni estar vacío: Module.</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>El siguiente parámetro no debe ser null ni estar vacío: Path.</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Update-Help se ha completado correctamente.</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>Error al extraer el contenido de Ayuda.</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>No se puede conectar al contenido de la Ayuda. Es posible que el servidor en el que se almacena el contenido de la Ayuda no esté disponible. Compruebe que el servidor está disponible o espere a que vuelva a estar en línea e intente ejecutar el comando de nuevo.</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>El contenido de Ayuda en la ubicación especificada no es válido. Especifique una ubicación que contenga contenido de Ayuda válido.</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>El XML de HelpInfo no es válido. Especifique XML de HelpInfo válido.</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>El contenido de Ayuda se guardó correctamente en la siguiente ubicación: {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>No se encuentra el archivo XSD de contenido de Ayuda en {0}. Compruebe que el archivo XSD existe en la ubicación especificada y, a continuación, vuelva a intentar el comando.</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
-'{0}'
+    <value>No se pudo guardar la Ayuda para los módulos: 
+"{0}"
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>Guardando Ayuda</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>El contenido de Ayuda contiene archivos que no son válidos. Solo se admiten archivos .txt y .xml.</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>No se pudo guardar la Ayuda para los módulos "{0}": {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>No se pudo guardar la Ayuda para los módulos "{0}" con los idiomas de interfaz de usuario {{{1}}} : {2}.
+El contenido de Ayuda de English-US está disponible y se puede guardar mediante: Save-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>No se pudo actualizar la Ayuda para los módulos "{0}" con los idiomas de interfaz de usuario {{{1}}} : {2}.
+El contenido de Ayuda de English-US está disponible y se puede instalar mediante: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>La cultura actual es ({0}), que no está asociada a ningún idioma. Considere la posibilidad de cambiar la referencia cultural del sistema o instalar el contenido de ayuda de inglés de EE. UU. mediante: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
-    <value>false</value>
+    <value>falso</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>El parámetro -Recurse solo está disponible si se especifica una ruta de acceso de origen.</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>La ruta de acceso {0} no contiene un proveedor FileSystem. Compruebe que la ruta de acceso especificada contiene el proveedor FileSystem y, a continuación, vuelva a intentar el comando.</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>Buscando Ayuda para {0} ...</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>No se encontró ningún idioma de interfaz de usuario que coincida con el siguiente patrón: {0}. Compruebe el patrón e intente de nuevo el comando.</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>No se guardó la Ayuda del módulo {0} porque el comando Save-Help se ejecutó en este equipo en las últimas 24 horas.
+Para guardar la Ayuda de nuevo, agregue el parámetro Force al comando.</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>No se actualizó la Ayuda del módulo {0} porque el comando Update-Help se ejecutó en este equipo en las últimas 24 horas.
+Para actualizar la Ayuda de nuevo, agregue el parámetro Force al comando.</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>Ya se han instalado los archivos de Ayuda más recientes.</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}. Cultura {2} versión {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>Actualizado {0}</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>El valor de la clave HelpInfoUri en el manifiesto del módulo debe resolverse en una URL raíz o contenedor en un sitio web donde se almacenan los archivos de ayuda. El HelpInfoUri "{0}" no se resuelve en un contenedor.</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>El contenido de Ayuda debe estar en el espacio de nombres {0}.</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Get-Help no puede encontrar los archivos de Ayuda para este cmdlet en este equipo. Solo muestra ayuda parcial.
+    -- Para descargar e instalar los archivos de Ayuda del módulo que incluye este cmdlet, use Update-Help.</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>Ya se han descargado los archivos de Ayuda más recientes.</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>Se guardó {0}</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>El HelpInfoURI {0} no comienza con HTTP.</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>El elemento a nivel raíz del contenido de la Ayuda debe ser "helpItems".</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>Guardando Ayuda para el módulo {0}</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>Actualizando Ayuda para el módulo {0}</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>Resolviendo URI: "{0}"</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>URI de Ayuda: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}, Versión actual: {1}, Versión disponible: {2}, UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>PROPIEDADES</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>MÉTODOS</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/Metadata.es.resx
+++ b/src/System.Management.Automation/resources/es/Metadata.es.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>No se pueden inicializar atributos para "{0}": "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>No se puede validar el argumento porque su tipo "{0}" no es del mismo tipo ({1}) que los límites máximo y mínimo del parámetro. Asegúrese de que el argumento es de tipo {1} e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>No se puede validar el argumento "{0}" porque su valor no es mayor que cero.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>No se puede validar el argumento "{0}" porque su valor no es mayor o igual que cero.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>No se puede validar el argumento "{0}" porque su valor no es menor que cero.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>No se puede validar el argumento "{0}" porque su valor no es menor o igual que cero.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>No se puede aceptar el intervalo mínimo especificado ({0}) porque no es del mismo tipo que el intervalo máximo especificado ({1}). Actualice el atributo ValidateRange para el parámetro.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>No se pueden aceptar los tipos de parámetro MaxRange y MinRange. Ambos parámetros deben ser objetos que implementen una interfaz IComparable.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>No se puede aceptar el intervalo máximo especificado porque es menor que el intervalo mínimo especificado. Actualice el atributo ValidateRange para el parámetro.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>El argumento {0} es mayor que el intervalo máximo permitido de {1}. Proporcione un argumento menor o igual que {1} e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>El argumento {0} es menor que el intervalo mínimo permitido de {1}. Proporcione un argumento mayor o igual {1} que e intente el comando de nuevo.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>El argumento "{0}" no coincide con el patrón "{1}". Proporcione un argumento que coincida con "{1}" e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>El atributo ValidateCount no se puede aplicar a un parámetro que no es de matriz. Quite el atributo del parámetro o convierta el parámetro en un parámetro de matriz.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>El parámetro requiere exactamente {0} valores: {1} se proporcionaron valores.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>El parámetro requiere al menos {0} valores y no más de {1} valores: {2} se proporcionaron valores.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>El número máximo de argumentos especificado para un parámetro es menor que el número mínimo de argumentos especificado. Actualice el atributo ValidateCount para el parámetro.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>La longitud de caracteres máxima especificada del argumento es menor que la longitud mínima de caracteres del argumento especificada. Actualice el atributo ValidateLength para el parámetro.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>El atributo ValidateLength no se puede aplicar a un parámetro que no es un parámetro string o string[]. Convierta el parámetro en un parámetro string o string[].</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>La longitud del carácter ({1}) del argumento es demasiado corta. Especifique un argumento con una longitud mayor o igual que "{0}" e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>La longitud de caracteres ({1}) del argumento es demasiado larga. Especifique un argumento con una longitud menor o igual que "{0}" e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>El argumento "{0}" no pertenece al conjunto "{1}" especificado por el atributo ValidateSet. Proporcione un argumento que esté en el conjunto e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>El generador de valores válidos devuelve un valor null.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>"{0}" error en la propiedad "{1}" {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>No se puede obtener o ejecutar el comando. Se ha superado el número máximo de conjuntos de parámetros para este comando.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>No se puede procesar el argumento porque el valor del argumento no es una cadena. Los valores de los argumentos de parámetro que tienen especificado ArgumentTransformationAttribute deben ser cadenas.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>No se puede validar la variable porque el valor {1} no es un valor válido para la {0} variable.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>No se puede agregar el atributo porque la variable {0} con valor {1} ya no sería válida.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>El argumento es null. Proporcione un valor válido para el argumento e intente ejecutar el comando de nuevo.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>El argumento tiene un valor null, o un elemento de la colección de argumentos contiene un valor nulo. Proporcione una colección que no contenga valores null e intente de nuevo el comando.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>El argumento es nulo o está vacío. Especifique un argumento que no sea NULL o esté vacío y, después, vuelva a intentar el comando.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>El argumento es null, está vacío o un elemento de la colección de argumentos contiene un valor null. Proporcione una colección que no contenga valores null e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>El argumento es null, está vacío o solo consta de caracteres de espacio en blanco. Proporcione un argumento que contenga caracteres que no contengan espacios en blanco e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Un elemento de la colección de argumentos es null, está vacío o solo consta de caracteres de espacio en blanco. Proporcione una colección que no contenga esos valores e intente el comando de nuevo.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>Un parámetro con el nombre "{0}" se definió varias veces para el comando.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>No se puede especificar el alias de parámetro porque ya se definió varias veces un alias con el nombre "{0}" para el comando.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>No se puede especificar el parámetro "{0}" porque entra en conflicto con el alias de parámetro del mismo nombre para el parámetro "{1}".</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>El script de validación "{1}" para el argumento con el valor "{0}" no devolvió un resultado de True. Determine por qué se produjo un error en el script de validación e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>El argumento "{0}" no contiene una versión válida de PowerShell. Proporcione un número de versión válido e intente el comando de nuevo.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>No se puede validar el argumento "{0}" porque no es un nombre de variable válido.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>El tipo de conversión de trabajo debe derivarse de IAstToScriptBlockConverter.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>El argumento de ruta de acceso no es válido. Proporcione un argumento de ruta de acceso que sea un tipo de cadena.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>La unidad de argumento de {0} ruta de acceso no pertenece al conjunto de unidades aprobadas: {1}. Proporcione un argumento de ruta de acceso con una unidad aprobada.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>El argumento de ruta de acceso contiene caracteres no válidos.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>El argumento de ruta de acceso no tiene ninguna unidad raíz.  Proporcione un argumento de ruta de acceso completa con una unidad raíz.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>El valor del argumento del parámetro "{0}" no puede ser nulo ni una cadena vacía.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>El miembro de enumeración "{0}" no es un valor válido para el parámetro "{1}". Especifique uno de los siguientes miembros e inténtelo de nuevo: {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>No se puede procesar la entrada. El argumento "{0}" no es de confianza.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>Error en la comprobación del atributo ValidateTrustedData</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>El argumento de parámetro "{0}" no es de confianza y se producirá un error en la comprobación del atributo de parámetro ValidateTrustedData en el modo de lenguaje restringido.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/Modules.es.resx
+++ b/src/System.Management.Automation/resources/es/Modules.es.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>No se cargó el módulo especificado "{0}" porque no se encontró ningún archivo de módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>El módulo especificado "{0}" con la versión "{1}" no se cargó porque no se encontró ningún archivo de módulo válido en ningún directorio de módulo.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>El valor de MaximumVersion "{0}" especificado no era correcto. Si usa "*", MaximumVersion solo admite un "*" y siempre debe colocarse al final de MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>El módulo especificado "{0}" con MaximumVersion "{1}" no se cargó porque no se encontró ningún archivo de módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>No se cargó el módulo especificado "{0}" con MinimumVersion "{1}" y MaximumVersion "{2}" porque no se encontró ningún archivo de módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion "{0}" no debe ser mayor que MaximumVersion "{1}".</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>No se cargó el ensamblado "{0}" porque no se encontró ningún ensamblado con ese nombre. Compruebe el nombre del ensamblado e inténtelo de nuevo.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>El módulo que se va a procesar "{0}", incluido en el campo "{1}" del manifiesto del módulo "{2}", no se procesó porque no se encontró ningún módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>No se devolvió ningún objeto personalizado para el módulo "{0}" porque el parámetro -AsCustomObject solo se puede usar con módulos de script.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>No se pudo procesar el manifiesto del módulo "{0}" porque no es un archivo de manifiesto de módulo de PowerShell válido. Quite los elementos que no están permitidos: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>El procesamiento del archivo de manifiesto de módulo "{0}" no dio como resultado un objeto de manifiesto válido. Actualice el archivo para que contenga un manifiesto de módulo de PowerShell válido. Puede crear un manifiesto válido con el cmdlet New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>No se puede importar el módulo "{0}" porque su manifiesto contiene uno o varios miembros que no son válidos. Los miembros de manifiesto válidos son ({1}). Quite los miembros que no son válidos ({2}) e intente importar el módulo de nuevo.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>La tabla hash que describe un módulo contiene uno o varios miembros que no son válidos. Los miembros válidos son ({0}). Quite los miembros que no son válidos ({1}) e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>No se puede cargar el módulo "{0}" porque se ha superado el límite de anidamiento del módulo. Los módulos solo se pueden anidar a {1} niveles. Evalúe y cambie el orden en que se cargan los módulos para evitar superar el límite de anidamiento e intente ejecutar el script de nuevo.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>El miembro "ModuleVersion" no está presente en el manifiesto del módulo. Este miembro debe existir y tener asignado un número de versión con el formato "n.n.n.n". Agregue el miembro que falta al archivo ''{0}".</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>El miembro "{0}" no es válido en el archivo de manifiesto de módulo ''{2}": {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>La versión "{0}" del módulo "{1}" no cumple la versión mínima requerida ''{2}. Compruebe que se admite el número de versión e intente cargar el módulo de nuevo.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>La versión de PowerShell en este equipo es ''{0}". El módulo "{1}" requiere una versión mínima de PowerShell de "{2}" para ejecutarse. Compruebe que tiene instalada la versión mínima necesaria de PowerShell e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>No se puede usar el miembro de manifiesto de módulo "NestedModules" si el miembro 'ModuleToProcess' es un módulo binario. Edite el archivo de manifiesto del módulo en "{0}" e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>El miembro "{0}" del manifiesto del módulo no es válido: {1}. Compruebe que se ha especificado un valor válido para este campo en el archivo ''{2}".</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>La ruta de acceso del manifiesto del módulo "{0}" no es válida. El valor del argumento Path debe resolverse en un único archivo que tenga una extensión ".psd1". Cambie el valor del argumento Path para que apunte a un archivo psd1 válido e inténtelo de nuevo.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>La clave ModuleVersion del manifiesto del módulo "{0}" especifica la versión del módulo "{1}", que no coincide con el nombre de la carpeta de versión en "{2}". Cambie el valor de la clave ModuleVersion para que coincida con el nombre de la carpeta de versión.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La entrada NestedModule especificada "{0}" en el manifiesto del módulo "{1}" no es válida. Vuelva a intentarlo después de actualizar esta entrada con valores válidos.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La entrada RequiredAssemblies especificada "{0}" en el manifiesto del módulo "{1}" no es válida. Vuelva a intentarlo después de actualizar esta entrada con valores válidos.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La entrada FileList especificada "{0}" en el manifiesto de módulo "{1}" no es válida. Vuelva a intentarlo después de actualizar esta entrada con valores válidos.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La entrada RequiredModules especificada "{0}" en el manifiesto del módulo "{1}" no es válida. Vuelva a intentarlo después de actualizar esta entrada con valores válidos.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La entrada ModuleList especificada "{0}" en el manifiesto de módulo "{1}" no es válida. Vuelva a intentarlo después de actualizar esta entrada con valores válidos.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>El manifiesto del módulo "{0}" se especifica con la clave CompatiblePSEditions, que solo se admite en la versión "5.1" o posterior de PowerShell. Actualice el valor de la clave PowerShellVersion a "5.1" o superior e inténtelo de nuevo.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>El valor especificado "{0}" para CompatiblePSEditions contiene nombres duplicados de la edición de PowerShell. Vuelva a intentarlo después de quitar los nombres duplicados de la edición de PowerShell.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>La versión especificada en la clave ModuleVersion es igual al nombre de la carpeta de versión.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Omitiendo la carpeta {0} Versión en Módulo {1} porque no tiene un archivo de manifiesto de módulo válido.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>El miembro 'ModuleName' no existe en la tabla hash que describe este módulo.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Los miembros "ModuleVersion", "MaximumVersion" y "RequiredVersion" no existen en la tabla hash que describe este módulo. Debe existir uno de estos tres miembros y se le debe asignar un número de versión con el formato "n.n.n.n".</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>El módulo necesario "{1}" no está cargado. Cargue el módulo o quítelo de "RequiredModules" en el archivo "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>El módulo necesario "{1}" con GUID "{2}" no está cargado. Cargue el módulo o quítelo de "RequiredModules" en el archivo "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>El módulo necesario "{1}" con la versión "{2}" no está cargado. Cargue el módulo o quítelo de "RequiredModules" en el archivo "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>El módulo necesario "{1}" con MaximumVersion "{2}" no está cargado. Cargue el módulo o quítelo de "RequiredModules" en el archivo "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>El módulo necesario "{1}" con MinimumVersion "{2}" y MaximumVersion "{3}" no está cargado. Cargue el módulo o quítelo de "RequiredModules" en el archivo "{0}".</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>No se encuentra el módulo "{0}" con ModuleVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>No se encuentra el módulo "{0}" con RequiredVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>No se encuentra el módulo "{0}" con MaximumVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>No se encuentra el módulo "{0}" con ModuleVersion "{1}" y MaximumVersion ''{2}".</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>No se encuentra el módulo "{0}".</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>No se quitó ningún módulo. Compruebe que la especificación de los módulos que se van a quitar es correcta y que esos módulos existen en el espacio de ejecución.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>El miembro "{0}", que se importó desde el módulo ''{1}", no se puede quitar por el siguiente motivo: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>No se puede quitar el módulo "{0}" porque es de solo lectura. Agregue el parámetro Force al comando para quitar módulos de solo lectura.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>No se puede quitar el módulo "{0}" porque está marcado como "constant". No se puede quitar un módulo si está marcado como "constant".</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>No se puede quitar el módulo "{0}" porque lo requiere "{1}". Agregue el parámetro Force al comando para quitar el módulo.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Solo se puede llamar al cmdlet Export-ModuleMember desde dentro de un módulo.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>La extensión "{0}" no es una extensión de módulo válida. Las extensiones de módulo admitidas son ".dll", ".ps1", ".psm1", ".psd1" y ".cdxml". Corrija la extensión y vuelva a intentar agregar el archivo "{1}".</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Esta operación no se puede realizar en un módulo binario. Solo se puede realizar en un módulo de script.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>No se permite el archivo "{0}" porque no tiene la extensión ".ps1".</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Desconocido</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Todos los derechos reservados.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Quitando la función "{0}" importada.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Quitando el alias "{0}" importado.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Quitando la variable "{0}" importada.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Cargando módulo desde la ruta de acceso "{0}".</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Cargando "{0}" desde la ruta de acceso "{1}".</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Dot-sourcing del archivo de script ''{0}".</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Importando función "{0}".</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Importando cmdlet "{0}".</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Importando alias "{0}".</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Importando variable ''{0}".</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Exportando cmdlet "{0}".</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Exportando función "{0}".</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Exportando alias "{0}".</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Exportando variable "{0}".</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Los nombres de algunos comandos importados del módulo "{0}" incluyen verbos no aprobados que podrían hacer que sean menos reconocibles. Para buscar los comandos con verbos no aprobados, vuelva a ejecutar el comando Import-Module con el parámetro Verbose. Para obtener una lista de verbos aprobados, escriba Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Se importó el comando "{0}" del módulo "{1}", pero como su nombre no incluye un verbo aprobado, puede ser difícil de encontrar. Para obtener una lista de verbos aprobados, escriba Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Se importó el comando "{0}" del módulo "{2}", pero como su nombre no incluye un verbo aprobado, puede ser difícil de encontrar. Los verbos alternativos sugeridos son "{1}".</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Algunos nombres de comando importados contienen uno o varios de los siguientes caracteres restringidos: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>El nombre de comando "{0}" del módulo "{1}" contiene uno o varios de los siguientes caracteres restringidos: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Creando el archivo de manifiesto del módulo "{0}".</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (ruta de acceso: "{1}")</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>La arquitectura actual del procesador es: {0}. El módulo "{1}" requiere la arquitectura siguiente: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>El nombre del host de PowerShell actual es: "{0}". El módulo "{1}" requiere el siguiente host de PowerShell: "{2}".</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>El host de PowerShell actual es: "{0}" (versión {1}). El módulo "{2}" requiere una versión mínima del host de PowerShell de "{3}" para ejecutarse.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Manifiesto de módulo para el módulo "{0}"</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Generado por: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Generado el: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Módulo de script o archivo de módulo binario asociado a este manifiesto.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Módulos que se van a importar como módulos anidados del módulo especificado en RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>Id. usado para identificar de forma única este módulo</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Autor de este módulo</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Empresa o proveedor de este módulo</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Declaración de copyright para este módulo</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Número de versión de este módulo.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Descripción de la funcionalidad proporcionada por este módulo</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Versión mínima del motor de PowerShell requerida por este módulo</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Versión mínima de Common Language Runtime (CLR) requerida por este módulo. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Módulos que se deben importar en el entorno global antes de importar este módulo</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Archivos de script (.ps1) que se ejecutan en el entorno del autor de la llamada antes de importar este módulo.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Archivos de tipo (.ps1xml) que se cargarán al importar este módulo</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Archivos de formato (.ps1xml) que se cargarán al importar este módulo</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Ensamblados que deben cargarse antes de importar este módulo</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Lista de todos los archivos empaquetados con este módulo</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Datos privados que se van a pasar al módulo especificado en RootModule/ModuleToProcess. También puede contener una tabla hash PSData con metadatos de módulo adicionales usados por PowerShell.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Etiquetas aplicadas a este módulo. Esto ayuda con la detección de módulos en galerías en línea.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>Una dirección URL al sitio web principal de este proyecto.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>Una dirección URL a la licencia de este módulo.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>Dirección URL a un icono que representa este módulo.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Notas de la versión de este módulo</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Cadena de versión preliminar de este módulo</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Marca para indicar si el módulo requiere la aceptación explícita del usuario para instalar, actualizar o guardar</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Módulos dependientes externos de este módulo</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Final de {0} tabla hash</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>El valor del parámetro PrivateData debe ser una tabla hash para crear el manifiesto del módulo con los siguientes valores de parámetro Tags, ProjectUri, LicenseUri, IconUri o ReleaseNotes. Quite los valores de los parámetros Tags, ProjectUri, LicenseUri, IconUri o ReleaseNotes o encapsule el contenido de PrivateData en una tabla hash.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData debe definirse como una tabla hash, pero este manifiesto de módulo lo define como un objeto. Considere la posibilidad de encapsular el contenido de PrivateData en una tabla hash. Esto le permitirá agregar las propiedades Tags, ProjectUri, LicenseUri, IconUri y ReleaseNotes al manifiesto del módulo más adelante.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>El valor especificado "{0}" no es válido; inténtelo de nuevo con un valor válido.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Las funciones para exportar desde este módulo, para obtener el mejor rendimiento, no usan caracteres comodín y no eliminan la entrada, use una matriz vacía si no hay ninguna función para exportar.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Los alias para exportar desde este módulo, para obtener el mejor rendimiento, no usan caracteres comodín y no eliminan la entrada, usan una matriz vacía si no hay ningún alias para exportar.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Los cmdlets para exportar desde este módulo, para obtener el mejor rendimiento, no usan caracteres comodín y no eliminan la entrada, usan una matriz vacía si no hay cmdlets para exportar.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Variables para exportar desde este módulo</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Recursos de DSC para exportar desde este módulo</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>PSEditions admitidas</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Arquitectura de procesador (None, X86, Amd64) requerida por este módulo</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Lista de todos los módulos empaquetados con este módulo</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Versión mínima de Microsoft .NET Framework requerida por este módulo. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Nombre del host de PowerShell requerido por este módulo</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Versión mínima del host de PowerShell requerida por este módulo</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>URI de HelpInfo de este módulo</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Dado que el {0} módulo proporciona el PSDrive en la sesión actual de PowerShell, no se quitó ningún módulo. Cambie el proveedor de PSDrive actual e intente quitar módulos de nuevo.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>No se importó el cmdlet "{0}" porque hay un miembro con el mismo nombre en el ámbito actual.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>No se importó el alias "{0}" porque hay un miembro con el mismo nombre en el ámbito actual.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>No se importó la función "{0}" porque hay un miembro con el mismo nombre en el ámbito actual.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>No se importó la variable "{0}" porque hay un miembro con el mismo nombre en el ámbito actual.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>No se permiten caracteres comodín en los miembros "ModuleToProcess", "RootModule" o "NestedModules" en el manifiesto de módulo "{0}".</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>El módulo "{0}" es un módulo principal de PowerShell. Agregue el parámetro Force al comando para quitar los módulos principales.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>El manifiesto del módulo no puede contener los miembros "ModuleToProcess" y "RootModule". Cambie el archivo de manifiesto del módulo para quitar uno de estos miembros en ''{0}" e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>El miembro del manifiesto de módulo "ModuleToProcess" está en desuso. En su lugar, use el miembro "RootModule".</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Prefijo predeterminado para los comandos exportados desde este módulo. Invalide el prefijo predeterminado mediante Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Los parámetros "Global" y "Scope" no se pueden especificar juntos. Quite uno de estos parámetros e intente ejecutar el comando de nuevo.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>El módulo necesario "{0}" no está cargado. El módulo "{0}" tiene un requiredModule "{1}" en su manifiesto de módulo "{2}" que apunta a una dependencia cíclica.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>No se cargó el módulo necesario "{0}" porque no se encontró ningún archivo de módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Algunos comandos del módulo {0} no se pueden importar a través de una CimSession. Para obtener todos los comandos, compruebe que el servidor remoto tiene habilitada la administración remota de PowerShell e intente agregar el parámetro PSSession a un cmdlet Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>El módulo {0} se carga en Windows PowerShell mediante {1} la sesión remota; tenga en cuenta que toda la entrada y salida de los comandos de este módulo serán objetos deserializados. Si desea cargar este módulo en PowerShell, use la sintaxis "Import-Module -SkipEditionCheck".</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Se detectó Windows PowerShell versión {0}. Se requiere Windows PowerShell 5.1 para cargar módulos mediante la característica de compatibilidad con Windows PowerShell. Instale Windows Management Framework (WMF) 5.1 desde https://aka.ms/WMF5Download para habilitar esta característica.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>La configuración "WindowsPowerShellCompatibilityModuleDenyList" del archivo de configuración de PowerShell bloquea la carga del módulo "{0}" mediante la característica de compatibilidad de Windows PowerShell.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>No se puede importar el módulo {0} a través de una CimSession. Pruebe a usar el parámetro PSSession del cmdlet Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>No se admite el valor de arquitectura de procesador de {0}. Vuelva a ejecutar el comando New-ModuleManifest y especifique uno de los siguientes valores de enumeración admitidos para la arquitectura del procesador: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>La ejecución del cmdlet Get-Module en un equipo remoto solo puede enumerar los módulos disponibles. Agregue el parámetro ListAvailable al comando e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>No se importó el módulo "{0}" porque ya se importó el complemento ''{0}".</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>No se permiten caracteres comodín en el miembro "RequiredAssemblies" del manifiesto de módulo "{0}".</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>El valor de la {0} clave en {1} es {2} y el módulo tiene módulos anidados. Cuando un archivo CDXML es el módulo raíz, se produce un error en el comando Import-Module porque los comandos de los módulos anidados no se pueden exportar. Mueva el archivo CDXML a la clave NestedModules e intente el comando de nuevo.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Error del comando remoto: {0}{{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>No se pudieron generar servidores proxy para el módulo remoto "{0}". {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>No se pudo procesar el módulo remoto {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>No se pudieron recibir los datos del módulo de la CimSession remota. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>El módulo necesario "{0}" con el GUID "{1}" y la versión "{2}" no se cargó porque no se encontró ningún archivo de módulo válido en ningún directorio de módulos.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>No se encontró un proveedor CIM para la detección de módulos en el servidor CIM. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>No se puede comprobar la versión {0} de Microsoft .NET Framework porque no está incluida en la lista de versiones permitidas.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Analizando {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Preparando los módulos para su primer uso.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Buscando módulos disponibles</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Buscando el recurso compartido UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>La ejecución del cmdlet Get-Module en un equipo remoto solo se puede realizar para nombres de módulo que no incluyan una ruta de acceso. El parámetro Name tiene este elemento "{0}" que se resuelve en una ruta de acceso. Actualice el parámetro Name para que no tenga elementos de ruta de acceso e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>No se admite la ejecución del cmdlet Get-Module sin el parámetro ListAvailable para los nombres de módulo que incluyen una ruta de acceso. El parámetro Name tiene este elemento "{0}" que se resuelve en una ruta de acceso. Actualice el parámetro Name para que no tenga elementos de ruta de acceso e inténtelo de nuevo.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>No se encontró el módulo especificado "{0}". Actualice el parámetro Name para que apunte a una ruta de acceso válida e inténtelo de nuevo. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Rellenando la propiedad RepositorySourceLocation para el módulo {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>El módulo que se va a procesar "{0}", incluido en el campo "{1}" del manifiesto del módulo "{2}", no se procesó. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Este requisito previo solo es válido para la edición de PowerShell Desktop.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>El módulo "{0}" no admite la edición actual de PowerShell "{1}". Sus ediciones admitidas son ''{2}". Use "Import-Module -SkipEditionCheck" para omitir la compatibilidad de este módulo.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>El módulo "{0}" admite la edición de PowerShell "{1}" y no se puede cargar implícitamente mediante la característica compatibilidad de Windows porque está deshabilitado en el archivo de configuración. Use "Import-Module -UseWindowsPowerShell" para cargar este módulo con Windows PowerShell o "Import-Module -SkipEditionCheck" para intentar cargar el módulo con el PowerShell actual.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Se debe especificar un valor de cadena no vacío para una característica experimental declarada en el manifiesto del módulo.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Se encontraron uno o varios nombres de características experimentales no válidos: {0}. El nombre de una característica experimental de módulo debe seguir esta convención: "ModuleName.FeatureName".</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>El parámetro de modificador -SkipEditionCheck no se puede usar sin el parámetro de modificador -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>No se permite importar archivos *.ps1 como módulos en el modo ConstrainedLanguage.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Error al cargar el módulo {0} de script porque tiene un modo de lenguaje diferente al manifiesto del módulo. El modo de lenguaje del manifiesto es {1} y el modo de lenguaje del módulo es {2}. Asegúrese de que todos los archivos de módulo están firmados o forman parte de la configuración de la lista de permitidos de la aplicación.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Este módulo usa el operador dot-source al exportar funciones con caracteres comodín, y esto no se permite cuando el sistema está bajo aplicación estricta de la verificación de aplicaciones.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>No se pueden exportar los miembros del módulo de un módulo que tiene un modo de lenguaje diferente al de la sesión en ejecución.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>No se puede crear un nuevo módulo mientras la sesión está en modo ConstrainedLanguage.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>No se encuentra el módulo integrado "{0}" compatible con la edición "Core". Asegúrese de que los módulos integrados de PowerShell están disponibles. Normalmente vienen con el paquete de PowerShell en la ruta de acceso del módulo $PSHOME y son necesarios para que PowerShell funcione correctamente.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Cmdlet Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>Se producirá un error en la exportación de los miembros del módulo en el modo de lenguaje restringido porque el módulo "{0}" tiene un modo de lenguaje "{1}" que es diferente de la sesión actual "{2}".</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Exportación de funciones implícitas del módulo</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>Se denegará la exportación implícita de funciones para el módulo "{0}" porque es de confianza (se ejecuta en modo de lenguaje completo), pero la sesión no es de confianza (se ejecuta en modo de lenguaje restringido). Se recomienda exportar siempre las funciones del módulo individualmente por nombre completo.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Importando archivo de script como módulo</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>La importación del archivo de script "{0}" como módulo no se permitirá en el modo ConstrainedLanguage.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>El módulo contiene el operador dot-source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>La importación del módulo "{0}" producirá un error en el modo de lenguaje restringido porque exporta funciones con caracteres comodín mientras también usa el operador dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"Funciones de exportación de módulos</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>El módulo "{0}" exporta funciones con caracteres comodín de nombre. Los nombres de función de módulo anidados se quitarán cuando se ejecuten en modo de lenguaje restringido.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"Cmdlet New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Se bloqueará un nuevo módulo de una sesión de lenguaje restringido que no sea de confianza para que no proporcione el bloque de script FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"Modos de idioma no coincidentes del módulo</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Se está cargando un módulo dependiente que tiene un modo de lenguaje diferente al primario. Esto no se permitirá cuando esté en modo de lenguaje restringido.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/PSConfigurationStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/PSConfigurationStrings.es.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell ha dejado de funcionar debido a un problema de seguridad: no se puede leer el archivo de configuración: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/ParserStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/ParserStrings.es.resx
@@ -127,7 +127,7 @@
     <value>Token de cadena incompleto.</value>
   </data>
   <data name="InvalidUnicodeEscapeSequence" xml:space="preserve">
-    <value>The Unicode escape sequence is not valid. A valid sequence is `u{ followed by one to six hex digits and a closing '}'.</value>
+    <value>La secuencia de escape Unicode no es válida. Una secuencia válida es `u{ seguida de entre uno y seis dígitos hexadecimales y un "}" de cierre.</value>
   </data>
   <data name="InvalidUnicodeEscapeSequenceValue" xml:space="preserve">
     <value>El valor de secuencia de escape Unicode está fuera del intervalo. El valor máximo es 0x10FFFF.</value>

--- a/src/System.Management.Automation/resources/es/RemotingErrorIdStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/RemotingErrorIdStrings.es.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>No se admiten caracteres comodín para el parámetro FilePath. Especifique una ruta de acceso sin caracteres comodín.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>Se debe especificar un {0} valor para la opción de sesión {1}.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>El número máximo de redireccionamientos de URI de WS-Man que se permiten al conectarse a un equipo remoto</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>El parámetro WriteEvents no se puede usar sin el parámetro Wait.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>La comunicación remota de PowerShell no se admite en el Entorno de preinstalación de Windows (WinPE).</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>Los cambios realizados por {0} no pueden surtir efecto hasta que se reinicie el servicio WinRM.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0} es posible que tenga que reiniciar el servicio WinRM si recientemente se ha anulado el registro de una configuración que usa este nombre, es posible que algunas estructuras de datos del sistema aún se almacenen en caché. En ese caso, puede ser necesario reiniciar WinRM.
+Todas las sesiones de WinRM conectadas a configuraciones de sesión de PowerShell, como Microsoft.PowerShell, y a configuraciones de sesión creadas con el cmdlet Register-PSSessionConfiguration, se desconectan.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>Está ejecutando una sesión remota y ha seleccionado la opción Force, lo que significa que el servicio WinRM puede reiniciarse. Si el servicio WinRM se reinicia, esta sesión remota finalizará y tendrá que crear una nueva sesión para continuar</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>El parámetro -WriteJobInResults no se puede usar sin el parámetro -Wait</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>El flujo de entrada proporcionado no es válido. Solo {0} se admite como flujo de entrada.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>El conjunto de flujos de salida proporcionado no es válido. Solo {0} se admite como flujo de salida.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>El WSMAN_SENDER_DETAILS proporcionado no es válido. No se puede procesar la WSMAN_SENDER_DETAILS null.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>El contexto de shell proporcionado no es válido.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>No se permite {0} el valor NULL con el método {1}de complemento.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>No se permite un valor NULL para los conjuntos de flujo de entrada y de flujo de salida. {0} y {1} son los flujos de entrada y salida admitidos.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>No se permite {0} el valor NULL con el método {1}de complemento.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>No se permite {0} el valor NULL con el método {1}de complemento.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>La operación del complemento de PowerShell se está cerrando. Esto puede ocurrir si el servicio de hospedaje o la aplicación se está cerrando.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>El complemento de PowerShell no entiende la opción {0}. Asegúrese de que el cliente es compatible con la compilación {1} y la versión {2} de protocolo de PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Se espera una opción con el nombre {0} del cliente. Asegúrese de que el cliente es compatible con la compilación {1} y la versión {2} de protocolo de PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;El complemento de PowerShell no admite la versión del protocolo {2} solicitada por el cliente.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>El complemento de PowerShell encontró un error irrecuperable al notificar el contexto al servicio WSMan.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>No se puede crear la sesión del servidor administrado.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>El complemento de PowerShell encontró un error irrecuperable al registrar un identificador de espera para la notificación de apagado.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>No se encontró el archivo ejecutable "{0}". Compruebe que la característica WOW64 está instalada.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>No se puede crear Windows PowerShell proceso porque no se encontró Windows PowerShell en este equipo.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/es/RunspaceStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/RunspaceStrings.es.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>El estado del espacio de ejecución no es válido para esta operación.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>No se puede abrir el espacio de ejecución porque el espacio de ejecución no está en el estado BeforeOpen. El estado actual del espacio de ejecución es "{0}".</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>No se puede realizar la operación porque el espacio de ejecución no tiene el estado Opened. El estado actual del espacio de ejecución es "{0}".</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>No se puede invocar la canalización porque el espacio de ejecución no tiene el estado Opened. El estado actual del espacio de ejecución es "{0}".</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>El estado de canalización no es válido para esta operación.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>No se puede invocar la canalización porque ya se ha invocado.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>El valor válido para el parámetro es PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>La canalización no contiene un comando.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>No se ejecutó la canalización porque ya se está ejecutando una canalización. Las canalizaciones no se pueden ejecutar simultáneamente.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>Una canalización anidada no se puede invocar de forma asincrónica. Use el método de Invocar.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>Solo debe ejecutar una canalización anidada desde dentro de una canalización en ejecución.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>No se puede cerrar el espacio de ejecución mientras haya una llamada al método SessionStateProxy en curso.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>No se puede invocar la canalización mientras hay una llamada al método SessionStateProxy en curso.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Hay una llamada al método SessionStateProxy en curso. No se permiten llamadas simultáneas al método SessionStateProxy.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Ya se está ejecutando una canalización. No se permiten llamadas simultáneas al método SessionStateProxy.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Esta propiedad no se puede cambiar una vez abierto el espacio de ejecución.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Se produjeron uno o varios errores al procesar el módulo "{0}" especificado en el objeto InitialSessionState usado para crear este espacio de ejecución. Consulte la propiedad ErrorRecords para obtener una lista completa de errores. El primer error fue: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>Las opciones de subproceso solo se pueden cambiar si el estado del contenedor es contenedor multiproceso (MTA), las opciones actuales son UseNewThread o UseCurrentThread y el nuevo valor es ReuseThread.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>{0} no puede ser false cuando el modo de idioma es {1} o {2}.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>No se puede desconectar un espacio de ejecución solo local.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>La operación Connect no se admite en espacios de ejecución locales.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>La sesión está ocupada. Se conectará a la sesión en cuanto esté disponible. Para cancelar el comando Enter-PSSession, presione Ctrl-C.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>El comando no se ha podido completar. No se admite la invocación de scripts en esta configuración de sesión. Esto puede ocurrir si la configuración de sesión está en modo sin idioma.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>No puede usar las operaciones Disconnect y Connect en espacios de ejecución locales.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>No se puede conectar la canalización porque el espacio de ejecución no está en el estado Abierto.  El estado actual del espacio de ejecución es "{0}".</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>No se puede construir un RemoteRunspace. El objeto RunspacePool proporcionado no es válido.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>No hay ningún comando desconectado asociado a este espacio de ejecución.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>La operación de desconexión no se admite en el equipo remoto. Para admitir la desconexión, el equipo remoto debe ejecutar Windows PowerShell 3.0 o una versión posterior de Windows PowerShell y usar el transporte WSMan.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>No se puede conectar la PSSession porque la sesión no está en estado Desconectado o no está disponible para la conexión.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>El valor del parámetro no puede ser PipelineResultTypes.None ni PipelineResultTypes.Output.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>Los valores válidos para el parámetro son PipelineResultTypes.Output o PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>No se admite la redirección de secuencias de depuración en el equipo remoto de destino.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>No se admite el redireccionamiento detallado de secuencias en el equipo remoto de destino.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>El redireccionamiento de secuencias de advertencia no se admite en el equipo remoto de destino.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>El redireccionamiento de flujo de información no se admite en el equipo remoto de destino.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>Ha entrado en una sesión que está ocupada ejecutando un comando o script.  Dado que la salida se enruta al trabajo "{0}", no verá la salida en la consola.  Puede esperar a que finalice el comando en ejecución o cancelar el comando y obtener un símbolo del sistema de entrada presionando Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>Ha entrado en una sesión que está ocupada ejecutando un comando o script y la salida se mostrará en la consola.  Puede esperar a que finalice el comando en ejecución o cancelarlo y obtener un mensaje de entrada presionando Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>Ha entrado en una sesión que está detenida actualmente en un punto de interrupción de depuración dentro de un comando o script en ejecución.  Use el depurador de línea de comandos de PowerShell para continuar con la depuración.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace debe ser LocalRunspace</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>La propiedad PrimaryRunspace estática solo se puede establecer una vez y ya se ha establecido.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/SessionStateStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/SessionStateStrings.es.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>No se puede procesar la información devuelta porque la información devuelta desde el método Start del proveedor era para un proveedor diferente del que se pasó.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>No se puede procesar la información devuelta porque la información devuelta desde el método Start del proveedor era null.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación GetItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación SetItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación SetItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso ''{1}". {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación ClearItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación InvokeDefaultAction en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación InvokeDefaultAction no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación ItemExists en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación ItemExists no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación IsValidPath en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación IsItemContainer en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación RemoveItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetChildItems en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación GetChildItems no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetChildNames en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación GetChildNames no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación RenameItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación RenameItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación NewItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación NewItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación HasChildItems en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación CopyItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación CopyItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetParentPath en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación NormalizeRelativePath en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación MakePath en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetChildName en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación MoveItem en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación MoveItem no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación GetProperty no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación SetProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación SetProperty no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación ClearProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación ClearProperty no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación NewProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación NewProperty no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación RemoveProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación RemoveProperty no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación CopyProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>No se pueden recuperar los parámetros dinámicos de la operación CopyProperty para el proveedor "{0}" de la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación MoveProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>No se pueden recuperar los parámetros dinámicos de la operación MoveProperty para el proveedor "{0}" de la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación RenameProperty en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>No se pueden recuperar parámetros dinámicos para RenameProperty para el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>No se puede recuperar el lector de contenido para el proveedor "{0}" para la ruta de acceso ''{1}". {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>No se pueden recuperar los parámetros dinámicos de la operación GetContentReader para el proveedor "{0}" de la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>No se puede recuperar el escritor de contenido para el proveedor "{0}" para la ruta de acceso ''{1}". {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>No se pueden recuperar los parámetros dinámicos de la operación GetContentWriter para el proveedor "{0}" de la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>No se puede obtener contenido porque es un directorio: "{0}". Use "Get-ChildItem" en su lugar.</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>No se puede escribir contenido porque es un directorio: "{0}".</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>No queda ningún historial de ubicaciones para navegar hacia atrás.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>No queda ningún historial de ubicaciones para avanzar.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack está vacío.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación ClearContent en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>No se puede borrar el contenido de "{0}" porque es un directorio. Clear-Content solo se admite en archivos.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Los parámetros dinámicos para la operación ClearContent no se pueden recuperar del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación GetSecurityDescriptor en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación SetSecurityDescriptor en el proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>Error al intentar realizar la operación De inicio en el proveedor ''{0}". {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>Error al intentar realizar la operación InitializeDefaultDrives en el proveedor ''{0}".</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>Error al intentar realizar la operación NewDrive en el proveedor "{0}" para la unidad con la raíz "{1}". {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>No se pueden recuperar parámetros dinámicos para NewDrive para el proveedor ''{0}". {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>Error en la invocación de RemoveDrive en el proveedor ''{0}". {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>No se puede quitar la unidad "{0}" porque el proveedor "{1}" lo impidió.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>La ruta de acceso "{0}" hacía referencia a un elemento que estaba fuera de la base ''{1}".</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Error en la invocación de Seek en el escritor de contenido del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>Error en la invocación de Close en el lector de contenido o escritor del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>Error en la invocación de Read en el lector de contenido del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Error en la invocación de Write en el escritor de contenido del proveedor "{0}" para la ruta de acceso "{1}". {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>El proveedor "{0}" no se puede usar para obtener o establecer datos mediante la sintaxis de variable. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>La sintaxis de variable no se puede usar para obtener o establecer datos en el proveedor. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>No se puede escribir en el alias porque el alias {0} es de solo lectura o constante y no se puede modificar.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>No se puede escribir en la función {0} porque es de solo lectura o constante.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>No se puede sobrescribir la variable {0} porque es de solo lectura o constante.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>No se puede tener acceso a la variable "${0}" porque es una variable privada.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>No se puede tener acceso al comando "{0}" porque es un comando privado.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>No se puede tener acceso al comando porque es un comando privado.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>No se puede acceder al recurso de estado de sesión porque es un recurso privado. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>No se quitó el alias {0} porque es constante o de solo lectura.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>No se puede quitar la función {0} porque es constante.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>No se puede quitar la variable {0} porque es constante o de solo lectura. Si la variable es de solo lectura, intente la operación de nuevo especificando la opción Force.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>El alias {0} no se puede modificar porque es constante.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>No se puede modificar el alias {0} porque es de solo lectura.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>No se puede modificar la función {0} porque es constante.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>No se puede modificar la función {0} porque es de solo lectura.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>El alias {0} no se puede convertir en constante después de crearse. Los alias solo se pueden hacer constantes en el momento de la creación.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>La función existente {0} no se puede convertir en constante. Las funciones solo se pueden hacer constantes en el momento de la creación.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>La variable {0} existente no se puede hacer constante. Las variables solo se pueden convertir en constantes en el momento de la creación.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>La opción AllScope no se puede quitar del alias ''{0}.</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>La opción AllScope no se puede quitar de la función "{0}".</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>La opción AllScope no se puede quitar de la variable "{0}".</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>La definición de función "{0}" contenía un calificador de ámbito, pero ningún nombre de función.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>No se puede quitar el proveedor {0}. Todas las unidades asociadas con el proveedor {0} deben quitarse antes de que se pueda quitar el proveedor {0}.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>No se puede procesar el nombre de la unidad porque contiene uno o varios de los caracteres siguientes que no son válidos: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>Error al crear la nueva unidad porque el proveedor no permite la creación de la nueva unidad.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>El valor proporcionado "{0}" se resolvió en más de una pila de ubicación.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>No se encuentra la pila de ubicación "{0}". No existe o no es un contenedor.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>No se encuentra la ruta de acceso '{0}' porque no existe.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>No se encuentra el alias porque el alias "{0}" no existe.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>No se puede establecer la ubicación porque la ruta de acceso "{0}" se resolvió en varios contenedores. Solo puede establecer la ubicación en un único contenedor a la vez.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>No se puede procesar la variable porque la ruta de acceso de la variable "{0}" se resolvió en varios elementos. Solo puede obtener o establecer el valor de variable de un elemento a la vez.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>No se encuentra la unidad. No existe una unidad con el nombre "{0}".</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>No se encuentra un proveedor con el nombre ''{0}".</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>No se encuentra un proveedor con el nombre ''{0}". El nombre no tiene el formato adecuado. Un nombre de proveedor solo puede ser caracteres alfanuméricos o un nombre de complemento de PowerShell seguido de un solo '\', seguido de caracteres alfanuméricos.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>"{0}" se resolvió en más de un nombre de proveedor. Las posibles coincidencias incluyen:{1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Error al intentar crear una instancia del proveedor. No se encontró el nombre de tipo de proveedor "{0}" en el ensamblado.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>No se puede usar el nombre de proveedor especificado "{0}" porque contiene uno o varios de los siguientes caracteres que no son válidos: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>Error al intentar crear una instancia del proveedor ''{0}". {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>No se encuentra una variable con el nombre ''{0}".</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>No se encuentra un origen de seguimiento con el nombre "{0}".</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>Ya existe una unidad con el nombre "{0}".</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>Ya existe una variable con el nombre "{0}".</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>No se permite el alias porque ya existe un alias con el nombre ''{0}".</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>No se puede registrar el proveedor de cmdlets porque ya existe un proveedor de cmdlets con el nombre ''{0}".</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>La ruta de acceso no hace referencia a una ruta de acceso del sistema de archivos.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>No se puede quitar el ámbito global.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>El número de ámbito "{0}" supera el número de ámbitos activos.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>No se puede comparar PSDriveInfo. Una instancia de PSDriveInfo solo se puede comparar con otra instancia de PSDriveInfo.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>El proveedor de cmdlets no puede transmitir los resultados porque no se especificó ningún cmdlet a través del cual transmitir la salida.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>El proveedor de cmdlet no puede transmitir los resultados porque no se especificó ningún cmdlet a través del cual transmitir el error.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>La ubicación principal de este proveedor no está establecida. Para establecer la ubicación principal, llame a "(get-psprovider ''{0}). Inicio = 'path'".</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>La ruta de acceso no tiene el formato correcto. Las rutas de acceso del proveedor deben contener un identificador de proveedor, seguido de "::", seguido de una ruta de acceso específica del proveedor.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>No se puede mover el elemento porque la ruta de acceso de destino solo se puede resolver en una única ruta de acceso.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>No se puede mover el elemento porque las rutas de acceso de origen y destino no se resolvieron en el mismo proveedor.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>No se puede mover el elemento porque la ruta de acceso de origen apunta a uno o varios elementos y la ruta de acceso de destino no es un contenedor. Valide que la ruta de acceso de destino sea un contenedor e inténtelo de nuevo.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>No se puede mover el elemento porque el destino se resolvió en varias rutas de acceso. Especifique una ruta de acceso de destino que se resuelva en un único destino e inténtelo de nuevo.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>No se puede copiar el contenedor en el elemento hoja existente.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>El contenedor no se puede copiar en otro contenedor. No se especificó el parámetro -Recurse ni el parámetro -Container.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>La ruta de acceso de origen y destino no se resolvió en el mismo proveedor.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>No se puede cambiar el nombre del elemento porque la ruta de acceso se resolvió en varios elementos. Solo se puede cambiar el nombre de un elemento a la vez.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>No se puede usar el proveedor "{0}" para resolver la ruta de acceso "{1}" debido a un error en el proveedor.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>No se puede usar la interfaz. Este proveedor no implementa la interfaz IContentCmdletProvider.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>No se puede usar la interfaz. Este proveedor no admite la interfaz IPropertyCmdletProvider.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>No se puede usar la interfaz. Este proveedor no implementa la interfaz IDynamicPropertyCmdletProvider.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>Este proveedor no admite los métodos NavigationCmdletProvider.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Métodos de proveedor no procesados. Este proveedor no admite los métodos ContainerCmdletProvider.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>No se pueden llamar a métodos. Este proveedor no admite los métodos ItemCmdletProvider.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>Este proveedor no admite los métodos DriveCmdletProvider.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>Operación de proveedor detenida porque el proveedor no admite esta operación.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>La operación del proveedor se detuvo porque el proveedor no admite el parámetro "Depth".</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>No se puede llamar al método. Este proveedor no admite el método Seek para contenido.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>No se puede realizar la operación ClearContent. Este proveedor no admite la operación ClearContent.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>El proveedor no admite el uso de credenciales. Vuelva a realizar la operación sin especificar las credenciales.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>El proveedor FileSystem solo admite credenciales en el cmdlet New-PSDrive. Vuelva a realizar la operación sin especificar las credenciales.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>El proveedor no admite transacciones. Vuelva a realizar la operación sin el parámetro -UseTransaction.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>No se puede llamar al método. El proveedor no admite el uso de filtros.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>No se puede crear la unidad. El proveedor no admite el uso de credenciales.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>El elemento de la ruta de acceso "{0}'"ya existe.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>No se puede copiar el elemento. El elemento de la ruta de acceso "{0}" no existe.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>El elemento de la ruta de acceso "{0}" no existe.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Unidad que contiene una vista de los alias almacenados en un estado de sesión</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>Unidad que contiene una vista de las variables de entorno del proceso</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Unidad que contiene una vista de las funciones almacenadas en un estado de sesión</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Unidad que contiene una vista de las variables almacenadas en un estado de sesión</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Unidad que se asigna a la ruta de acceso del directorio temporal para el usuario actual</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>No se puede crear el vínculo "{0}" porque no se especificó el valor de destino.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Las referencias a la variable null siempre devuelven el valor null. Las asignaciones no tienen ningún efecto.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Número máximo de objetos de historial que se conservarán en una sesión</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>No se puede cambiar el nombre de la función porque la función {0} es de solo lectura o constante.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>No se puede cambiar el nombre del alias porque el alias {0} es de solo lectura o constante.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>No se puede cambiar el nombre de la variable {0} porque es de solo lectura o constante.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>No se pueden establecer opciones en la variable local {0}. Use New-Variable para crear una variable que permita establecer opciones.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>No se puede modificar el cmdlet {0} porque es de solo lectura.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>No se puede quitar la variable {0} porque se ha optimizado y no se puede quitar. Pruebe a usar el cmdlet Remove-Variable (sin ningún alias) o use dot-sourcing para usar el comando que usa para quitar la variable.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>No se puede sobrescribir la variable {0} porque se ha optimizado. Pruebe a usar el cmdlet New-Variable o Set-Variable (sin ningún alias), o use dot-source para establecer la variable.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>Los parámetros {0} y {1} no se pueden usar juntos. Especifique solo un parámetro.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Actualmente, el parámetro Tail solo se admite para el proveedor FileSystem.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>No se permite el alias porque ya existe un comando con el nombre "{0}" y el tipo de comando ''{1}".</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>No se puede ejecutar el software. Permiso denegado.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>"-{0}" y "-{1}" son mutuamente excluyentes y no se pueden especificar al mismo tiempo.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>La ruta de acceso "{0}" no es válida. Solo se admiten rutas de acceso absolutas en las operaciones de copia remota.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>No se puede validar la ruta de acceso remota "{0}".</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>No se puede realizar la operación porque la sesión {0} está establecida en {1}.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>El parámetro "{0}" no puede ser nulo ni estar vacío.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Variables de estado de sesión</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>El cambio o creación del ámbito de la variable "{0}" a AllScope se impedirá en el modo ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/es/TabCompletionStrings.es.resx
+++ b/src/System.Management.Automation/resources/es/TabCompletionStrings.es.resx
@@ -118,274 +118,274 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>El resultado de la finalización con tabulación no se puede deserializar correctamente porque el espacio de ejecución remoto no contiene una instancia de TypeTable.</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>No se puede acceder a las propiedades de una instancia null del tipo CompletionResult.</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>No bit a bit</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>Operador lógico no. Niega la instrucción que le sigue.</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es igual que el operando derecho.</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es igual que el operando derecho.</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Igual a: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es igual que el operando derecho.</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>No es igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no es igual que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no es igual que el operando derecho.</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>No es igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no es igual que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no es igual que el operando derecho.</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>No es igual a: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no es igual que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no es igual que el operando derecho.</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Mayor que o igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor o igual que el operando derecho.</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Mayor que o igual a: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor o igual que el operando derecho.</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Mayor o igual que: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor o igual que el operando derecho.</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Mayor que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor que el operando derecho.</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Mayor que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor que el operando derecho.</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Mayor que: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son mayores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es mayor que el operando derecho.</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Menor que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor que el operando derecho.</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Menor que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor que el operando derecho.</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Menor que: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor que el operando derecho.</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Menor o igual que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor o igual que el operando derecho.</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Menor o igual que: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor o igual que el operando derecho.</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Menor o igual que: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que son menores o iguales que el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo es menor o igual que el operando derecho.</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Carácter comodín que coincide con el operador: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Expresión regular que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Expresión regular que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Expresión regular que coincide con el operador: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo coincide con el operando derecho.</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Expresión regular que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Expresión regular que coincide con el operador: no distingue entre mayúsculas y minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Expresión regular que coincide con el operador: distingue mayúsculas de minúsculas. Cuando el operando izquierdo es una colección, devuelve los valores de la colección que no coinciden con el operando derecho; en caso contrario, devuelve TRUE si el operando izquierdo no coincide con el operando derecho.</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operador de reemplazo: no distingue entre mayúsculas y minúsculas. Cambia el operando izquierdo. Ejemplo: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operador de reemplazo: no distingue entre mayúsculas y minúsculas. Cambia el operando izquierdo. Ejemplo: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operador de reemplazo: distingue mayúsculas de minúsculas. Cambia el operando izquierdo. Ejemplo: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando derecho) coincide exactamente con al menos uno de los valores del operando izquierdo.</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando derecho) coincide exactamente con al menos uno de los valores del operando izquierdo.</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operador de independencia: distingue mayúsculas de minúsculas. Devuelve TRUE solo cuando el valor de prueba (operando derecho) coincide exactamente con al menos uno de los valores del operando izquierdo.</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando derecho) no coincide exactamente con ninguno de los valores del operando izquierdo.</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando derecho) no coincide exactamente con ninguno de los valores del operando izquierdo.</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operador de independencia: distingue mayúsculas de minúsculas. Devuelve TRUE cuando el valor de prueba (operando derecho) no coincide exactamente con ninguno de los valores del operando izquierdo.</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) coincide exactamente con al menos uno de los valores del operando derecho.</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) coincide exactamente con al menos uno de los valores del operando derecho.</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operador de independencia: distingue mayúsculas de minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) coincide exactamente con al menos uno de los valores del operando derecho.</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operador de independencia: distingue mayúsculas de minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) no coincide exactamente con ninguno de los valores del operando derecho.</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operador de independencia: no distingue entre mayúsculas y minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) no coincide exactamente con ninguno de los valores del operando derecho.</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operador de independencia: distingue mayúsculas de minúsculas. Devuelve TRUE cuando el valor de prueba (operando izquierdo) no coincide exactamente con ninguno de los valores del operando derecho.</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Dividir: no distingue entre mayúsculas y minúsculas. Divide una o varias cadenas en substrings.
+-Dividir &lt;String&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;String&gt; -Dividir &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;String&gt; -Dividir {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Dividir: no distingue entre mayúsculas y minúsculas. Divide una o varias cadenas en substrings.
+-Dividir &lt;String&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;String&gt; -Dividir &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;String&gt; -Dividir {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Dividir: distingue mayúsculas de minúsculas. Divide una o varias cadenas en substrings.
+-Dividir &lt;String&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;String&gt; -Dividir &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;String&gt; -Dividir {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>Devuelve TRUE cuando el operando izquierdo no es una instancia del tipo de .NET Framework especificado (operando derecho).</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>Devuelve TRUE cuando el operando izquierdo es una instancia del tipo de .NET Framework especificado (operando derecho).</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>Convierte el operando izquierdo al tipo .NET Framework especificado (operando derecho).</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>Da formato a las cadenas mediante el método de formato de los objetos de cadena.</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>Operador lógico and. Devuelve TRUE cuando ambas instrucciones son TRUE.</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>Bit a bit Y</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>Operador lógico or. TRUE cuando una o ambas instrucciones son TRUE.</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>Bit a bit O (inclusivo)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>Operador lógico or exclusivo. Devuelve TRUE cuando una de las instrucciones es TRUE y la otra es FALSE.</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>Bit a bit O (exclusivo)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
--Join &lt;String[]&gt;
-&lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
+    <value>Unir: combina varias cadenas en una sola.
+-Unir &lt;String[]&gt;
+&lt;String[]&gt; -Unir &lt;Delimiter&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>Operador de bits de desplazamiento a la izquierda. Inserta un cero en la posición del bit más a la derecha.</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>Operador de bits de desplazamiento a la derecha. Inserta un cero en la posición del bit más a la izquierda. En los valores con signo, se conserva el bit de signo.</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Especifica el nombre de la propiedad que se va a crear.</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Especifica el nombre de la propiedad que se va a crear.</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
     <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+Bloque de script que se usa para calcular el valor de la nueva propiedad.</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+Define cómo se muestran los valores en una columna.
+Los valores válidos son "left", "center" o "right".</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+Especifica una cadena de formato que define cómo se da formato al valor para la salida.</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+Especifica el ancho máximo de columna en una tabla cuando se muestra el valor.
+El valor debe ser mayor que 0.</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+La clave de profundidad especifica la profundidad de expansión por propiedad.</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Especifica el orden de ordenación de una o más propiedades.</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Especifica el orden de ordenación de una o más propiedades.</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+Especifica los nombres de registro de los que se obtendrán eventos.
+Admite caracteres comodín.</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+Especifica los proveedores del registro de eventos de los que se obtendrán eventos.
+Admite caracteres comodín.</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+Especifica las rutas de acceso a los archivos de registro de los que se van a obtener eventos.
+Los formatos de archivo válidos son: .etl, .evt y .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
     <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+Selecciona eventos con las máscaras de bits de palabra clave especificadas.
+Las siguientes son palabras clave estándar:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,213 +398,213 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+Selecciona eventos con los identificadores de evento especificados.</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
+Selecciona eventos con los niveles de registro especificados.
+Los siguientes niveles de registro son válidos:
+1: Crítico
 2: Error
-3: Warning
-4: Informational
-5: Verbose</value>
+3: Advertencia
+4: Información
+5: Detallado</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created after the specified date and time.</value>
+Selecciona eventos creados después de la fecha y hora especificadas.</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created before the specified date and time.</value>
+Selecciona eventos creados antes de la fecha y hora especificadas.</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+Selecciona eventos generados por el usuario especificado.
+Puede ser una representación de cadena de un SID o un dominio y nombre de usuario con el formato DOMAIN\USERNAME o USERNAME@DOMAIN</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
     <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+Selecciona eventos con cualquiera de los valores especificados en la sección EventData.</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
     <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+Excluye los eventos que coinciden con los valores especificados en la tabla hash.</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[string] o [hashtable]
+Especifica una matriz de módulos de PowerShell que requiere el script.
+Cada elemento puede ser una cadena con el nombre del módulo como valor o una tabla hash con las siguientes claves:
+Nombre: nombre del módulo
+GUID: GUID del módulo
+Uno de los siguientes:
+ModuleVersion: especifica la versión mínima aceptable del módulo.
+RequiredVersion: especifica una versión exacta y obligatoria del módulo.
+MaximumVersion: especifica la versión máxima aceptable del módulo.</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
     <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+Especifica una edición de PowerShell que requiere el script.
+Los valores válidos son "Core" y "Desktop"</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
     <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+Especifica que PowerShell debe ejecutarse como administrador en Windows.
+Debe ser el último parámetro de la línea de la instrucción #requires.</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
     <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+Especifica la versión mínima de PowerShell que requiere el script.</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>Especifica que el script requiere PowerShell 7+* para ejecutarse.</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>Especifica que el script requiere Windows PowerShell 5.1 para ejecutarse.</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
     <value>[string]
-Required. Specifies the module name.</value>
+Obligatorio. Especifica el nombre del módulo.</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
     <value>[string]
-Optional. Specifies the GUID of the module.</value>
+Opcional. Especifica el GUID del módulo.</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+Especifica la versión mínima aceptable del módulo.</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies an exact, required version of the module.</value>
+Especifica una versión exacta y obligatoria del módulo.</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+Especifica la versión máxima aceptable del módulo.</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Una descripción breve de la función o script.
+Esta palabra clave solo se puede usar una vez en cada tema.</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Una descripción detallada de la función o script.
+Esta palabra clave solo se puede usar una vez en cada tema.</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
     <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+La descripción de un parámetro.
+Agregue la palabra clave .PARAMETER para cada parámetro en la sintaxis de la función o del script.</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>Comando de ejemplo que usa la función o el script, seguido opcionalmente de una salida de ejemplo y una descripción.
+Repita esta palabra clave para cada ejemplo.</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>Los tipos .NET de los objetos que se pueden canalizar a la función o script.
+También puede incluir una descripción de los objetos de entrada.</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>Tipo de .NET de los objetos que devuelve el cmdlet.
+También puede incluir una descripción de los objetos devueltos.</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>Información adicional sobre la función o script.</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>Nombre de un tema relacionado.
+Repita la palabra clave .LINK para cada tema relacionado.
+El contenido de la palabra clave .Link también puede incluir un URI en una versión en línea del mismo tema de ayuda.</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>Nombre de la tecnología o característica que usa la función o el script, o con la que está relacionada.</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>El nombre del rol de usuario para el tema de ayuda.</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>Las palabras clave que describen el uso previsto de la función.</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+Redirige al tema de ayuda del comando especificado.</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+Especifica la categoría de ayuda del elemento en .ForwardHelpTargetName</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+Especifica una sesión que contiene el tema de ayuda.
+Escriba una variable que contenga un objeto PSSession.</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+La palabra clave .ExternalHelp es necesaria cuando una función o un script se documenta en archivos XML.</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>Especifica la ruta de acceso a un ensamblado .NET que se va a cargar.
 
-using assembly &lt;.NET-assembly-path&gt;</value>
+usando el ensamblado &lt;.NET-assembly-path&gt;</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>Especifica un módulo de PowerShell desde el que cargar clases.
 
-using module &lt;ModuleName or Path&gt;
+usando módulo &lt;ModuleName o Path&gt;
 
-using module &lt;ModuleSpecification hashtable&gt;</value>
+usando módulo &lt;tabla hash ModuleSpecification&gt;</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>Especifica un espacio de nombres .NET desde el que resolver tipos o un alias de espacio de nombres.
 
-using namespace &lt;.NET-namespace&gt;
+usando el espacio de nombres &lt;.NET-namespace&gt;
 
-using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
+usando el espacio de nombres &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>Especifica un alias para un tipo de .NET.
 
-using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
+usando el tipo &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>Una cadena normal.</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>Una cadena que contiene referencias no expandidas a variables de entorno que se expanden cuando se recupera el valor.</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>Datos binarios en cualquier formulario.</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>Un número binario de 32 bits.</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>Una matriz de cadenas.</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>Un número binario de 64 bits.</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>Un tipo de datos del Registro no admitido.</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
-    <value>',' - Comma</value>
+    <value>",": coma</value>
   </data>
   <data name="SeparatorCommaSpaceToolTip" xml:space="preserve">
-    <value>', ' - Comma-Space</value>
+    <value>", ": coma y espacio</value>
   </data>
   <data name="SeparatorSemiColonToolTip" xml:space="preserve">
-    <value>';' - Semi-Colon</value>
+    <value>";": punto y coma</value>
   </data>
   <data name="SeparatorSemiColonSpaceToolTip" xml:space="preserve">
-    <value>'; ' - Semi-Colon-Space</value>
+    <value>"; ": punto y coma y espacio</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
     <value>{0} - Newline</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
-    <value>'-' - Dash</value>
+    <value>"-": guion</value>
   </data>
   <data name="SeparatorSpaceToolTip" xml:space="preserve">
-    <value>' ' - Space</value>
+    <value>" ": espacio</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/Authenticode.fr.resx
+++ b/src/System.Management.Automation/resources/fr/Authenticode.fr.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>Nous ne pouvons pas charger le fichier {0}, car vous avez choisi de ne pas exécuter ce logiciel maintenant.</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>Le fichier {0} ne peut pas être chargé, car vous avez choisi de ne jamais exécuter de logiciel de cet éditeur.</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>Le fichier {0} est publié par {1}. Cet éditeur n’est pas explicitement approuvé sur votre système. Le script ne s’exécutera pas sur le système. Pour découvrir plus d’informations, exécutez la commande « get-help about_signing ».</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>Nous ne pouvons pas charger le fichier {0}, car l’exécution de scripts est désactivée sur ce système. Pour découvrir plus d’informations, consultez about_Execution_Policies à l’adresse https://go.microsoft.com/fwlink/?LinkID=135170.</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>Nous ne pouvons pas charger le fichier {0}. {1}.</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>Nous ne pouvons pas charger le fichier {0} car son exécution est bloquée par des stratégies de restriction logicielle, telles que celles créées en tirant parti de la stratégie de groupe.</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>Nous ne pouvons pas charger le fichier {0} car son contenu n’a pas pu être lu.</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>Nous ne pouvons pas signer le code. Le certificat spécifié ne convient pas pour la signature de code.</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>Nous ne pouvons pas signer le code. L’URL du serveur TimeStamp doit être entièrement qualifiée et au format http://&lt;server url&gt; ou https://&lt;server url&gt;.</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>Nous ne pouvons pas signer le code. L'algorithme de hachage n'est pas pris en charge.</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>Voulez-vous exécuter le logiciel provenant de cet éditeur non approuvé ?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>Le fichier {0} est publié par {1} et n’est pas approuvé sur votre système. N’exécutez que des scripts provenant d’éditeurs approuvés.</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>Le logiciel {0} est publié par un éditeur inconnu. Nous vous recommandons de ne pas exécuter ce logiciel.</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>Avertissement de sécurité</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>Référencez uniquement les scripts auxquels vous faites confiance. Les scripts provenant d’Internet peuvent être utiles, mais ce script peut éventuellement endommager votre ordinateur. Si vous faites confiance à ce script, utilisez la cmdlet Unblock-File pour autoriser son exécution sans ce message d’avertissement. Voulez-vous exécuter {0} ?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>Ja&amp;mais exécuté</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>Ne pas exécuter le script de cet éditeur dès maintenant et ne pas m’inviter à l’exécuter à l’avenir. Les futures tentatives d’exécution de ce script entraîneront un échec silencieux.</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>&amp;Ne pas exécuter</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Ne pas exécuter pas le script de cet éditeur dès maintenant et continuer à m’inviter à l’exécuter à l’avenir.</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>&amp;Exécuter une fois</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Exécuter le script de cet éditeur dès maintenant et continuer à m’inviter à l’exécuter à l’avenir.</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>&amp;Toujours exécuter</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>Exécutez le script de cet éditeur maintenant et continuer à m’inviter à l’exécuter à l’avenir.</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Suspendre</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>Suspendez le pipeline actuel et revenez à l’invite de commandes. Tapez exit pour reprendre l’opération lorsque vous avez terminé.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/DebuggerStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/DebuggerStrings.fr.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>Point d’arrêt de variable sur « ${0} » ({1} accès)</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>Point d’arrêt de variable sur « {0} :${1} » (accès {2})</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>Point d’arrêt de ligne sur « {0} :{1} »</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>Point d’arrêt de ligne sur « {0} :{1}, {2} »</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>Point d’arrêt de commande sur « {0} »</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>Point d’arrêt de commande sur « {0} :{1} »</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>Le point d’arrêt {0} ne sera pas atteint</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Étape unique (pas à pas dans les fonctions, scripts, etc.)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Passer à l’instruction suivante (pas à pas principal dans les fonctions, les scripts, etc.)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Quittez la fonction, le script, etc.</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} Continuer l’opération</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} Arrêter l’opération et quitter le débogueur</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Get-PSCallStack Afficher la pile des appels</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Répertoriez le code source du script actif.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Utiliser « list » pour commencer à partir de la ligne active, « list &lt;m&gt; »  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     pour commencer à partir de la ligne &lt;m&gt;, et « list &lt;m&gt; &lt;n&gt; » pour répertorier &lt;n&gt; </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     lignes à partir de la ligne &lt;m&gt;</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Répéter la dernière commande si elle était {0}, {1} ou {2}</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} affiche ce message d’aide.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Pour obtenir des instructions sur la personnalisation de l’invite de votre débogueur, tapez « help about_prompt ».</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+La session active ne prend pas en charge le débogage, l’opération se poursuivra.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0} : ligne {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>Aucun code source n’est disponible.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>La ligne de départ doit être un entier positif inférieur ou égal à {0}</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>Le nombre de lignes doit être un entier positif.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
     <value>&lt;No file&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>sur {0}, {1} : ligne {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>Le débogueur ne peut pas traiter les commandes tant qu’il n’est pas à l’état Arrêté.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>SetDebugAction n’est pas implémenté pour le débogueur de script local.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>Le débogueur ne peut pas définir d’action de reprise, car le débogueur de la session distante n’est pas à l’état Arrêté.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>Nous ne pouvons pas déboguer le travail, car le débogueur est actuellement occupé.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Le travail fourni et tous les travaux enfants ont été passés en revue, mais aucun travail pouvant être débogué n’a été trouvé.  Pour déboguer un travail ou un travail enfant, celui-ci doit prendre en charge le débogage et être à l’état en cours d’exécution.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>Le débogueur ne peut pas être activé pour le mode pas à pas, car il est désactivé avec le mode de débogage défini sur Aucun.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>Nous ne pouvons pas déboguer l’instance d’exécution, car le débogueur hôte est actuellement occupé.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>Nous ne pouvons pas déboguer l’instance d’exécution. Le débogueur d’instance d’exécution est actuellement désactivé (DebugMode a la valeur « Aucun »).</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>Nous ne pouvons pas déboguer une instance d’exécution qui n’est pas à l’état Ouvert. L’état de cette instance d’exécution est {0}.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>Nous ne pouvons pas déboguer l’instance d’exécution. L’instance d’exécution {0} n’a aucun débogueur associé.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>Le débogueur est déjà remplacé.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>Nous ne pouvons pas envoyer un objet de débogueur sur lui-même.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>La commande {0} n’est pas prise en charge pour une utilisation à distance dans la version de PowerShell qui s’exécute dans l’instance d’exécution distante.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>Processus</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} Poursuivez l’opération et détachez le débogueur.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>La commande de détachement du débogueur n’est pas applicable.  La commande de détachement s’applique uniquement lors du débogage de travaux et d’instances d’exécution avec les cmdlets Debug-Job ou Debug-Runspace.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>ID d’instance d’exécution non valide : {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>Nous ne pouvons pas obtenir l’instance d’exécution.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Un point d’arrêt ou une BreakpointList doit être spécifiée.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>La BreakpointList contenait un élément qui n’était pas un point d’arrêt.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/DiscoveryExceptions.fr.resx
+++ b/src/System.Management.Automation/resources/fr/DiscoveryExceptions.fr.resx
@@ -186,7 +186,7 @@ L’instruction #requires doit être dans l’un des formats suivants :
     <value>Nous ne pouvons pas exécuter le script « {0} », car les composants logiciels enfichables suivants spécifiés par les instructions « #requires » du script sont manquants : {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell snap-in when running in PowerShell.</value>
+    <value>Une instruction #requires a spécifié uniquement un shellID. Les instructions #Requires doivent spécifier un composant logiciel enfichable PowerShell requis lors de l’exécution dans PowerShell.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
     <value>Le script « {0} » ne peut pas être exécuté car il contient une instruction « #requires » pour une exécution en tant qu’administrateur(-trice). La session PowerShell actuelle n’est pas exécutée en tant qu’administrateur(-trice). Démarrez PowerShell en utilisant l’option Exécuter en tant qu’administrateur(-trice), puis essayez de relancer le script.</value>

--- a/src/System.Management.Automation/resources/fr/ErrorCategoryStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/ErrorCategoryStrings.fr.resx
@@ -118,102 +118,102 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CloseError" xml:space="preserve">
-    <value>CloseError: ({1}:{2}) [{0}], {3}</value>
+    <value>CloseError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>Blocage détecté : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
-    <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
+    <value>DeviceError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidArgument" xml:space="preserve">
-    <value>InvalidArgument: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidArgument : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidData" xml:space="preserve">
-    <value>InvalidData: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidData : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>InvalidOperation: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidOperation : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidResult" xml:space="preserve">
-    <value>InvalidResult: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidResult : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidType" xml:space="preserve">
-    <value>InvalidType: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidType : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="MetadataError" xml:space="preserve">
-    <value>MetadataError: ({1}:{2}) [{0}], {3}</value>
+    <value>MetadataError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="NotImplemented" xml:space="preserve">
-    <value>NotImplemented: ({1}:{2}) [{0}], {3}</value>
+    <value>NotImplemented : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="NotInstalled" xml:space="preserve">
-    <value>NotInstalled: ({1}:{2}) [{0}], {3}</value>
+    <value>NotInstalled : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ObjectNotFound" xml:space="preserve">
-    <value>ObjectNotFound: ({1}:{2}) [{0}], {3}</value>
+    <value>ObjectNotFound : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="OpenError" xml:space="preserve">
-    <value>OpenError: ({1}:{2}) [{0}], {3}</value>
+    <value>OpenError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="OperationStopped" xml:space="preserve">
-    <value>OperationStopped: ({1}:{2}) [{0}], {3}</value>
+    <value>OperationStopped : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="OperationTimeout" xml:space="preserve">
-    <value>OperationTimeout: ({1}:{2}) [{0}], {3}</value>
+    <value>OperationTimeout : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ParserError" xml:space="preserve">
-    <value>ParserError: ({1}:{2}) [{0}], {3}</value>
+    <value>ParserError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="PermissionDenied" xml:space="preserve">
-    <value>PermissionDenied: ({1}:{2}) [{0}], {3}</value>
+    <value>PermissionDenied : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ReadError" xml:space="preserve">
-    <value>ReadError: ({1}:{2}) [{0}], {3}</value>
+    <value>ReadError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceBusy" xml:space="preserve">
-    <value>ResourceBusy: ({1}:{2}) [{0}], {3}</value>
+    <value>ResourceBusy : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceExists" xml:space="preserve">
-    <value>ResourceExists: ({1}:{2}) [{0}], {3}</value>
+    <value>ResourceExists : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ResourceUnavailable" xml:space="preserve">
-    <value>ResourceUnavailable: ({1}:{2}) [{0}], {3}</value>
+    <value>ResourceUnavailable : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="SyntaxError" xml:space="preserve">
-    <value>SyntaxError: ({1}:{2}) [{0}], {3}</value>
+    <value>SyntaxError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="WriteError" xml:space="preserve">
-    <value>WriteError: ({1}:{2}) [{0}], {3}</value>
+    <value>WriteError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="FromStdErr" xml:space="preserve">
-    <value>FromStdErr: ({1}:{2}) [{0}], {3}</value>
+    <value>FromStdErr : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="SecurityError" xml:space="preserve">
-    <value>SecurityError: ({1}:{2}) [{0}], {3}</value>
+    <value>SecurityError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ProtocolError" xml:space="preserve">
-    <value>ProtocolError: ({1}:{2}) [{0}], {3}</value>
+    <value>ProtocolError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="ConnectionError" xml:space="preserve">
-    <value>ConnectionError: ({1}:{2}) [{0}], {3}</value>
+    <value>ConnectionError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="AuthenticationError" xml:space="preserve">
-    <value>AuthenticationError: ({1}:{2}) [{0}], {3}</value>
+    <value>AuthenticationError : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="LimitsExceeded" xml:space="preserve">
-    <value>LimitsExceeded: ({1}:{2}) [{0}], {3}</value>
+    <value>LimitsExceeded : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="QuotaExceeded" xml:space="preserve">
-    <value>QuotaExceeded: ({1}:{2}) [{0}], {3}</value>
+    <value>QuotaExceeded : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="NotEnabled" xml:space="preserve">
-    <value>NotEnabled: ({1}:{2}) [{0}], {3}</value>
+    <value>NotEnabled : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="NotSpecified" xml:space="preserve">
-    <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
+    <value>NotSpecified : ({1} :{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>Code d’erreur non reconnu : {4} : ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/ExperimentalFeatureStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/ExperimentalFeatureStrings.fr.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>Aucune fonctionnalité expérimentale correspondant au nom '{0}' n’a été trouvée.</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>L’activation et la désactivation des fonctionnalités expérimentales ne prennent pas effet avant le prochain démarrage de PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/ExtendedTypeSystem.fr.resx
+++ b/src/System.Management.Automation/resources/fr/ExtendedTypeSystem.fr.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>Le membre « {0} » est déjà présent.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>Le membre « {0} » est déjà présent dans le fichier de données de type étendu.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>Le membre « {0} » n’est pas présent.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>Exception lors de la définition de « {0} » : « {1} »</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>Exception lors de l’obtention de « {0} » : « {1} »</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>L’exception suivante s’est produite lors de la tentative d’énumération de la collection : « {0} ».</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>Impossible d’accéder au membre « {0} » en dehors d’un PSObject.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>Impossible de modifier le membre créé à partir de la configuration de type : « {0} ».</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>Le nom de membre « {0} » est réservé.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>« {0} » n’est pas modifiable.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>Exception lors de l’appel de « {0} » avec « {1} » argument(s) : « {2} »</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>Une exception a été levée lors de la tentative d’appel de « {0} » pour extraire le contenu d’un objet de type « {1} » : « {2} »</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>Impossible de trouver une surcharge pour « {0} » avec le nombre d’arguments « {1} ».</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>Impossible de trouver une surcharge de méthode générique appropriée pour « {0} » avec « {1} » paramètre(s) de type et avec le nombre d’arguments « {2} ».</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>Plusieurs surcharges ambiguës ont été trouvées pour « {0} » avec le nombre d’arguments « {1} ».</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>Impossible de convertir l’argument « {0} », avec la valeur « {1} », pour « {2} » en type « {3} » : « {4} »</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>L’accesseur Get de la propriété « {0} » n’est pas disponible.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>L’accesseur Set de la propriété « {0} » n’est pas disponible.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>La méthode setter doit être publique, nulle et non avenue, statique et comporter deux paramètres. Le premier paramètre doit être de type PSObject. Un second paramètre est requis si une méthode getter est également disponible, et il doit avoir le même type que le type de retour de la méthode getter.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>La méthode getter doit être publique, non void, statique et avoir un paramètre de type PSObject.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>Le CodeProperty doit utiliser une méthode getter ou setter.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>Impossible de créer une méthode de code en raison du format de la méthode. La méthode doit être publique, statique et avoir un paramètre de type PSObject.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>L’alias nommé « {0} » contient une boucle.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>Impossible de convertir la valeur « {0} » de type « {1} » en type « {2} ».</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>Impossible de convertir la valeur de type « {0} » en type « {1} ».</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>Impossible de convertir la valeur « {0} » en type « {1} ». Erreur : « {2} »</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>Impossible de convertir la valeur « {0} » en type « {1} » car aucune virgule n’est autorisée pour cette énumération.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>Impossible de convertir la valeur « {0} » en type « {1} » en raison de valeurs d’énumération non valides. Spécifiez l’une des valeurs d’énumération suivantes, puis réessayez. Les valeurs d’énumération possibles sont « {2} ».</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>Impossible de convertir null en type « {0} » en raison de valeurs d’énumération non valides. Spécifiez l’une des valeurs d’énumération suivantes, puis réessayez. Les valeurs d’énumération possibles sont « {1} ».</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>Impossible de convertir null en type « {0} ».</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>Impossible de convertir la valeur en type « {0} ».  Erreur : « {1} »</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>Impossible de convertir la valeur en type System.String.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>Un type de référence est attendu dans l’argument.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>Impossible de comparer « {0} » car il n’est pas IComparable.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>Impossible de comparer « {0} » à « {1} ». Erreur : « {2} »</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>Impossible de comparer « {0} » et « {1} », car les objets ne sont pas du même type ou l’objet « {0} » n’implémente pas « {2} ».</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>Impossible de convertir la valeur « {0} » en type « {1} », car au moins deux correspondances ont été trouvées ({2}, {3}) et une seule correspondance est autorisée pour cette énumération.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>Impossible de convertir la valeur « {0} » en type « {1} ». Les paramètres booléens acceptent uniquement les valeurs booléennes et les nombres, tels que $True, $False, 1 ou 0.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>Impossible d’obtenir la valeur de la propriété, car « {0} » est une propriété en écriture seule.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>« {0} » est une propriété ReadOnly.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>Impossible de définir « {0} » car seules des chaînes peuvent être utilisées comme valeurs pour définir les propriétés XmlNode.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>Impossible de définir « {0} » car seuls des attributs uniques ou des nœuds terminaux uniques non attribués peuvent être définis.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>Impossible d’ajouter un objet PSProperty ou PSMethod à cette collection.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>L’erreur suivante s’est produite lors du chargement du fichier de données de type étendu : {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de la chaîne : « {0} »</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>Le champ ou la propriété « {0} » du type «{1} » ne diffère du champ ou de la propriété « {2} » autrement que par la casse. Le type doit être conforme à CLS (Common Language Specification).</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>L’exception suivante s’est produite lors de la récupération de la hiérarchie des noms de type : « {0} ».</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération des membres « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération des membres : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de l’état de lecture de la propriété « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de l’état d’écrire de la propriété « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération du type pour la propriété « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de la représentation sous forme de chaîne de la propriété « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération des attributs de la propriété « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération des définitions de la méthode « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de la représentation sous forme de chaîne de la méthode « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération du type pour la propriété paramétrable « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de l’état de lecture de la propriété paramétrée « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de l’état d’écriture de la propriété paramétrée « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération des définitions de la propriété paramétrée « {1} » : « {0} »</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la récupération de la représentation sous forme de chaîne pour la propriété paramétrable « {1} » : « {0} »</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>Impossible de définir la propriété Value pour l’objet PSMemberInfo de type « {0} ».</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>L’argument « {0} » doit être un {1}. Utilisez {2}.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>Argument : « {0} » ne doit pas être un {1}. N’utilisez pas {2}.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>La propriété « {0} » est introuvable.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>Impossible d'obtenir ou de définir la valeur de la propriété. L’argument « {0} » doit être de type « {1} » ou « {2} ».</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>Impossible de définir la valeur de la propriété « {0} » car l’objet est de type « {1} » au lieu de « {2} ».</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>Exception lors de l’appel de « {0} » : « {1} »</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0} n’est pas un chemin d’accès de classe valide.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} est un chemin non valide.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>L’adaptateur ne peut pas déterminer si la propriété « {0} » peut être modifiée.</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>L’adaptateur ne peut pas déterminer si la propriété « {0} » est accessible en lecture.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>L’adaptateur ne peut pas obtenir la valeur de la propriété « {0} ».</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>L’adaptateur ne peut pas définir la valeur de la propriété « {0} ».</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>L’adaptateur ne peut pas obtenir le type de propriété « {0} ».</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>L’adaptateur ne peut pas obtenir la hiérarchie de types de « {0} ».</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>L’adaptateur ne peut pas obtenir les propriétés de « {0} ».</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>L’adaptateur ne peut pas obtenir la propriété « {0} » pour « {1} ».</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>« {0} » a renvoyé une valeur null.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>La propriété « {0} » est introuvable pour l’objet « {1} ». Les propriétés définissables sont : {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>La propriété « {0} » est introuvable pour l’objet « {1} ». Aucune propriété définissable n’est disponible.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>Impossible de créer un objet de type « {0} ». {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>Impossible d’appeler des méthodes statiques ou d’accéder aux propriétés statiques sur le type générique ouvert {0}.  Spécifiez les paramètres de type, puis réessayez.  Par exemple, au lieu de [System.Collections.Generic.HashSet``1]::CreateSetComparer(), utilisez [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>L’exception suivante s’est produite lors de la construction de l’attribut « {1} » : « {0} »</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>La valeur « {0} » ne peut pas être convertie en tableau de chaînes.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>Impossible de convertir la valeur en type « {0} ». Seuls les types principaux sont pris en charge dans ce mode de langage.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Impossible de convertir en type ByRef-like « {0} ». Les types similaires à ByRef ne sont pas pris en charge dans PowerShell.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Impossible d’obtenir ou de définir la propriété ou le champ « {0} » du type similaire à ByRef « {1} ». Les types similaires à ByRef ne sont pas pris en charge dans PowerShell.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Impossible d’appeler la méthode « {0} » du type de retour similaire à ByRef « {1} ». Les types similaires à ByRef ne sont pas pris en charge dans PowerShell.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nous ne pouvons pas créer une instance du type similaire à ByRef « {0} ». Les types similaires à ByRef ne sont pas pris en charge dans PowerShell.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Conversion de table de hachage du système de types étendus</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>La conversion de type de HashTable vers « {0} » ne sera pas autorisée en mode ConstrainedLanguage.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Conversion de table de hachage du système de types étendus</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>La conversion de type de « {0} » vers « {1} » ne sera pas autorisée en mode ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/Metadata.fr.resx
+++ b/src/System.Management.Automation/resources/fr/Metadata.fr.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>Impossible d’initialiser les attributs pour «{0}» : «{1}»</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>Impossible de valider l’argument, car son type «{0}» n’est pas du même type ({1}) que les limites maximale et minimale du paramètre. Vérifiez que l’argument est de type {1}, puis réessayez la commande.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>Impossible de valider l’argument «{0}», car sa valeur n’est pas supérieure à zéro.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>Impossible de valider l’argument «{0}», car sa valeur n’est pas supérieure ou égale à zéro.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>Impossible de valider l’argument «{0}», car sa valeur n’est pas inférieure à zéro.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>Impossible de valider l’argument «{0}», car sa valeur n’est pas inférieure ou égale à zéro.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>La plage minimale spécifiée ({0}) ne peut pas être acceptée, car elle n’est pas du même type que la plage maximale spécifiée ({1}). Mettez à jour l’attribut ValidateRange pour le paramètre.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>Impossible d’accepter les types de paramètres MaxRange et MinRange. Les deux paramètres doivent être des objets qui implémentent une interface IComparable.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>Impossible d’accepter la plage maximale spécifiée, car elle est inférieure à la plage minimale spécifiée. Mettez à jour l’attribut ValidateRange pour le paramètre.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>L’argument {0} est supérieur à la plage maximale autorisée de {1}. Fournissez un argument inférieur ou égal à {1}, puis recommencez la commande.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>L’argument {0} est inférieur à la plage minimale autorisée de {1}. Fournissez un argument supérieur ou égal à {1}, puis recommencez la commande.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>L’argument «{0}» ne correspond pas au modèle «{1}». Fournissez un argument qui correspond à «{1}», puis réessayez la commande.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>L’attribut ValidateCount ne peut pas être appliqué à un paramètre autre qu’un paramètre de tableau. Supprimez l’attribut du paramètre ou faites du paramètre un paramètre de tableau.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>Le paramètre requiert exactement {0} valeur(s) - {1} valeur(s) ont été fournies.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>Le paramètre nécessite au moins {0} valeur(s) et pas plus de {1} valeur(s) - {2} valeur(s) ont été fournies.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>Le nombre maximal d’arguments spécifié pour un paramètre est inférieur au nombre minimal d’arguments spécifié. Mettez à jour l’attribut ValidateCount pour le paramètre.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>La longueur de caractère maximale spécifiée de l’argument est inférieure à la longueur minimale de caractère d’argument spécifiée. Mettez à jour l’attribut ValidateLength pour le paramètre.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>L’attribut ValidateLength ne peut pas être appliqué à un paramètre qui n’est pas un paramètre string ou string[]. Définissez le paramètre comme un paramètre string ou string[].</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>La longueur du caractère ({1}) de l’argument est trop courte. Spécifiez un argument dont la longueur est supérieure ou égale à «{0}», puis réessayez.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>La longueur du caractère ({1}) de l’argument est trop longue. Spécifiez un argument dont la longueur est inférieure ou égale à «{0}», puis réessayez.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>L’argument «{0}» n’appartient pas à l’ensemble «{1}» spécifié par l’attribut ValidateSet. Fournissez un argument qui se trouve dans le jeu, puis réessayez la commande.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>Le générateur de valeurs valides renvoie une valeur nulle.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>«{0}» a échoué sur la propriété «{1}» {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>Impossible d’obtenir ou d’exécuter la commande. Le nombre maximal de jeux de paramètres pour cette commande a été dépassé.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>Impossible de traiter l’argument, car la valeur de l’argument n’est pas une chaîne. Les valeurs des arguments de paramètre dont ArgumentTransformationAttribute est spécifié doivent être des chaînes.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>Impossible de valider la variable, car la valeur {1} n’est pas une valeur valide pour la variable {0}.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>Impossible d’ajouter l’attribut, car la variable {0} avec une valeur {1} n’est plus valide.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>L’argument est nul. Fournissez une valeur valide pour l’argument, puis réessayez d’exécuter la commande.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>L'argument a une valeur nulle, ou un élément de la collection d'arguments contient une valeur nul. Fournissez une collection ne contenant aucune valeur nul, puis réessayez la commande.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>L'argument est nul ou vide. Fournissez un argument qui n'est ni nul ni vide, puis réessayez la commande.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>L’argument est nul, vide ou un élément de la collection d’arguments contient une valeur nul. Fournissez une collection qui ne contient aucune valeur nul, puis réessayez la commande.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>L’argument est nul, vide ou se compose uniquement de caractères d’espace blanc. Fournissez un argument qui contient des caractères autres que des espaces blancs, puis recommencez la commande.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Un élément de la collection d’arguments est nul, vide ou se compose uniquement de caractères d’espace blanc. Fournissez une collection qui ne contient aucune de ces valeurs, puis réessayez la commande.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>Un paramètre portant le nom «{0}» a été défini plusieurs fois pour la commande.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>Impossible de spécifier l’alias de paramètre, car un alias portant le nom «{0}» a déjà été défini plusieurs fois pour la commande.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>Impossible de spécifier le paramètre «{0}», car il est en conflit avec l’alias de paramètre du même nom pour le paramètre «{1}».</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>Le script de validation «{1}» pour l’argument avec la valeur «{0}» n’a pas retourné le résultat True. Déterminez pourquoi le script de validation a échoué, puis réessayez la commande.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>L’argument «{0}» ne contient pas de version PowerShell valide. Fournissez un numéro de version valide, puis recommencez la commande.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>Impossible de valider l’argument «{0}», car il ne s’agit pas d’un nom de variable valide.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>Le type de conversion de travail doit dériver de IAstToScriptBlockConverter.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>L’argument de chemin d’accès n’est pas valide. Fournissez un argument de chemin d’accès qui est un type de chaîne.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>Le lecteur d’argument de chemin d’accès {0} n’appartient pas à l’ensemble de lecteurs approuvés : {1}. Fournissez un argument de chemin d’accès avec un lecteur approuvé.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>L’argument de chemin d’accès contient des caractères non valides.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>L’argument de chemin d’accès n’a pas de lecteur racine.  Fournissez un argument de chemin d’accès complet avec un lecteur racine.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>La valeur d’argument du paramètre '{0}' ne peut pas être nul ou une chaîne vide.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Le membre Enum '{0}' n’est pas une valeur valide pour le paramètre '{1}'. Spécifiez l’un des membres suivants et réessayez : {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>Impossible de traiter l’entrée. L’argument «{0}» n’est pas approuvé.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>Échec de la vérification d’attribut ValidateTrustedData</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>L’argument de paramètre «{0}» n’est pas approuvé et échoue à la vérification de l’attribut de paramètre ValidateTrustedData en mode langue contrainte.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/Modules.fr.resx
+++ b/src/System.Management.Automation/resources/fr/Modules.fr.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module spécifié « {0} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module spécifié « {0} » avec la version « {1} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>La valeur spécifiée pour MaximumVersion « {0} » est incorrecte. Si vous utilisez « * », MaximumVersion ne prend en charge qu’un seul « * » et doit toujours être placé à la fin de MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module spécifié « {0} » avec MaximumVersion « {1} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module spécifié « {0} » avec MinimumVersion « {1} » et MaximumVersion « {2} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>La valeur MinimumVersion « {0} » ne doit pas être supérieure à MaximumVersion « {1} ».</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>L’assembly « {0} » n’a pas été chargé, car aucun assembly portant ce nom n’a été trouvé. Vérifiez le nom de l’assembly, puis réessayez.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Le module à traiter « {0} », répertorié dans le champ « {1} » du manifeste du module « {2} », n’a pas été traité, car aucun module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Aucun objet personnalisé n’a été retourné pour le module « {0} » car le paramètre -AsCustomObject ne peut être utilisé qu’avec des modules de script.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Impossible de traiter le manifeste du module « {0} », car il ne s’agit pas d’un fichier manifeste de module PowerShell valide. Supprimez les éléments non autorisés : {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Le traitement du fichier manifeste du module « {0} » n’a pas abouti à un objet manifeste valide. Mettez à jour le fichier pour qu’il contienne un manifeste de module PowerShell valide. Vous pouvez créer un manifeste valide à l’aide de l’applet de commande New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Impossible d’importer le module « {0} » car son manifeste contient un ou plusieurs membres non valides. Les membres de manifeste valides sont ({1}). Supprimez les membres non valides ({2}), puis réessayez d’importer le module.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>La table de hachage décrivant un module contient un ou plusieurs membres non valides. Les membres valides sont ({0}). Supprimez les membres non valides ({1}), puis réessayez.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Impossible de charger le module « {0} », car la limite d’imbrication des modules a été dépassée. Les modules ne peuvent être imbriqués que jusqu’à {1} niveaux. Évaluez et modifiez l’ordre dans lequel vous chargez les modules pour éviter de dépasser la limite d’imbrication, puis réessayez d’exécuter votre script.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Le membre « ModuleVersion » n’est pas présent dans le manifeste du module. Ce membre doit exister et recevoir un numéro de version au format « n.n.n.n ». Ajoutez le membre manquant au fichier « {0} ».</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Le membre « {0} » n’est pas valide dans le fichier manifeste du module « {2} » : {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>La version « {0} » du module « {1} » ne répond pas à la version minimale requise « {2} ». Vérifiez que ce numéro de version est pris en charge, puis essayez de charger à nouveau le module.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>La version de PowerShell installée sur cet ordinateur est « {0} ». Le module « {1} » nécessite une version minimale de PowerShell « {2} » pour s’exécuter. Vérifiez que la version minimale requise de PowerShell est installée, puis réessayez.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Le membre de manifeste du module « NestedModules » ne peut pas être utilisé si le membre « ModuleToProcess » est un module binaire. Modifiez le fichier manifeste du module dans « {0} », puis réessayez.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Le membre « {0} » dans le manifeste du module n’est pas valide : {1}. Vérifiez qu’une valeur valide est spécifiée pour ce champ dans le fichier « {2} ».</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Le chemin d’accès au manifeste du module « {0} » n’est pas valide. La valeur de l’argument Path doit résoudre un seul fichier avec l’extension « .psd1 ». Modifiez la valeur de l’argument Path pour qu’il pointe vers un fichier psd1 valide, puis réessayez.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>La clé ModuleVersion dans le manifeste du module « {0} » spécifie la version du module « {1} », qui ne correspond pas au nom de son dossier de version à l’emplacement « {2} ». Modifiez la valeur de la clé ModuleVersion pour qu’elle corresponde au nom du dossier de version.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>L’entrée NestedModule spécifiée « {0} » dans le manifeste du module « {1} » n’est pas valide. Réessayez après avoir mis à jour cette entrée avec des valeurs valides.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>L’entrée RequiredAssemblies spécifiée « {0} » dans le manifeste du module « {1} » n’est pas valide. Réessayez après avoir mis à jour cette entrée avec des valeurs valides.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>L’entrée FileList spécifiée « {0} » dans le manifeste du module « {1} » n’est pas valide. Réessayez après avoir mis à jour cette entrée avec des valeurs valides.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>L’entrée RequiredModules spécifiée « {0} » dans le manifeste du module « {1} » n’est pas valide. Réessayez après avoir mis à jour cette entrée avec des valeurs valides.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>L’entrée ModuleList spécifiée « {0} » dans le manifeste du module « {1} » n’est pas valide. Réessayez après avoir mis à jour cette entrée avec des valeurs valides.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Le manifeste du module « {0} » est spécifié avec la clé CompatiblePSEditions, prise en charge uniquement sous PowerShell version « 5.1 » ou ultérieure. Mettez à jour la valeur de la clé PowerShellVersion à « 5.1 » ou une version ultérieure, puis réessayez.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>La valeur spécifiée « {0} » pour CompatiblePSEditions contient des noms d’édition PowerShell en double. Réessayez après avoir supprimé les noms d’édition PowerShell en double.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>La version spécifiée dans la clé ModuleVersion est identique au nom du dossier de version.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Le dossier Version {0} sous le module {1} est ignoré, car il ne contient pas de fichier manifeste de module valide.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Le membre « ModuleName » n’existe pas dans la table de hachage qui décrit ce module.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Les membres « ModuleVersion », « MaximumVersion » et « RequiredVersion » n’existent pas dans la table de hachage qui décrit ce module. L’un de ces trois membres doit exister et recevoir un numéro de version au format « n.n.n.n ».</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Le module requis « {1} » n’est pas chargé. Chargez le module ou supprimez-le de « RequiredModules » dans le fichier « {0} ».</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Le module requis « {1} » avec le GUID « {2} » n’est pas chargé. Chargez le module ou supprimez-le de « RequiredModules » dans le fichier « {0} ».</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Le module requis « {1} » avec la version « {2} » n’est pas chargé. Chargez le module ou supprimez-le de « RequiredModules » dans le fichier « {0} ».</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Le module requis « {1} » avec MaximumVersion « {2} » n’est pas chargé. Chargez le module ou supprimez-le de « RequiredModules » dans le fichier « {0} ».</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Le module requis « {1} » avec MinimumVersion « {2} » et MaximumVersion « {3} » n’est pas chargé. Chargez le module ou supprimez-le de « RequiredModules » dans le fichier « {0} ».</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Le module « {0} » est introuvable avec ModuleVersion « {1} ».</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Le module « {0} » est introuvable avec RequiredVersion « {1} ».</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Le module « {0} » est introuvable avec MaximumVersion « {1} ».</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Le module « {0} » est introuvable avec ModuleVersion « {1} » et MaximumVersion « {2} ».</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Le module « {0} » est introuvable.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Aucun module n’a été supprimé. Vérifiez que la spécification des modules à supprimer est correcte et que ces modules existent dans l’instance d’exécution.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Impossible de supprimer le membre « {0} » importé à partir du module « {1} » pour la raison suivante : {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Impossible de supprimer le module « {0} » car il est en lecture seule. Ajoutez le paramètre Force à votre commande pour supprimer les modules en lecture seule.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Impossible de supprimer le module « {0} » car il est marqué comme « constant ». Un module ne peut pas être supprimé s’il est marqué comme « constant ».</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Impossible de supprimer le module « {0} », car il est requis par « {1} ». Ajoutez le paramètre Force à votre commande pour supprimer le module.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>La cmdlet Export-ModuleMember ne peut être appelée qu’à partir d’un module.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>L’extension « {0} » n’est pas une extension de module valide. Les extensions de module prises en charge sont « .dll », « .ps1 », « .psm1 », « .psd1 » et « .cdxml ». Corrigez l’extension, puis essayez d’ajouter de nouveau le fichier « {1} ».</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Cette opération ne peut pas être effectuée sur un module binaire. Elle ne peut être effectuée que sur un module de script.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Le fichier « {0} » n’est pas autorisé, car il n’a pas l’extension « .ps1 ».</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Inconnu</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Tous droits réservés.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Suppression de la fonction « {0} » importée.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Suppression de l’alias « {0} » importé.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Suppression de la variable importée « {0} ».</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Chargement du module depuis le chemin d’accès « {0} ».</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Chargement de « {0} » à partir du chemin d’accès « {1} ».</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Dot-sourcing du fichier de script « {0} ».</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Importation de la fonction « {0} ».</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Importation de la cmdlet « {0} ».</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Importation de l’alias « {0} ».</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Importation de la variable « {0} ».</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Exportation de l’applet de commande « {0} ».</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Exportation de la fonction « {0} ».</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Exportation de l’alias « {0} ».</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Exportation de la variable « {0} ».</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Les noms de certaines commandes importées depuis le module « {0} » incluent des verbes non approuvés, ce qui peut les rendre moins faciles à découvrir. Pour trouver les commandes qui utilisent des verbes non approuvés, exécutez de nouveau la commande Import-Module avec le paramètre Verbose. Pour obtenir la liste des verbes approuvés, tapez Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>La commande « {0} » dans le module « {1} » a été importée, mais comme son nom n’inclut pas de verbe approuvé, elle peut être difficile à trouver. Pour obtenir la liste des verbes approuvés, tapez Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>La commande « {0} » dans le module « {2} » a été importée, mais comme son nom n’inclut pas de verbe approuvé, elle peut être difficile à trouver. Les verbes alternatifs suggérés sont « {1} ».</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Certains noms de commandes importés contiennent un ou plusieurs des caractères restreints suivants : # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Le nom de commande « {0} » du module « {1} » contient un ou plusieurs des caractères restreints suivants : # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Création du fichier manifeste du module « {0} ».</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (chemin d’accès : « {1} »)</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>L’architecture actuelle du processeur est : {0}. Le module « {1} » nécessite l’architecture suivante : {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Le nom de l’hôte PowerShell actuel est : « {0} ». Le module « {1} » nécessite l’hôte PowerShell suivant : « {2} ».</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>L’hôte PowerShell actuel est : « {0} » (version {1}). Le module « {2} » nécessite une version minimale de l’hôte PowerShell « {3} » pour s’exécuter.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Manifeste du module « {0} »</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Généré par : {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Généré le : {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Module de script ou fichier de module binaire associé à ce manifeste.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Modules à importer en tant que modules imbriqués du module spécifié dans RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>ID utilisé pour identifier ce module de manière unique</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Auteur de ce module</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Société ou fournisseur de ce module</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Déclaration de copyright pour ce module</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Numéro de version de ce module.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Description de la fonctionnalité fournie par ce module</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Version minimale du moteur PowerShell requise par ce module</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Version minimale du CLR (Common Language Runtime) requise par ce module. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Modules qui doivent être importés dans l’environnement global avant l’importation de ce module</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Fichiers de script (.ps1) exécutés dans l’environnement de l’appelant avant l’importation de ce module.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Fichiers de type (.ps1xml) à charger lors de l’importation de ce module</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Fichiers de format (.ps1xml) à charger lors de l’importation de ce module</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Assemblys qui doivent être chargés avant l’importation de ce module</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Liste de tous les fichiers empaquetés avec ce module</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Données privées à transmettre au module spécifié dans RootModule/ModuleToProcess. Cela peut également contenir une table de hachage PSData avec des métadonnées de module supplémentaires utilisées par PowerShell.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Balises appliquées à ce module. Elles aident à la découverte de modules dans les galeries en ligne.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>URL du site web principal de ce projet.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>URL de la licence de ce module.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>URL d’une icône représentant ce module.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Notes de publication de ce module</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Chaîne de préversion de ce module</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Indique si le module nécessite une acceptation explicite de l’utilisateur pour l’installation, la mise à jour ou l’enregistrement</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Modules dépendants externes de ce module</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Fin de la table de hachage {0}</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>La valeur du paramètre PrivateData doit être une table de hachage pour créer le manifeste du module avec les valeurs de paramètre suivantes : Tags, ProjectUri, LicenseUri, IconUri ou ReleaseNotes. Supprimez les valeurs des paramètres Tags, ProjectUri, LicenseUri, IconUri ou ReleaseNotes, ou enveloppez le contenu de PrivateData dans une table de hachage.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData doit être défini comme une table de hachage, mais ce manifeste de module le définit comme un objet. Envisagez d’envelopper le contenu de PrivateData dans une table de hachage. Cela vous permettra d’ajouter ultérieurement les propriétés Tags, ProjectUri, LicenseUri, IconUri et ReleaseNotes au manifeste du module.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>La valeur spécifiée « {0} » n’est pas valide. Réessayez avec une valeur valide.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Fonctions à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide s’il n’y a aucune fonction à exporter.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Les alias à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide s’il n’y a aucun alias à exporter.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Cmdlets à exporter à partir de ce module. Pour de meilleures performances, n’utilisez pas de caractères génériques et ne supprimez pas l’entrée. Utilisez un tableau vide s’il n’y a aucune cmdlet à exporter.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Variables à exporter depuis ce module</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Ressources DSC à exporter depuis ce module</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Éditions PowerShell prises en charge</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Architecture du processeur (None, X86, Amd64) requise par ce module</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Liste de tous les modules empaquetés avec ce module</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Version minimale de Microsoft .NET Framework requise par ce module. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Nom de l’hôte PowerShell requis par ce module</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Version minimale de l’hôte PowerShell requis par ce module</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>URI HelpInfo de ce module</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Étant donné que le module {0} fournit le PSDrive dans la session PowerShell actuelle, aucun module n’a été supprimé. Modifiez le fournisseur PSDrive actuel, puis réessayez de supprimer des modules.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>La cmdlet « {0} » n’a pas été importée, car un membre portant le même nom existe dans l’étendue actuelle.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>L’alias « {0} » n’a pas été importé, car un membre portant le même nom existe dans l’étendue actuelle.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>La fonction « {0} » n’a pas été importée, car un membre portant le même nom existe dans l’étendue actuelle.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>La variable « {0} » n’a pas été importée, car un membre portant le même nom existe dans l’étendue actuelle.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>Les caractères génériques ne sont pas autorisés dans les membres « ModuleToProcess », « RootModule » ou « NestedModules » du manifeste du module « {0} ».</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Le module « {0} » est un module de base pour PowerShell. Ajoutez le paramètre Force à votre commande pour supprimer les modules de base.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Le manifeste du module ne peut pas contenir à la fois les membres « ModuleToProcess » et « RootModule ». Modifiez le fichier manifeste du module pour supprimer l’un de ces membres dans « {0} », puis réessayez.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Le membre du manifeste de module « ModuleToProcess » est déconseillé. Utilisez le membre « RootModule » à la place.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Préfixe par défaut des commandes exportées à partir de ce module. Remplacez le préfixe par défaut à l’aide de Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Les paramètres « Global » et « Scope » ne peuvent pas être spécifiés ensemble. Supprimez l’un de ces paramètres, puis réessayez d’exécuter la commande.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Le module requis « {0} » n’est pas chargé. Le module « {0} » a un requiredModule « {1} » dans son manifeste de module « {2} » qui pointe vers une dépendance cyclique.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module requis « {0} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Certaines commandes du module {0} ne peuvent pas être importées via une CimSession. Pour obtenir toutes les commandes, vérifiez que la gestion distante PowerShell est activée sur le serveur distant, puis essayez d’ajouter le paramètre PSSession à la cmdlet Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Le module {0} est chargé dans Windows PowerShell à l’aide d’une session de remoting {1} ; notez que toutes les entrées et sorties des commandes de ce module seront des objets désérialisés. Si vous souhaitez charger ce module dans PowerShell, utilisez la syntaxe « Import-Module -SkipEditionCheck ».</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Windows PowerShell, version {0}. Windows PowerShell 5.1 est requis pour charger des modules à l’aide de la fonctionnalité de compatibilité Windows PowerShell. Installez Windows Management Framework (WMF) 5.1 à partir de https://aka.ms/WMF5Download pour activer cette fonctionnalité.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Le chargement du module « {0} » à l’aide de la fonctionnalité de compatibilité Windows PowerShell est bloqué par un paramètre « WindowsPowerShellCompatibilityModuleDenyList » dans le fichier de configuration PowerShell.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Impossible d’importer le module {0} sur une session CimSession. Essayez d’utiliser le paramètre PSSession de la cmdlet Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>La valeur d’architecture de processeur de {0} n’est pas prise en charge. Réexécutez la commande New-ModuleManifest en spécifiant l’une des valeurs d’énumération prises en charge suivantes pour l’architecture de processeur : None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>L’exécution de la cmdlet Get-Module sur un ordinateur distant peut uniquement répertorier les modules disponibles. Ajoutez le paramètre ListAvailable à votre commande, puis réessayez.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Le module « {0} » n’a pas été importé, car le composant logiciel enfichable « {0} » avait déjà été importé.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>Les caractères génériques ne sont pas autorisés dans le membre « RequiredAssemblies » du manifeste du module « {0} ».</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>La valeur de la clé {0} dans {1} est {2} et le module contient des modules imbriqués. Lorsqu’un fichier CDXML est le module racine, la commande Import-Module échoue, car les commandes des modules imbriqués ne peuvent pas être exportées. Déplacez le fichier CDXML vers la clé NestedModules, puis réessayez la commande.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Échec de la commande distante : {0} : {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Échec de la génération des proxys pour le module distant « {0} ». {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Échec du traitement du module distant {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Échec de la réception des données du module à partir de la CimSession distante. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Le module requis « {0} » avec le GUID « {1} » et la version « {2} » n’a pas été chargé, car aucun fichier de module valide n’a été trouvé dans aucun répertoire de module.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Un fournisseur CIM pour la découverte de modules est introuvable sur le serveur CIM. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Impossible de vérifier la version de Microsoft .NET Framework {0}, car elle ne figure pas dans la liste des versions autorisées.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Analyse de {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Préparation des modules pour la première utilisation.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Recherche des modules disponibles</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Recherche du partage UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>L’utilisation de la cmdlet Get-Module sur un ordinateur distant n’est possible que pour les noms de module qui n’incluent pas de chemin d’accès. Le paramètre Name contient l’élément « {0} », qui se résout en chemin d’accès. Mettez à jour le paramètre Name pour qu’il ne contienne pas d’éléments de chemin d’accès, puis réessayez.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>L’utilisation de l’applet de commande Get-Module sans le paramètre ListAvailable n’est pas prise en charge pour les noms de module qui incluent un chemin d’accès. Le paramètre Name contient l’élément « {0} », qui se résout en chemin d’accès. Mettez à jour le paramètre Name pour qu’il ne contienne pas d’éléments de chemin d’accès, puis réessayez.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Le module spécifié « {0} » est introuvable. Mettez à jour le paramètre Name pour qu’il pointe vers un chemin valide, puis réessayez. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Remplissage de la propriété RepositorySourceLocation pour le module {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Le module à traiter « {0} », répertorié dans le champ « {1} » du manifeste du module « {2} », n’a pas été traité. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Cette condition préalable est valide uniquement pour l’édition PowerShell Desktop.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Le module « {0} » ne prend pas en charge l’édition actuelle de PowerShell « {1} ». Les éditions prises en charge sont « {2} ». Utilisez « Import-Module -SkipEditionCheck » pour ignorer la compatibilité de ce module.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Le module « {0} » prend en charge l’édition PowerShell « {1} » et ne peut pas être chargé implicitement à l’aide de la fonctionnalité de compatibilité Windows, car celle-ci est désactivée dans le fichier de paramètres. Utilisez « Import-Module -UseWindowsPowerShell » pour charger ce module avec Windows PowerShell ou « Import-Module -SkipEditionCheck » pour essayer de le charger avec la version actuelle de PowerShell.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Une valeur de chaîne non vide doit être spécifiée pour une fonctionnalité expérimentale déclarée dans le manifeste du module.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Un ou plusieurs noms de fonctionnalité expérimentale non valides ont été trouvés : {0}. Un nom de fonctionnalité expérimentale de module doit suivre cette convention : « ModuleName.FeatureName ».</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Le paramètre de commutateur -SkipEditionCheck ne peut pas être utilisé sans le paramètre de commutateur -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>L’importation de fichiers *.ps1 en tant que modules n’est pas autorisée en mode ConstrainedLanguage.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Une erreur s’est produite lors du chargement du module de script {0}, car son mode de langage est différent de celui du manifeste du module. Le mode de langage du manifeste est {1} et le mode de langage du module est {2}. Vérifiez que tous les fichiers du module sont signés ou qu’ils font partie de la configuration de la liste d’autorisation de votre application.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Ce module utilise l’opérateur dot-source lors de l’exportation de fonctions à l’aide de caractères génériques, ce qui n’est pas autorisé lorsque le système est soumis à obligation de vérification des applications.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Impossible d’exporter des membres de module à partir d’un module dont le mode de langage est différent de celui de la session en cours.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Impossible de créer un nouveau module tant que la session est en mode ConstrainedLanguage.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Impossible de trouver le module intégré « {0} » compatible avec l’édition « Core ». Vérifiez que les modules intégrés PowerShell sont disponibles. Ils sont généralement fournis avec le package PowerShell sous le chemin de module $PSHOME, et sont nécessaires au bon fonctionnement de PowerShell.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Cmdlet Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>L’exportation des membres du module échouera en mode de langage contraint, car le module « {0} » a un mode de langage « {1} » différent du mode de la session actuelle « {2} ».</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Exportation implicite des fonctions du module</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>L’exportation implicite de fonctions pour le module « {0} » sera refusée, car il est approuvé (il s’exécute en mode de langage complet), mais la session ne l’est pas (elle s’exécute en mode de langage contraint). Il est recommandé d’exporter systématiquement les fonctions du module individuellement, avec leur nom complet.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Importation du fichier de script en tant que module</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>L’importation du fichier de script « {0} » en tant que module ne sera pas autorisée en mode ConstrainedLanguage.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Le module contient un opérateur Dot-Source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>L’importation du module « {0} » échouera en mode de langage contraint, car il exporte des fonctions à l’aide de caractères génériques tout en utilisant l’opérateur dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>« Fonctions d’exportation de module</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Le module « {0} » exporte des fonctions à l’aide de caractères génériques dans le nom. Tous les noms de fonctions des modules imbriqués seront supprimés lors de l’exécution en mode de langage contraint.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>«Cmdlet New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Un nouveau module provenant d’une session de langage contraint non approuvée sera empêché de fournir le bloc de script FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>« Modes de langage incompatibles avec les modules</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Un module dépendant est en cours de chargement avec un mode de langue différent de celui du module parent. Cela ne sera pas autorisé en mode de langage contraint.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/PSConfigurationStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/PSConfigurationStrings.fr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell a cessé de fonctionner en raison d’un problème de sécurité : impossible de lire le fichier de configuration : {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/RemotingErrorIdStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/RemotingErrorIdStrings.fr.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>Les caractères génériques ne sont pas pris en charge pour le paramètre FilePath. Indiquez un chemin d’accès sans caractères génériques.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>Une valeur {0} doit être spécifiée pour l’option de session {1}.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>Nombre maximal de redirections d’URI WS-Man autorisées lors de la connexion à un ordinateur distant</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>Le paramètre WriteEvents ne peut pas être utilisé sans le paramètre Wait.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>La communication à distance PowerShell n’est pas prise en charge dans l’environnement de préinstallation Windows (WinPE).</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>Les modifications effectuées par {0} ne peuvent pas prendre effet tant que le service WinRM n’est pas redémarré.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0} Vous devrez peut-être redémarrer le service WinRM si une configuration utilisant ce nom a été récemment désinscrite, car des structures de données système peuvent encore être mises en cache. Dans ce cas, un redémarrage de WinRM peut être requis.
+Toutes les sessions WinRM connectées à des configurations de session PowerShell, telles que Microsoft.PowerShell et les configurations de session, créées avec la cmdlet Register-PSSessionConfiguration, sont déconnectées.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>Vous exécutez une session à distance et avez sélectionné l’option Forcer, ce qui signifie que le service WinRM peut redémarrer. Si le service WinRM redémarre, cette session à distance est terminée et vous devez créer une session pour continuer</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>Le paramètre -WriteJobInResults ne peut pas être utilisé sans le paramètre -Wait</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>Le flux d’entrée fourni n’est pas valide. Seul {0} est pris en charge comme flux d’entrée.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>Le jeu de flux de sortie fourni n’est pas valide. Seul {0} est pris en charge comme flux de sortie.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>L’élément WSMAN_SENDER_DETAILS fourni n’est pas valide. Nous ne pouvons pas traiter un élément WSMAN_SENDER_DETAILS nul.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>Le contexte d’interpréteur de commandes fourni n’est pas valide.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>La valeur NULL n’est pas autorisée pour {0} avec la méthode de plug-in {1}.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>La valeur NULL n’est pas autorisée pour les jeux de flux d’entrée et de sortie. {0} et {1} sont des flux d’entrée et de sortie pris en charge.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>La valeur NULL n’est pas autorisée pour {0} avec la méthode de plug-in {1}.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>La valeur NULL n’est pas autorisée pour {0} avec la méthode de plug-in {1}.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>L’opération du plug-in de PowerShell est en cours d’arrêt. Ce problème peut se produire si le service ou l’application d’hébergement est en cours d’arrêt.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Le plug-in PowerShell ne comprend pas l’option {0}. Vérifiez que le client est compatible avec la version de build {1} et de protocole {2} de PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Une option nommée {0} est attendue du client. Vérifiez que le client est compatible avec la version de build {1} et de protocole {2} de PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Le plug-in PowerShell ne prend pas en charge la version de protocole {2} demandée par le client.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>Le plug-in PowerShell a rencontré une erreur irrécupérable lors de la transmission du contexte au service WSMan.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>Nous ne pouvons pas créer une session de serveur géré.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>Le plug-in PowerShell a rencontré une erreur irrécupérable lors d’inscriptions d’un handle d’attente pour la notification d’arrêt.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>Le fichier exécutable « {0} » est introuvable. Confirmez que la fonctionnalité WOW64 est installée.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>Nous ne pouvons pas créer le processus Windows PowerShell, car Windows PowerShell est introuvable sur cet ordinateur.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/fr/RunspaceStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/RunspaceStrings.fr.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>L’état de l’instance d’exécution n’est pas valide pour cette opération.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>Nous ne pouvons pas ouvrir l’instance d’exécution, car elle n’est pas dans l’état BeforeOpen. L’état actuel de l’instance d’exécution est « {0} ».</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Nous ne pouvons pas effectuer l’opération, car l’instance d’exécution n’est pas dans l’état Ouvert. L’état actuel de l’instance d’exécution est « {0} ».</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Nous ne pouvons pas appeler le pipeline, car l’instance d’exécution n’est pas à l’état Ouvert. L’état actuel de l’instance d’exécution est « {0} ».</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>L’état du pipeline n’est pas valide pour cette opération.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>Nous ne pouvons pas appeler le pipeline, car il a déjà été appelé.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>La valeur valide pour le paramètre est PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>Le pipeline ne contient pas de commande.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>Le pipeline n’a pas été exécuté, car un pipeline est déjà en cours d’exécution. Vous ne pouvez pas exécuter les pipelines simultanément.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>Un pipeline imbriqué ne peut pas être appelé de manière asynchrone. Utilisez la méthode Invoke.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>Vous devez exécuter un pipeline imbriqué uniquement à partir d’un pipeline en cours d’exécution.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>Nous ne pouvons pas fermer l’instance d’exécution pendant qu’un appel de méthode SessionStateProxy est en cours.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>Nous ne pouvons pas appeler le pipeline pendant qu’un appel de méthode SessionStateProxy est en cours.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Un appel de méthode SessionStateProxy est en cours. Les appels simultanés de méthode SessionStateProxy ne sont pas autorisés.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Un pipeline est déjà en cours d’exécution. Les appels simultanés de méthode SessionStateProxy ne sont pas autorisés.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Cette propriété ne peut pas être modifiée après l’ouverture de l’instance d’exécution.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Une ou plusieurs erreurs se sont produites lors du traitement du module « {0} » spécifié dans l’objet InitialSessionState utilisé pour créer cette instance d’exécution. Consultez la propriété ErrorRecords pour obtenir la liste complète des erreurs. La première erreur était : {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>Les options de thread ne peuvent être modifiées que si l’état de cloisonnement est MTA (Multithreaded Apartment), si les options actuelles sont UseNewThread ou UseCurrentThread, et si la nouvelle valeur est ReuseThread.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>{0} ne peut pas avoir la valeur false lorsque le mode de langage est {1} ou {2}.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>Vous ne pouvez pas déconnecter un espace d’exécution local uniquement.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>L’opération Connect n’est pas prise en charge sur les instances d’exécution locales.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>La session est occupée. Dès que la session sera disponible, vous serez connecté. Pour annuler la commande Enter-PSSession, appuyez sur Ctrl+C.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>Nous ne pouvons pas effectuer la commande. L’appel de script n’est pas pris en charge dans la configuration de cette session. Cela peut se produire si la configuration de session est en mode sans langage.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>Vous ne pouvez pas utiliser les opérations Disconnect et Connect sur les instances d’exécution locales.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>Nous ne pouvons pas effectuer la connexion au pipeline, car l’instance d’exécution n’est pas à l’état Ouvert.  L’état actuel de l’instance d’exécution est « {0} ».</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>Nous ne pouvons pas créer un RemoteRunspace. L’objet RunspacePool fourni n’est pas valide.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>Il n’existe aucune commande déconnectée associée à cette instance d’exécution.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>L’opération de déconnexion n’est pas prise en charge sur l’ordinateur distant. Pour prendre en charge la déconnexion, l’ordinateur distant doit exécuter Windows PowerShell 3.0 ou une version ultérieure de Windows PowerShell et utiliser le transport WSMan.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>Nous ne pouvons pas effectuer la connexion à PSSession, car la session n’est pas à l’état Déconnecté ou n’est pas disponible pour la connexion.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>La valeur du paramètre ne peut pas être PipelineResultTypes.None ou PipelineResultTypes.Output.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>Les valeurs valides pour le paramètre sont PipelineResultTypes.Output ou PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>La redirection du flux de débogage n’est pas prise en charge sur l’ordinateur distant ciblé.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>La redirection du flux détaillé n’est pas prise en charge sur l’ordinateur distant ciblé.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>La redirection du flux d’avertissement n’est pas prise en charge sur l’ordinateur distant ciblé.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>La redirection du flux d’informations n’est pas prise en charge sur l’ordinateur distant ciblé.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>Vous avez ouvert une session qui est occupée à exécuter une commande ou un script.  Comme la sortie est redirigée vers le travail « {0} », vous ne verrez pas la sortie dans la console.  Vous pouvez attendre la fin de la commande en cours ou l’annuler pour obtenir une requête d’entrée en appuyant sur Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>Vous avez entré une session qui est occupée à exécuter une commande ou un script dont le résultat s’affichera dans la console.  Vous pouvez attendre la fin de la commande en cours ou l’annuler pour obtenir une requête d’entrée en appuyant sur Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>Vous avez entré une session actuellement arrêtée à un point d’arrêt de débogage au sein d’une commande ou d’un script en cours d’exécution.  Utilisez le débogueur de ligne de commande PowerShell pour poursuivre le débogage.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace doit être un LocalRunspace</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>La propriété statique PrimaryRunspace ne peut être définie qu’une seule fois et a déjà été définie.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/SessionStateStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/SessionStateStrings.fr.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>Impossible de traiter les informations retournées, car celles retournées par la méthode Start du fournisseur étaient pour un différent fournisseur de celui qui a été transmis.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>Impossible de traiter les informations retournées, car celles retournées par la méthode Start du fournisseur étaient null.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération SetItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération SetItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération ClearItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération InvokeDefaultAction sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération InvokeDefaultAction pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération ItemExists sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération ItemExists pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération IsValidPath sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération IsItemContainer sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération RemoveItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetChildItems sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetChildItems pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetChildNames sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetChildNames pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération RenameItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération RenameItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération NewItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération NewItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération HasChildItems sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération CopyItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération CopyItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetParentPath sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération NormalizeRelativePath sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération MakePath sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetChildName sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération MoveItem sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération MoveItem pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetProperty pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération SetProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération SetProperty pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération ClearProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération ClearProperty pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération NewProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération NewProperty pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération RemoveProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération RemoveProperty pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération CopyProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération CopyProperty pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération MoveProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération MoveProperty pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération RenameProperty sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de RenameProperty pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Impossible de récupérer le lecteur de contenu pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetContentReader pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Impossible de récupérer l’enregistreur de contenu pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération GetContentWriter pour le fournisseur « {0} » pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>Impossible d’obtenir le contenu, car il s’agit d’un répertoire : « {0} ». Utilisez plutôt « Get-ChildItem ».</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>Impossible d’écrire le contenu, car il s’agit d’un répertoire : « {0} ».</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>Il n’y a plus d’historique d’emplacement pour naviguer vers l’arrière.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>Il n’y a plus d’historique d’emplacement pour naviguer vers l’avant.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack est vide.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération ClearContent sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>Impossible d’effacer le contenu de « {0} », car il s’agit d’un répertoire. Clear-Content n’est pris en charge que sur les fichiers.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de l’opération ClearContent pour le fournisseur « {0} » depuis le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération GetSecurityDescriptor sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération SetSecurityDescriptor sur le fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>La tentative d’exécution de l’opération Start sur le fournisseur « {0} » a échoué. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>La tentative d’exécution de l’opération InitializeDefaultDrives sur le fournisseur « {0} » a échoué.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>La tentative d’exécution de l’opération NewDrive sur le fournisseur « {0} » a échoué pour le lecteur avec la racine « {1} ». {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>Impossible de récupérer les paramètres dynamiques de NewDrive pour le fournisseur « {0} ». {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>L’appel de RemoveDrive sur le fournisseur « {0} » a échoué. {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>Le lecteur « {0} » ne peut pas être supprimé, car le fournisseur « {1} » l’a empêché.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>Le chemin d’accès « {0} » faisait référence à un élément situé en dehors de la base « {1} ».</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>L’appel de Seek sur le rédacteur de contenu du fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>L’appel de Close sur le lecteur ou l’enregistreur de contenu du fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>L’appel de Read sur le lecteur de contenu du fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>L’appel de Write sur le rédacteur de contenu du fournisseur « {0} » a échoué pour le chemin d’accès « {1} ». {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>Le fournisseur « {0} » ne peut pas être utilisé pour obtenir ou définir des données à l’aide de la syntaxe de variable. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>Impossible d’utiliser la syntaxe de variable pour obtenir ou définir des données dans le fournisseur. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>Alias n’est pas accessible en écriture, car l’alias {0} étant une constante ou en lecture seule, il n’est pas possible d’y écrire.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>Impossible d’écrire dans la fonction {0}, car elle est en lecture seule ou constante.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>Impossible de remplacer la variable {0} car elle est en lecture seule ou constante.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>Impossible d’accéder à la variable « ${0} », car il s’agit d’une variable privée.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>Impossible d’accéder à la commande « {0} », car il s’agit d’une commande privée.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>Impossible d’accéder à la commande, car il s’agit d’une commande privée.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>Impossible d’accéder à la ressource d’état de session, car il s’agit d’une ressource privée. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>L’alias n’a pas été supprimé, car l’alias {0} est constant ou en lecture seule.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>Impossible de supprimer la fonction {0}, car elle est constante.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>Impossible de supprimer la variable {0} car elle est constante ou en lecture seule. Si la variable est en lecture seule, recommencez l’opération en spécifiant l’option Force.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>Impossible de modifier l’alias {0} car il est constant.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>Impossible de modifier l’alias {0} car il est en lecture seule.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>Impossible de modifier la fonction {0}, car elle est constante.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>Impossible de modifier la fonction {0}, car elle est « lecture seule ».</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>L’alias {0} ne peut pas être défini comme constant une fois créé. Les alias ne peuvent être définis comme constants qu’au moment de leur création.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>La fonction existante {0} ne peut pas être définie comme constante. Les fonctions ne peuvent être définies comme constantes qu’au moment de leur création.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>La variable existante {0} ne peut pas être définie comme constante. Les variables ne peuvent être définies comme constantes qu’au moment de leur création.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>L’option AllScope ne peut pas être supprimée de l’alias « {0} ».</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>L’option AllScope ne peut pas être supprimée de la fonction « {0} ».</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>L’option AllScope ne peut pas être supprimée de la variable « {0} ».</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>La définition de fonction « {0} » contenait un qualificateur d’étendue, mais aucun nom de fonction.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>Impossible de supprimer le fournisseur {0}. Tous les lecteurs associés au fournisseur {0} doivent être supprimés avant de pouvoir supprimer le fournisseur {0}.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>Impossible de traiter le nom du lecteur, car il contient un ou plusieurs des caractères non valides suivants : ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>La création du nouveau lecteur a échoué, car le fournisseur n’autorise pas la création d’un nouveau lecteur.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>La valeur fournie « {0} » correspond à plusieurs piles d’emplacements.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>Impossible de trouver la pile d’emplacements « {0} ». Elle n’existe pas ou ce n’est pas un conteneur.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>Impossible de trouver le chemin d'accès « {0} », car il n'existe pas.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>Alias introuvable, car l’alias « {0} » n’existe pas.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>Impossible de définir l’emplacement, car le chemin « {0} » a été résolu en plusieurs conteneurs. Vous ne pouvez définir l’emplacement que sur un seul conteneur à la fois.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>Impossible de traiter la variable, car le chemin d’accès de variable « {0} » a été résolu en plusieurs éléments. Vous ne pouvez obtenir ou définir la valeur de la variable d’un seul élément à la fois.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>Nous ne pouvons pas trouver le lecteur. Aucun lecteur nommé « {0} » n’existe.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>Impossible de trouver un fournisseur portant le nom « {0} ».</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Impossible de trouver un fournisseur portant le nom « {0} ». Le format du nom n’est pas correct. Un nom de fournisseur ne peut contenir que des caractères alphanumériques, ou un nom de composant logiciel enfichable PowerShell suivi d’un seul « \ », puis de caractères alphanumériques.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>« {0} » a donné plusieurs noms de fournisseur. Les correspondances possibles sont les suivantes : {1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Une erreur s’est produite lors de la tentative de création d’une instance du fournisseur. Le nom du type de fournisseur « {0} » est introuvable dans l’assembly.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>Le nom de fournisseur spécifié « {0} » ne peut pas être utilisé, car il contient un ou plusieurs des caractères non valides suivants : \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>Une erreur s’est produite lors de la tentative de création d’une instance du fournisseur « {0} ». {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>Impossible de trouver une variable nommée « {0} ».</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>Impossible de trouver une source de trace nommée « {0} ».</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>Un lecteur portant le nom « {0} » existe déjà.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>Une variable portant le nom « {0} » existe déjà.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>L’alias n’est pas autorisé, car un alias portant le nom « {0} » existe déjà.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>Impossible d’inscrire le fournisseur d’applets de commande, car un fournisseur d’applets de commande portant le nom « {0} » existe déjà.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>Le chemin d’accès ne fait pas référence à un chemin d’accès de système de fichiers.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>L’étendue globale ne peut pas être supprimée.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>Le nombre d’étendues actives est inférieur à « {0} ».</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>Impossible de comparer PSDriveInfo. Une instance de PSDriveInfo ne peut être comparée qu’à une autre instance de PSDriveInfo.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Le fournisseur d’applets de commande ne peut pas diffuser les résultats, car aucun cmdlet n’a été spécifié n’a été spécifiée pour diffuser la sortie.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Le fournisseur d’applets de commande ne peut pas diffuser les résultats, car aucun cmdlet n’a été spécifié pour diffuser l’erreur.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>L’emplacement d’accueil de ce fournisseur n’est pas défini. Pour définir l’emplacement d’accueil, appelez « (get-psprovider '{0}').Home = 'path' ».</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>Le format du chemin est incorrect. Les chemins d’accès du fournisseur doivent contenir un ID de fournisseur, suivi de « :: », puis d’un chemin d’accès propre au fournisseur.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>Impossible de déplacer l’élément, car le chemin d’accès de destination ne peut être résolu qu’en un seul chemin d’accès.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>Impossible de déplacer l’élément, car les chemins d’accès source et destination n’ont pas été résolus vers le même fournisseur.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>Impossible de déplacer l’élément, car le chemin source pointe vers un ou plusieurs éléments et le chemin de destination n’est pas un conteneur. Vérifiez que le chemin de destination est un conteneur et réessayez.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>Impossible de déplacer l’élément, car la destination a été résolue en plusieurs chemins d’accès. Spécifiez un chemin de destination qui mène à une seule destination, puis réessayez.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>Impossible de copier un conteneur sur un élément feuille existant.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>Impossible de copier un conteneur dans un autre conteneur. Le paramètre -Recurse ou -Container n’est pas spécifié.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>Les chemins source et de destination n’ont pas été résolus vers le même fournisseur.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>Impossible de renommer l’élément, car le chemin d’accès a été résolu en plusieurs éléments. Un seul élément peut être renommé à la fois.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>Le fournisseur « {0} » ne peut pas être utilisé pour résoudre le chemin d’accès « {1} » en raison d’une erreur dans le fournisseur.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>Impossible d’utiliser l’interface. L’interface IContentCmdletProvider n’est pas implémentée par ce fournisseur.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>Impossible d’utiliser l’interface. L’interface IPropertyCmdletProvider n’est pas prise en charge par ce fournisseur.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>Impossible d’utiliser l’interface. L’interface IDynamicPropertyCmdletProvider n’est pas implémentée par ce fournisseur.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>Les méthodes NavigationCmdletProvider ne sont pas prises en charge par ce fournisseur.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Méthodes de fournisseur non traitées. Les méthodes ContainerCmdletProvider ne sont pas prises en charge par ce fournisseur.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>Impossible d'appeler des méthodes. Les méthodes ItemCmdletProvider ne sont pas prises en charge par ce fournisseur.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>Les méthodes DriveCmdletProvider ne sont pas prises en charge par ce fournisseur.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>L’opération du fournisseur s’est arrêtée, car ce fournisseur ne prend pas en charge cette opération.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>L’opération du fournisseur s’est arrêtée, car ce fournisseur ne prend pas en charge le paramètre « Depth ».</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>Impossible d'appeler la méthode. La méthode Seek du contenu n’est pas prise en charge par ce fournisseur.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>Impossible d’effectuer l’opération ClearContent. Cette opération n’est pas prise en charge par ce fournisseur.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>Le fournisseur ne prend pas en charge l’utilisation des informations d’identification. Recommencez l’opération sans spécifier d’informations d’identification.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>Le fournisseur FileSystem ne prend en charge les informations d’identification que dans le cmdlet New-PSDrive. Recommencez l’opération sans spécifier d’informations d’identification.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>Le fournisseur ne prend pas en charge les transactions. Recommencez l’opération sans le paramètre -UseTransaction.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>Impossible d'appeler la méthode. Le fournisseur ne prend pas en charge l’utilisation des filtres.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>Désolé, nous ne pouvons pas créer le lecteur. Le fournisseur ne prend pas en charge l’utilisation des informations d’identification.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>L'élément « {0} » du chemin d’accès existe déjà.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>Impossible de copier l’élément. L’élément « {0} » du chemin d’accès n’existe pas.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>L’élément « {0} » du chemin d’accès n’existe pas.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Lecteur qui contient une vue des alias stockés dans un état de session</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>Lecteur qui contient une vue des variables d’environnement pour le processus</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Lecteur qui contient une vue des fonctions stockées dans un état de session</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Lecteur qui contient une vue de ces variables dans un état de session</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Lecteur mappé au chemin d’accès du répertoire temporaire pour l’utilisateur actuel</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>Le lien « {0} » ne peut pas être créé, car la valeur de destination n’a pas été spécifiée.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Les références à la variable null retournent toujours la valeur null. Les affectations n’ont aucun effet.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Nombre maximal d’objets d’historique à conserver dans une session</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>Impossible de renommer la fonction, car la fonction {0} est en lecture seule ou constante.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>Impossible de renommer l’alias, car l’alias {0} est en lecture seule ou constant.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>Impossible de renommer la variable, car la variable {0} est en lecture seule ou constante.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>Impossible de définir des options sur la variable locale {0}. Utilisez New-Variable pour créer une variable qui autorise la définition d’options.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Impossible de modifier le cmdlet {0} car il est en lecture seule.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>Impossible de supprimer la variable {0} car elle a été optimisée et ne peut pas être supprimée. Essayez d’utiliser le cmdlet Remove-Variable (sans alias) ou d’effectuer un dot-sourcing de la commande que vous utilisez pour supprimer la variable.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>Impossible de remplacer la variable {0} car elle a été optimisée. Essayez d’utiliser le cmdlet New-Variable ou Set-Variable (sans alias) ou d’effectuer un dot-sourcing de la commande que vous utilisez pour définir la variable.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>Les paramètres {0} et {1} ne peuvent pas être utilisés ensemble. Spécifiez un seul paramètre.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Le paramètre Tail n’est actuellement pris en charge que pour le fournisseur FileSystem.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>L’alias n’est pas autorisé, car une commande portant le nom « {0} » et le type de commande « {1} » existe déjà.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>Impossible d’exécuter le logiciel. Autorisation refusée.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>« -{0} » et « -{1} » s’excluent mutuellement et ne peuvent pas être spécifiés en même temps.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>Le chemin d'accès « {0} » n'est pas valide. Seuls les chemins d’accès absolus sont pris en charge pour les opérations de copie à distance.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>Impossible de valider le chemin d’accès distant « {0} ».</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>Impossible d’effectuer l’opération, car la session {0} est définie sur {1}.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>Le paramètre « {0} » ne peut pas être vide ou avoir une valeur null.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Variables d’état de session</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>La modification de portée de la variable « {0} » en AllScope, ou la création d’une telle variable, sera empêchée en mode ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/fr/TransactionStrings.fr.resx
+++ b/src/System.Management.Automation/resources/fr/TransactionStrings.fr.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>Nous ne pouvons pas utiliser la transaction. Aucune transaction n’est active.</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>Nous ne pouvons pas valider une transaction. Aucune transaction n’est active.</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>Nous ne pouvons pas restaurer la transaction, car aucune transaction n’est active.</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>Nous ne pouvons pas restaurer la transaction. La transaction a déjà été validée.</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>Nous ne pouvons pas valider une transaction. La transaction a déjà été validée.</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Nous ne pouvons pas valider une transaction. La transaction a été restaurée ou a expiré.</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>Nous ne pouvons pas restaurer la transaction. La transaction a déjà été restaurée ou a expiré.</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>Nous ne pouvons pas définir de transaction active. Aucune transaction n’a été créée.</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>Nous ne pouvons pas définir de transaction active. La transaction active a été restaurée ou a expiré.</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>La cmdlet nécessite une transaction active. La transaction actuelle a déjà été validée ou restaurée.</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>Cette cmdlet requiert une transaction. Réexécutez la commande avec le paramètre -UseTransaction.</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>Nous ne pouvons pas utiliser la transaction. Aucune transaction n’a été lancée.</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>Nous ne pouvons pas utiliser la transaction. La transaction a été validée.</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Nous ne pouvons pas utiliser la transaction. La transaction a été restaurée ou a expiré.</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>Nous ne pouvons pas utiliser la transaction. La transaction a expiré.</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>La transaction de base n’a pas été définie.</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>La transaction de base n’est pas active.</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>La transaction de base ne peut pas être définie après la création d’autres transactions.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/AutomationExceptions.it.resx
+++ b/src/System.Management.Automation/resources/it/AutomationExceptions.it.resx
@@ -118,93 +118,93 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Argument" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is not valid. Change the value of the "{0}" argument and run the operation again.</value>
+    <value>Non è possibile elaborare l'argomento perché il valore dell'argomento "{0}" non è valido. Modificare il valore dell'argomento "{0}" ed eseguire di nuovo l'operazione.</value>
   </data>
   <data name="InvalidScopeIdArgument" xml:space="preserve">
-    <value>Cannot process argument because the value of parameter "{0}" is not valid. Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes where 0 is the current scope and 1 is its parent). Change the value of the "{0}" parameter and run the operation again.</value>
+    <value>Non è possibile elaborare l'argomento perché il valore del parametro "{0}" non è valido. I valori validi sono "Global", "Local" o "Script" oppure un numero relativo all'ambito corrente (tra 0 e il numero di ambiti, dove 0 è l'ambito corrente e 1 è il relativo ambito padre). Modificare il valore del parametro "{0}" ed eseguire di nuovo l'operazione.</value>
   </data>
   <data name="ArgumentNull" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is null. Change the value of argument "{0}" to a non-null value.</value>
+    <value>Non è possibile elaborare l'argomento perché il valore dell'argomento "{0}" è null. Modificare il valore dell'argomento "{0}" in un valore non null.</value>
   </data>
   <data name="ArgumentOutOfRange" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is out of range. Change argument "{0}" to a value that is within range.</value>
+    <value>Non è possibile elaborare l'argomento perché il valore dell'argomento "{0}" non rientra nell'intervallo. Modificare il valore dell'argomento "{0}" in un valore compreso nell'intervallo.</value>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not valid. Remove operation "{0}", or investigate why it is not valid.</value>
+    <value>Non è possibile eseguire l'operazione perché l'operazione "{0}" non è valida. Rimuovere l'operazione "{0}" oppure individuare il motivo per cui non è valida.</value>
   </data>
   <data name="NotImplemented" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not implemented.</value>
+    <value>Non è possibile eseguire l'operazione perché l'operazione "{0}" non è implementata.</value>
   </data>
   <data name="NotSupported" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not supported.</value>
+    <value>Non è possibile eseguire l'operazione perché l'operazione "{0}" non è supportata.</value>
   </data>
   <data name="ObjectDisposed" xml:space="preserve">
-    <value>Cannot perform operation because object "{0}" has already been disposed.</value>
+    <value>Non è possibile eseguire l'operazione perché l'oggetto "{0}" è già stato eliminato.</value>
   </data>
   <data name="ScriptBlockInvokeOnOneClauseOnly" xml:space="preserve">
-    <value>The script block cannot be invoked because it contains more than one clause. The Invoke() method can only be used on script blocks that contain a single clause.</value>
+    <value>Non è possibile richiamare il blocco di script perché contiene più di una clausola. Il metodo Invoke() può essere usato solo su blocchi di script che contengono una singola clausola.</value>
   </data>
   <data name="CanConvertOneClauseOnly" xml:space="preserve">
-    <value>The script block cannot be converted because it contains more than one clause. Expressions or control structures are not permitted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>Non è possibile convertire il blocco di script perché contiene più di una clausola. Le espressioni o le strutture di controllo non sono consentite. Verificare che il blocco di script contenga esattamente una pipeline o un comando.</value>
   </data>
   <data name="CantConvertEmptyPipeline" xml:space="preserve">
-    <value>An empty script block cannot be converted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>Non è possibile convertire un blocco di script vuoto. Verificare che il blocco di script contenga esattamente una pipeline o un comando.</value>
   </data>
   <data name="CanOnlyConvertOnePipeline" xml:space="preserve">
-    <value>Only a script block that contains exactly one pipeline or command can be converted. Expressions or control structures are not permitted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>È possibile convertire solo un blocco di script che contenga esattamente una pipeline o un comando. Le espressioni o le strutture di controllo non sono consentite. Verificare che il blocco di script contenga esattamente una pipeline o un comando.</value>
   </data>
   <data name="CantConvertScriptBlockWithTrap" xml:space="preserve">
-    <value>A script block that contains a top-level trap statement cannot be converted.</value>
+    <value>Non è possibile convertire un blocco di script contenente un'istruzione trap di primo livello.</value>
   </data>
   <data name="CantConvertWithUndeclaredVariables" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che dereferenzia variabili non dichiarate nel blocco param(...).  Nome della variabile non dichiarata: {0}.</value>
   </data>
   <data name="CantConvertWithNonConstantExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che restituisce espressioni non costanti. Espressione non costante: {0}.</value>
   </data>
   <data name="CantConvertWithDynamicExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che restituisce espressioni dinamiche. Espressione dinamica: {0}.</value>
   </data>
   <data name="CantConvertWithScriptBlocks" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che tenta di passare altri blocchi di script all'interno dei valori degli argomenti.</value>
   </data>
   <data name="CantConvertWithCommandInvocations" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che richiama pipeline, comandi o funzioni per restituire gli argomenti della pipeline principale.</value>
   </data>
   <data name="CantConvertWithDotSourcing" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that uses dot sourcing.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che usa il dot sourcing.</value>
   </data>
   <data name="CantConvertWithScriptBlockInvocation" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that invokes other script blocks.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che richiama altri blocchi di script.</value>
   </data>
   <data name="CanConvertOneOutputErrorRedir" xml:space="preserve">
-    <value>The script block cannot be converted to a PowerShell object because it contains forbidden redirection operators.</value>
+    <value>Non è possibile convertire il blocco di script in un oggetto PowerShell perché contiene operatori di reindirizzamento non consentiti.</value>
   </data>
   <data name="CantConvertScriptBlockWithNoContext" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that does not have an associated operation context.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock a cui non è associato un contesto dell'operazione.</value>
   </data>
   <data name="HaltCommandException" xml:space="preserve">
-    <value>The command was stopped by the user.</value>
+    <value>Il comando è stato interrotto dall'utente.</value>
   </data>
   <data name="DynamicParametersWrongType" xml:space="preserve">
-    <value>Object "{0}" is the wrong type to return from the dynamicparam block. The dynamicparam block must return either $null, or an object with type [System.Management.Automation.RuntimeDefinedParameterDictionary].</value>
+    <value>L'oggetto "{0}" è di tipo errato per essere restituito dal blocco dynamicparam. Il blocco dynamicparam deve restituire $null o un oggetto di tipo [System.Management.Automation.RuntimeDefinedParameterDictionary].</value>
   </data>
   <data name="CantConvertScriptBlockToOpenGenericType" xml:space="preserve">
-    <value>The script block cannot be converted to an open generic type. Define an appropriate closed generic type, and then retry.</value>
+    <value>Non è possibile convertire il blocco di script in un tipo generico aperto. Definire un tipo generico chiuso appropriato e riprovare.</value>
   </data>
   <data name="CantConvertPipelineStartsWithExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that starts a pipeline with an expression.</value>
+    <value>Non è possibile generare un oggetto PowerShell per uno ScriptBlock che avvia una pipeline con un'espressione.</value>
   </data>
   <data name="UsingVariableIsUndefined" xml:space="preserve">
-    <value>The value of the using variable '$using:{0}' cannot be retrieved because it has not been set in the local session.</value>
+    <value>Non è possibile recuperare il valore della variabile using "$using:{0}" perché non è stata impostata nella sessione locale.</value>
   </data>
   <data name="CantGetUsingExpressionValueWithSpecifiedVariableDictionary" xml:space="preserve">
-    <value>Cannot get the value of the Using expression '{0}' in the specified variable dictionary. When creating a PowerShell instance from a script block, the Using expression cannot contain an indexing operation or member-accessing operation.</value>
+    <value>Non è possibile ottenere il valore dell'espressione Using "{0}" nel dizionario delle variabili specificato. Quando si crea un'istanza di PowerShell da un blocco di script, l'espressione Using non può contenere un'operazione di indicizzazione o di accesso ai membri.</value>
   </data>
   <data name="WDACCompiledScriptBlockLogTitle" xml:space="preserve">
-    <value>Compiled Script Block Dot Source</value>
+    <value>Dot sourcing del blocco di script compilato</value>
   </data>
   <data name="WDACCompiledScriptBlockLogMessage" xml:space="preserve">
-    <value>Script block '{0}' invocation into current scope will be disallowed in Constrained Language mode. Script language mode: {1}, Context language mode: {2}.</value>
+    <value>La chiamata del blocco di script "{0}" nell'ambito corrente non sarà consentita in modalità Linguaggio con restrizioni. Modalità linguaggio script: {1}, modalità linguaggio contesto: {2}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/DiscoveryExceptions.it.resx
+++ b/src/System.Management.Automation/resources/it/DiscoveryExceptions.it.resx
@@ -186,7 +186,7 @@ L'istruzione #requires deve essere in uno dei formati seguenti:
     <value>Non è possibile eseguire lo script '{0}' perché mancano gli snap-in seguenti, specificati dalle istruzioni '#requires' dello script: {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell snap-in when running in PowerShell.</value>
+    <value>In un'istruzione #requires è stato specificato solo un ID shell. Le istruzioni #Requires devono specificare uno snap-in di PowerShell obbligatorio durante l'esecuzione in PowerShell.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
     <value>Non è possibile eseguire lo script '{0}' perché contiene un'istruzione "#requires" per l'esecuzione come amministratore. La sessione di PowerShell corrente non è in esecuzione come amministratore. Avvia PowerShell usando l'opzione Esegui come amministratore, quindi prova a eseguire di nuovo lo script.</value>

--- a/src/System.Management.Automation/resources/it/EtwLoggingStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/EtwLoggingStrings.it.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>Il comando {0} è {1}.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>Stato del motore modificato da {0} a {1}.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>ID errore completo = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>Messaggio di errore = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>Azione consigliata = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>Criteri di esecuzione</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>Comando processo = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>ID processo = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>ID istanza processo = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>Posizione processo = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>Nome processo = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>Stato del processo = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        Nome comando = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        Percorso comando = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        Tipo di comando = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        Versione motore = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        ID host = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        Nome host = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        Applicazione host = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        Versione host = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        ID pipeline = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        ID spazio di esecuzione = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        Nome script = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        Numero sequenza = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        Gravità = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        ID shell = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        Ora = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        Utente = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        Utente connesso = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>Processo NULL</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>Nome provider</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>Il provider {0} ha cambiato stato in {1}.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>L'esecuzione di script è {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>Variabile {0} modificata da {1} a {2}.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>La variabile {0} è stata modificata in {1}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/FileSystemProviderStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/FileSystemProviderStrings.it.resx
@@ -118,240 +118,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvokeItemAction" xml:space="preserve">
-    <value>Invoke Item</value>
+    <value>Richiama elemento</value>
   </data>
   <data name="InvokeItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Elemento: {0}</value>
   </data>
   <data name="RemoveItemActionFile" xml:space="preserve">
-    <value>Remove File</value>
+    <value>Rimuovi file</value>
   </data>
   <data name="RemoveItemActionDirectory" xml:space="preserve">
-    <value>Remove Directory</value>
+    <value>Rimuovere la directory</value>
   </data>
   <data name="CopyItemActionFile" xml:space="preserve">
-    <value>Copy File</value>
+    <value>Copia file</value>
   </data>
   <data name="CopyItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Elemento: {0} Destinazione: {1}</value>
   </data>
   <data name="CopyItemActionDirectory" xml:space="preserve">
-    <value>Copy Directory</value>
+    <value>Copia directory</value>
   </data>
   <data name="RenameItemActionFile" xml:space="preserve">
-    <value>Rename File</value>
+    <value>Rinomina file</value>
   </data>
   <data name="RenameItemActionDirectory" xml:space="preserve">
-    <value>Rename Directory</value>
+    <value>Rinomina directory</value>
   </data>
   <data name="RenameItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Elemento: {0} Destinazione: {1}</value>
   </data>
   <data name="MoveItemActionFile" xml:space="preserve">
-    <value>Move File</value>
+    <value>Sposta file</value>
   </data>
   <data name="MoveItemActionDirectory" xml:space="preserve">
-    <value>Move Directory</value>
+    <value>Sposta directory</value>
   </data>
   <data name="MoveItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Elemento: {0} Destinazione: {1}</value>
   </data>
   <data name="SetPropertyActionFile" xml:space="preserve">
-    <value>Set Property File</value>
+    <value>Imposta file di proprietà</value>
   </data>
   <data name="SetPropertyActionDirectory" xml:space="preserve">
-    <value>Set Property Directory</value>
+    <value>Imposta directory delle proprietà</value>
   </data>
   <data name="SetPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1} Value: {2}</value>
+    <value>Elemento: {0} Proprietà: {1} Valore: {2}</value>
   </data>
   <data name="ClearPropertyActionFile" xml:space="preserve">
-    <value>Clear Property File</value>
+    <value>Cancella file delle proprietà</value>
   </data>
   <data name="ClearPropertyActionDirectory" xml:space="preserve">
-    <value>Clear Property Directory</value>
+    <value>Cancella directory delle proprietà</value>
   </data>
   <data name="ClearPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1}</value>
+    <value>Elemento: {0} Proprietà: {1}</value>
   </data>
   <data name="NewItemActionFile" xml:space="preserve">
-    <value>Create File</value>
+    <value>Crea file</value>
   </data>
   <data name="NewItemActionDirectory" xml:space="preserve">
-    <value>Create Directory</value>
+    <value>Crea directory</value>
   </data>
   <data name="NewItemActionTemplate" xml:space="preserve">
-    <value>Destination: {0}</value>
+    <value>Destinazione: {0}</value>
   </data>
   <data name="ClearContentActionFile" xml:space="preserve">
-    <value>Clear Content</value>
+    <value>Cancella contenuto</value>
   </data>
   <data name="ClearContentesourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Elemento: {0}</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>Could not find item {0}.</value>
+    <value>Non è possibile trovare l'elemento {0}.</value>
   </data>
   <data name="CannotRemoveItem" xml:space="preserve">
-    <value>Cannot remove item {0}: {1}</value>
+    <value>Non è possibile rimuovere {0}elemento : {1}</value>
   </data>
   <data name="CannotRestoreAttributes" xml:space="preserve">
-    <value>Cannot restore attributes on item {0}: {1}</value>
+    <value>Non è possibile ripristinare gli attributi dell'elemento {0}: {1}</value>
   </data>
   <data name="ItemDoesNotExist" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist.</value>
+    <value>Un oggetto nel percorso specificato {0} non esiste.</value>
   </data>
   <data name="DirectoryNotEmpty" xml:space="preserve">
-    <value>Directory {0} cannot be removed because it is not empty.</value>
+    <value>Non è possibile rimuovere la directory {0} perché non è vuota.</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>Il tipo non è un tipo noto per il file system. È possibile specificare solo "file","directory" o "symboliclink".</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
-    <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>
+    <value>Non è possibile elaborare il percorso perché il percorso specificato fa riferimento a un elemento esterno a basePath.</value>
   </data>
   <data name="DriveRootError" xml:space="preserve">
-    <value>The specified drive root "{0}" either does not exist, or it is not a folder.</value>
+    <value>La radice dell'unità specificata "{0}" non esiste oppure non è una cartella.</value>
   </data>
   <data name="DirectoryExist" xml:space="preserve">
-    <value>An item with the specified name {0} already exists.</value>
+    <value>Esiste già un elemento con il nome specificato {0}.</value>
   </data>
   <data name="DelimiterError" xml:space="preserve">
-    <value>A delimiter cannot be specified when reading the stream one byte at a time.</value>
+    <value>Non è possibile specificare un delimitatore durante la lettura del flusso di un byte alla volta.</value>
   </data>
   <data name="CopyError" xml:space="preserve">
-    <value>Cannot overwrite the item {0} with itself.</value>
+    <value>Non è possibile sovrascrivere l'elemento {0} con se stesso.</value>
   </data>
   <data name="RenameError" xml:space="preserve">
-    <value>Cannot rename the specified target, because it represents a path or device name.</value>
+    <value>Non è possibile rinominare la destinazione specificata perché rappresenta un percorso o un nome di dispositivo.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property {0} does not exist or was not found.</value>
+    <value>La proprietà {0} non esiste o non è stata trovata.</value>
   </data>
   <data name="PermissionError" xml:space="preserve">
-    <value>You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.</value>
+    <value>Non si dispone di diritti di accesso sufficienti per eseguire questa operazione oppure l'elemento è nascosto, di sistema o di sola lettura.</value>
   </data>
   <data name="AttributesNotSupported" xml:space="preserve">
-    <value>The attribute cannot be set because attributes are not supported. Only the following attributes can be set: Archive, Hidden, Normal, ReadOnly, or System.</value>
+    <value>Non è possibile impostare l'attributo perché gli attributi non sono supportati. È possibile impostare solo i seguenti attributi: Archive, Hidden, Normal, ReadOnly, o System.</value>
   </data>
   <data name="CannotClearProperty" xml:space="preserve">
-    <value>The property cannot be cleared because the property is not supported. Only the Attributes property can be cleared.</value>
+    <value>Non è possibile cancellare la proprietà perché non è supportata. È possibile cancellare solo la proprietà Attributes.</value>
   </data>
   <data name="TargetCannotContainDeviceName" xml:space="preserve">
-    <value>Cannot process path '{0}' because the target represents a reserved device name.</value>
+    <value>Non è possibile elaborare il percorso ''{0}'' perché la destinazione rappresenta un nome di dispositivo riservato.</value>
   </data>
   <data name="EncodingNotUsed" xml:space="preserve">
-    <value>Encoding not used when '-AsByteStream' specified.</value>
+    <value>Codifica non utilizzata quando è specificato ''-AsByteStream''.</value>
   </data>
   <data name="ByteEncodingError" xml:space="preserve">
-    <value>Cannot proceed with byte encoding. When using byte encoding the content must be of type byte.</value>
+    <value>Non è possibile procedere con la codifica byte. Quando si utilizza la codifica byte, il contenuto deve essere di tipo byte.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>Cannot process the file because the file {0} was not found.</value>
+    <value>Non è possibile elaborare il file perché il file {0} non è stato trovato.</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
     <value>    Directory: </value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
-    <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>
+    <value>Non è possibile rilevare la codifica del file. La codifica specificata {0} non è supportata quando il contenuto viene letto in direzione inversa.</value>
   </data>
   <data name="AlternateDataStreamNotFound" xml:space="preserve">
-    <value>Could not open the alternate data stream '{0}' of the file '{1}'.</value>
+    <value>Non è possibile aprire il flusso di dati alternativo ''{0}'' del file ''{1}''.</value>
   </data>
   <data name="StreamAction" xml:space="preserve">
-    <value>Stream '{0}' of file '{1}'.</value>
+    <value>Flusso ''{0}'' del file ''{1}''.</value>
   </data>
   <data name="RawAndWaitCannotCoexist" xml:space="preserve">
-    <value>The Raw and Wait parameters cannot be specified in the same command.</value>
+    <value>Non è possibile specificare i parametri Raw e Wait nello stesso comando.</value>
   </data>
   <data name="InvalidDriveName" xml:space="preserve">
-    <value>To use the Persist switch parameter, the drive name must be supported by the operating system (for example, drive letters A-Z).</value>
+    <value>Per utilizzare il parametro di commutazione Persist, il nome dell'unità deve essere supportato dal sistema operativo (ad esempio, lettere di unità A-Z).</value>
   </data>
   <data name="PersistNotSupported" xml:space="preserve">
-    <value>When you use the Persist parameter, the root must be a file system location on a remote computer.</value>
+    <value>Quando si utilizza il parametro Persist, la radice deve essere un percorso del file system in un computer remoto.</value>
   </data>
   <data name="NoFirstLastWaitForRaw" xml:space="preserve">
-    <value>The '{0}' and '{1}' parameters cannot be specified in the same command.</value>
+    <value>Non è possibile specificare i parametri ''{0}'' e ''{1}'' nello stesso comando.</value>
   </data>
   <data name="ItemNotDirectory" xml:space="preserve">
-    <value>A directory is required for the operation. The item '{0}' is not a directory.</value>
+    <value>Per l'operazione è necessaria una directory. L'elemento ''{0}'' non è una directory.</value>
   </data>
   <data name="NewItemActionJunction" xml:space="preserve">
-    <value>Create Junction</value>
+    <value>Crea giunzione</value>
   </data>
   <data name="NewItemActionSymbolicLink" xml:space="preserve">
-    <value>Create Symbolic Link</value>
+    <value>Crea collegamento simbolico</value>
   </data>
   <data name="ElevationRequired" xml:space="preserve">
-    <value>Administrator privilege required for this operation.</value>
+    <value>Per questa operazione sono necessari i privilegi di Amministratore.</value>
   </data>
   <data name="NewItemActionHardLink" xml:space="preserve">
-    <value>Create Hard Link</value>
+    <value>Crea collegamento reale</value>
   </data>
   <data name="ItemNotFile" xml:space="preserve">
-    <value>A file is required for the operation. The item '{0}' is not a file.</value>
+    <value>Per l'operazione è necessario un file. L'elemento ''{0}'' non è un file.</value>
   </data>
   <data name="HardLinkNotSupported" xml:space="preserve">
-    <value>Hard links are not supported for the specified path.</value>
+    <value>I collegamenti reali non sono supportati per il percorso specificato.</value>
   </data>
   <data name="SymbolicLinkNotSupported" xml:space="preserve">
-    <value>Symbolic links are not supported for the specified path.</value>
+    <value>I collegamenti simbolici non sono supportati per il percorso specificato.</value>
   </data>
   <data name="CopyItemRemotelyProgressActivity" xml:space="preserve">
     <value>Copia di {0} in {1}</value>
   </data>
   <data name="CopyItemRemoteDestinationIsFile" xml:space="preserve">
-    <value>Destination path {0} is a file that already exists on the target destination.</value>
+    <value>Il percorso di destinazione {0} è un file già esistente nella destinazione.</value>
   </data>
   <data name="CopyItemRemotelyFailed" xml:space="preserve">
-    <value>Failed to copy file {0} to remote target destination.</value>
+    <value>Non è possibile copiare il file {0} nella destinazione remota.</value>
   </data>
   <data name="CopyItemRemotelyStatusDescription" xml:space="preserve">
     <value>Da {0} a {1}</value>
   </data>
   <data name="CopyItemRemotelyDestinationIsFile" xml:space="preserve">
-    <value>Cannot copy a directory '{0}' to file '{0}'</value>
+    <value>Non è possibile copiare una directory ''{0}'' nel file ''{0}''</value>
   </data>
   <data name="CopyItemRemotelyFailedToGetDirectoryChildItems" xml:space="preserve">
-    <value>Failed to get directory {0} child items.</value>
+    <value>Non è possibile ottenere gli elementi figlio della directory {0}.</value>
   </data>
   <data name="CopyItemRemotelyFailedToReadFile" xml:space="preserve">
-    <value>Failed to read remote file '{0}'.</value>
+    <value>Non è possibile leggere il file remoto ''{0}''.</value>
   </data>
   <data name="CopyItemRemotelyFailedToValidateIfDestinationIsFile" xml:space="preserve">
-    <value>Cannot validate if remote destination {0} is a file.</value>
+    <value>Non è possibile verificare se la destinazione remota {0} è un file.</value>
   </data>
   <data name="CopyItemRemotelyFailedToCreateDirectory" xml:space="preserve">
-    <value>Failed to create directory '{0}' on remote destination.</value>
+    <value>Non è possibile creare la directory ''{0}'' nella destinazione remota.</value>
   </data>
   <data name="DriveMaxSizeError" xml:space="preserve">
-    <value>Maximum size for drive has been exceeded: {0}.</value>
+    <value>È stata superata la dimensione massima per l'unità: {0}.</value>
   </data>
   <data name="SymlinkItemExists" xml:space="preserve">
-    <value>Cannot create link because the path already exists: {0}.</value>
+    <value>Non è possibile creare il collegamento perché il percorso esiste già: {0}.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Skip already-visited directory {0}.</value>
+    <value>Ignora directory già visitata {0}.</value>
   </data>
   <data name="TargetCannotBeSubdirectoryOfSource" xml:space="preserve">
-    <value>Destination path cannot be a subdirectory of the source or the source itself: {0}.</value>
+    <value>Il percorso di destinazione non può essere una sottodirectory dell'origine o l'origine stessa: {0}.</value>
   </data>
   <data name="NewItemTargetIsSameAsLink" xml:space="preserve">
-    <value>The target and path cannot be the same.</value>
+    <value>La destinazione e il percorso non possono essere uguali.</value>
   </data>
   <data name="CopyingLocalFileActivity" xml:space="preserve">
-    <value>Copied {0} of {1} files</value>
+    <value>Copiati {0} di {1} file</value>
   </data>
   <data name="CopyingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} di {1} ({2:0.0} MB/s)</value>
   </data>
   <data name="RemovingLocalFileActivity" xml:space="preserve">
-    <value>Removed {0} of {1} files</value>
+    <value>Rimozione completata di {0} di {1} file</value>
   </data>
   <data name="RemovingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} di {1} ({2:0.0} MB/s)</value>
   </data>
   <data name="JunctionAbsolutePath" xml:space="preserve">
-    <value>Creating a junction requires an absolute path for the target.</value>
+    <value>La creazione di una giunzione richiede un percorso assoluto per la destinazione.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/FormatAndOut_out_xxx.it.resx
+++ b/src/System.Management.Automation/resources/it/FormatAndOut_out_xxx.it.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConsoleLineOutput_PagingPrompt" xml:space="preserve">
-    <value>&lt;SPACE&gt; next page; &lt;CR&gt; next line; Q quit</value>
+    <value>&lt;SPACE&gt; pagina successiva; &lt;CR&gt; riga successiva; Q esci</value>
   </data>
   <data name="OutLineOutput_NullLineOutputParameter" xml:space="preserve">
-    <value>The value of LineOutput should not be null.</value>
+    <value>Il valore di LineOutput non deve essere Null.</value>
   </data>
   <data name="OutLineOutput_InvalidLineOutputParameterType" xml:space="preserve">
-    <value>The lineOutput type {0} was not expected; LineOutput expects type {1}.</value>
+    <value>Il tipo lineOutput {0} non era previsto; LineOutput prevede il tipo {1}.</value>
   </data>
   <data name="OutLineOutput_OutOfSequencePacket" xml:space="preserve">
-    <value>The object of type "{0}" is not valid or not in the correct sequence. This is likely caused by a user-specified "{1}" command which is conflicting with the default formatting.</value>
+    <value>L'oggetto di tipo "{0}" non è valido o non è nella sequenza corretta. È probabile che sia causato da un comando "{1}" specificato dall'utente, in conflitto con la formattazione predefinita.</value>
   </data>
   <data name="OutFile_FileOpenFailure" xml:space="preserve">
-    <value>Cannot open file "{0}".</value>
+    <value>Impossibile aprire il file "{0}".</value>
   </data>
   <data name="OutFile_Action" xml:space="preserve">
-    <value>Output to File</value>
+    <value>Output su file</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/HelpDisplayStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/HelpDisplayStrings.it.resx
@@ -121,7 +121,7 @@
     <value>NOME</value>
   </data>
   <data name="Synopsis" xml:space="preserve">
-    <value>SYNOPSIS</value>
+    <value>RIEPILOGO</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
     <value>DESCRIPTION</value>
@@ -130,106 +130,106 @@
     <value>SYNTAX</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>PARAMETRI</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>INPUT</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>OUTPUT</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>ERRORI IRREVERSIBILI</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>ERRORI NON FATALI</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>NOTE</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>ESEMPI</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>Esempio</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>ESEMPIO</value>
   </data>
   <data name="Output" xml:space="preserve">
     <value>OUTPUT</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>COLLEGAMENTI CORRELATI</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>DESCRIZIONE BREVE</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>Titolo:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>Domanda:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>Risposta</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>Termine:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>Definizione:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>Contenuto:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>NOME DEL PROVIDER</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
+    <value>    Questo cmdlet supporta i parametri comuni: Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
+    OutBuffer, PipelineVariable e OutVariable. Per altre informazioni, vedere
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>Obbligatorio?                    </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>Posizione?                    </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>Tipo: </value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>Tipo oggetto di destinazione:   </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>Valore predefinito                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>Accettare input da pipeline?       </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>Accettare caratteri jolly?  </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(Categoria: </value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>Azione suggerita: </value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>Per ulteriori informazioni, digitare: </value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>Per informazioni tecniche, digitare: </value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>Per visualizzare gli esempi, digitare: </value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>Per visualizzare la Guida, digitare: </value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
@@ -241,52 +241,52 @@
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>Denominato</value>
   </data>
   <data name="Drives" xml:space="preserve">
-    <value>DRIVES</value>
+    <value>UNITÀ</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>FUNZIONALITÀ</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>ATTIVITÀ</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>ATTIVITÀ: </value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>FILTRI</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>PARAMETRI DINAMICI</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>Cmdlet supportati: </value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>ALIAS</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Get-Help non riesce a trovare i file della Guida per questo cmdlet in questo computer. Viene visualizzata solo una parte della Guida.
+    -- Per scaricare e installare i file della Guida per il modulo che include questo cmdlet, usare Update-Help.
+    -- Per visualizzare l'argomento della Guida per questo cmdlet online, digitare "Get-Help {0} -Online" o
+       Passa a {1}.</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>Nessuno</value>
   </data>
   <data name="ParameterAliases" xml:space="preserve">
-    <value>Aliases                      </value>
+    <value>Alias                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>Dinamica?                     </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>Nome del set di parametri           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>Non è possibile recuperare il file HelpInfo XML per le impostazioni cultura dell'interfaccia utente {0}. Verificare che la proprietà HelpInfoUri nel manifesto del modulo sia valida o controllare la connessione di rete, quindi riprovare.</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
@@ -298,176 +298,176 @@
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>Le impostazioni di cultura specificate non sono supportate: {0}. Specificare un'impostazione di cultura dall'elenco seguente: {{{1}}}.</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>Il posticipo dell'errore e il tentativo di usare le impostazioni cultura di fallback verranno visualizzati come errore se nessuna delle impostazioni di fallback è supportata:
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>Non è possibile trovare la directory ModuleBase. Verificare la directory e riprovare.</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>Il percorso {0} non è una directory valida. Verificare che la directory esista e riprovare.</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>Un URI della Guida non può contenere più di 10 reindirizzamenti. Specificare un URI della Guida valido.</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>Aggiornamento della Guida</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>Connessione al contenuto della Guida in corso...</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>Download del contenuto della Guida in corso...</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>Installazione del contenuto della Guida in corso...</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>Individuazione del contenuto della Guida in corso...</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(Tutti)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Non sono stati trovati moduli di PowerShell corrispondenti al modello seguente: {0}. Verificare il modello, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>Non sono stati trovati moduli di PowerShell corrispondenti al valore FullyQualifiedModule specificato {0}. Verificare il valore di FullyQualifiedModule, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>Non è possibile trovare il contenuto della Guida. Verificare che il server sia disponibile e che il percorso del contenuto della Guida sia definito correttamente nel codice XML HelpInfo.</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>Il comando Update-Help non è riuscito perché il modulo specificato non supporta la Guida aggiornabile. Usare Get-Help -Online oppure cercare online la Guida per i comandi di questo modulo.</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>Il parametro seguente non deve essere Null o vuoto: Module.</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>Il parametro seguente non deve essere Null o vuoto: Path.</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Aggiornamento della Guida completato.</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>Errore durante l'estrazione del contenuto della Guida.</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>Non è possibile connettersi al contenuto della Guida. Il server in cui è archiviato il contenuto della Guida potrebbe non essere disponibile. Verificare che il server sia disponibile o attendere che il server sia nuovamente online, quindi riprovare.</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>Il contenuto della Guida nel percorso specificato non è valido. Specificare un percorso contenente contenuto valido della Guida.</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>HelpInfo XML non è valido. Specificare un HelpInfo XML valido.</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>Il contenuto della Guida è stato salvato nel percorso seguente: {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>Non è possibile trovare il file XSD del contenuto della Guida in {0}. Verificare che il file XSD esista nel percorso specificato, quindi ripetere il comando.</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
+    <value>Non è possibile aggiornare la Guida per i moduli: 
 '{0}'
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>Salvataggio della Guida</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>Il contenuto della Guida contiene file non validi. Sono supportati solo file .txt e .xml.</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>Non è possibile salvare la Guida per i moduli ''{0}'': {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>Non è possibile salvare la Guida per i moduli ''{0}'' con impostazioni cultura dell'interfaccia utente {{{1}}}: {2}.
+Il contenuto della Guida in inglese-US è disponibile e può essere salvato usando: Save-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>Non è stato possibile aggiornare la Guida per i moduli ''{0}'' con le impostazioni cultura dell'interfaccia utente {{{1}}}: {2}.
+Il contenuto della Guida in inglese-US è disponibile e può essere installato usando: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>Le impostazioni cultura correnti sono ({0}), che non sono associate ad alcuna lingua. Valutare di modificare le impostazioni cultura del sistema oppure installare il contenuto della Guida in inglese-US usando: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
     <value>false</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>Il parametro -Recurse è disponibile solo se viene specificato un percorso di origine.</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>Il percorso {0} non contiene un provider FileSystem. Verificare che il percorso specificato contenga il provider FileSystem, quindi riprovare il comando.</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>Ricerca nella Guida di {0} ...</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Non sono state trovate impostazioni cultura dell'interfaccia utente che corrispondono al modello seguente: {0}. Verificare il modello, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>La Guida non è stata salvata per il modulo {0}, perché il comando Save-Help è stato eseguito nel computer nelle ultime 24 ore.
+Per salvare di nuovo la Guida, aggiungere il parametro Force al comando.</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>La Guida non è stata aggiornata per il modulo {0}, perché il comando Update-Help è stato eseguito nel computer nelle ultime 24 ore.
+Per aggiornare di nuovo la Guida, aggiungere il parametro Force al comando.</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>I file della Guida più recenti sono già installati.</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}. Cultura {2} versione {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>Aggiornamento di {0} completato</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>Il valore della chiave HelpInfoUri nel manifesto del modulo deve essere risolto in un contenitore o in un URL radice in un sito Web in cui sono archiviati i file della Guida. Il valore HelpInfoUri ''{0}'' non viene risolto in un contenitore.</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>Il contenuto della Guida deve essere nello spazio dei nomi {0}.</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Get-Help non riesce a trovare i file della Guida per questo cmdlet in questo computer. Viene visualizzata solo una parte della Guida.
+    -- Per scaricare e installare i file della Guida per il modulo che include questo cmdlet, usare Update-Help.</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>I file più recenti della Guida sono già stati scaricati.</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>{0} salvato</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>HelpInfoURI {0} non inizia con HTTP.</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>L'elemento di livello radice del contenuto della Guida deve essere "helpItems".</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>Salvataggio della Guida per il modulo {0}</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>Aggiornamento della Guida per il modulo {0}</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>Risoluzione dell'URI in corso: "{0}"</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>URI della Guida: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}, versione corrente: {1}, versione disponibile: {2}, UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>PROPRIETÀ</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>METODI</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/InternalCommandStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/InternalCommandStrings.it.resx
@@ -118,76 +118,76 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AmbiguousMethodName" xml:space="preserve">
-    <value>Input name "{0}" is ambiguous. It can be resolved to multiple matched methods. Possible matches include:{1}.</value>
+    <value>Il nome di input "{0}" è ambiguo. Può essere risolto in più metodi corrispondenti. Le possibili corrispondenze includono:{1}.</value>
   </data>
   <data name="AmbiguousPropertyOrMethodName" xml:space="preserve">
-    <value>Input name "{0}" is ambiguous. It can be resolved to multiple matched members. Possible matches include:{1}.</value>
+    <value>Il nome di input "{0}" è ambiguo. Può essere risolto in più membri corrispondenti. Le possibili corrispondenze includono:{1}.</value>
   </data>
   <data name="ForEachObjectKeyAction" xml:space="preserve">
-    <value>Retrieve the value for key '{0}'</value>
+    <value>Recupera il valore per la chiave "{0}"</value>
   </data>
   <data name="ForEachObjectMethodActionWithArguments" xml:space="preserve">
-    <value>Invoke method '{0}' with arguments: {1}</value>
+    <value>Richiama il metodo "{0}" con argomenti: {1}</value>
   </data>
   <data name="ForEachObjectMethodActionWithoutArguments" xml:space="preserve">
-    <value>Invoke method '{0}'</value>
+    <value>Richiama il metodo "{0}"</value>
   </data>
   <data name="ForEachObjectPropertyAction" xml:space="preserve">
-    <value>Retrieve the value for property '{0}'</value>
+    <value>Recupera il valore per la proprietà "{0}"</value>
   </data>
   <data name="ForEachObjectTarget" xml:space="preserve">
     <value>InputObject: {0}</value>
   </data>
   <data name="InputObjectIsNull" xml:space="preserve">
-    <value>Cannot operate on a 'null' input object.</value>
+    <value>Non è possibile operare su un oggetto di input "null".</value>
   </data>
   <data name="MethodNotFound" xml:space="preserve">
-    <value>Input name "{0}" cannot be resolved to a method.</value>
+    <value>Il nome di input "{0}" non può essere risolto in un metodo.</value>
   </data>
   <data name="NoMethodInvocationInRestrictedLanguageMode" xml:space="preserve">
-    <value>Cannot invoke a method in the restricted language mode.</value>
+    <value>Non è possibile richiamare un metodo in modalità linguaggio con restrizioni.</value>
   </data>
   <data name="NoShouldProcessForScriptBlockSet" xml:space="preserve">
-    <value>The -WhatIf and -Confirm parameters are not supported for script blocks.</value>
+    <value>I parametri -WhatIf e -Confirm non sono supportati per i blocchi di script.</value>
   </data>
   <data name="OperationNotAllowedInRestrictedLanguageMode" xml:space="preserve">
-    <value>The '{0}' operation is not allowed in the RestrictedLanguage mode.</value>
+    <value>L'operazione "{0}" non è consentita in modalità RestrictedLanguage.</value>
   </data>
   <data name="OperatorNotSpecified" xml:space="preserve">
-    <value>An operator is required to compare the two specified values. Include a valid operator in the command, and then try the command again. For example, Get-Process | Where-Object -Property Name -eq Idle</value>
+    <value>Per confrontare i due valori specificati, è necessario un operatore. Immettere un operatore valido nel comando, quindi riprovare a eseguire il comando. Ad esempio, Get-Process | Where-Object -Property Name -eq Idle</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The input name "{0}" cannot be resolved to a property.</value>
+    <value>Non è possibile risolvere il nome di input "{0}" in una proprietà.</value>
   </data>
   <data name="PropertyOrMethodNotFound" xml:space="preserve">
-    <value>The input name "{0}" cannot be resolved to a member.</value>
+    <value>Non è possibile risolvere il nome di input "{0}" in un membro.</value>
   </data>
   <data name="ValueNotSpecifiedForWhereObject" xml:space="preserve">
-    <value>The specified operator requires both the -Property and -Value parameters. Provide values for both parameters, and then try the command again.</value>
+    <value>L'operatore specificato richiede entrambi i parametri -Property e -Value. Specificare i valori per entrambi i parametri, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="PSTaskStreamWriterWrongThread" xml:space="preserve">
-    <value>This method cannot be run on the current thread. It can only be called on the cmdlet thread.</value>
+    <value>Non è possibile eseguire questo metodo sul thread corrente. Può essere chiamato solo sul thread del cmdlet.</value>
   </data>
   <data name="ParallelUsingVariableCannotBeScriptBlock" xml:space="preserve">
-    <value>A ForEach-Object -Parallel using variable cannot be a script block. Passed-in script block variables are not supported with ForEach-Object -Parallel, and can result in undefined behavior.</value>
+    <value>Una variabile using di ForEach-Object -Parallel non può essere un blocco di script. Le variabili del blocco di script passate non sono supportate con ForEach-Object -Parallel e possono causare un comportamento indefinito.</value>
   </data>
   <data name="ParallelPipedInputObjectCannotBeScriptBlock" xml:space="preserve">
-    <value>A ForEach-Object -Parallel piped input object cannot be a script block. Passed-in script block variables are not supported with ForEach-Object -Parallel, and can result in undefined behavior.</value>
+    <value>Un oggetto di input inviato tramite pipe a ForEach-Object -Parallel non può essere un blocco di script. Le variabili del blocco di script passate non sono supportate con ForEach-Object -Parallel e possono causare un comportamento indefinito.</value>
   </data>
   <data name="ParallelCannotUseTimeoutWithJob" xml:space="preserve">
-    <value>The 'TimeoutSeconds' parameter cannot be used with the 'AsJob' parameter.</value>
+    <value>Non è possibile usare il parametro "TimeoutSeconds" con il parametro "AsJob".</value>
   </data>
   <data name="ParallelCommonParametersNotSupported" xml:space="preserve">
-    <value>The following common parameters are not currently supported in the Parallel parameter set:
+    <value>I seguenti parametri comuni non sono attualmente supportati nel set di parametri Parallel:
 ErrorAction, WarningAction, InformationAction, PipelineVariable</value>
   </data>
   <data name="ParallelPipedInputProcessingError" xml:space="preserve">
-    <value>An unexpected error has occurred while processing ForEach-Object -Parallel input. This may mean that some of the piped input did not get processed. Error: {0}.</value>
+    <value>Si è verificato un errore imprevisto durante l'elaborazione dell'input di ForEach-Object -Parallel. Questo può significare che una parte dell'input inviato tramite pipe non è stata elaborata. Errore: {0}.</value>
   </data>
   <data name="WDACLogTitle" xml:space="preserve">
-    <value>ForEach-Object Cmdlet</value>
+    <value>Cmdlet ForEach-Object</value>
   </data>
   <data name="WDACLogMessage" xml:space="preserve">
-    <value>Method invocation on type '{0}' will not be allowed when run in Constrained Language mode.</value>
+    <value>La chiamata al metodo sul tipo "{0}" non sarà consentita quando viene eseguita in modalità Linguaggio con restrizioni.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/InternalHostUserInterfaceStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/InternalHostUserInterfaceStrings.it.resx
@@ -118,106 +118,106 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteDebugLineStoppedError" xml:space="preserve">
-    <value>WriteDebug stopped because the value of the DebugPreference variable was 'Stop'.</value>
+    <value>WriteDebug arrestato perché il valore della variabile DebugPreference è ''Stop''.</value>
   </data>
   <data name="UnsupportedPreferenceError" xml:space="preserve">
-    <value>The value {0} is not a supported ActionPreference value.</value>
+    <value>Il valore {0} non è un valore ActionPreference supportato.</value>
   </data>
   <data name="PromptEmptyDescriptionsError" xml:space="preserve">
-    <value>The "{0}" parameter must contain at least one value.</value>
+    <value>Il parametro "{0}" deve contenere almeno un valore.</value>
   </data>
   <data name="ShouldContinueYesLabel" xml:space="preserve">
-    <value>&amp;Yes</value>
+    <value>&amp;Sì</value>
   </data>
   <data name="ShouldContinueYesHelp" xml:space="preserve">
-    <value>Continue.</value>
+    <value>Continuare.</value>
   </data>
   <data name="ShouldContinueYesToAllLabel" xml:space="preserve">
-    <value>Yes to &amp;All</value>
+    <value>Sì per t&amp;utti</value>
   </data>
   <data name="ShouldContinueYesToAllHelp" xml:space="preserve">
-    <value>Continue, and do not ask again whether to continue in this session.</value>
+    <value>Continuare senza chiedere nuovamente se continuare in questa sessione.</value>
   </data>
   <data name="ShouldContinueNoLabel" xml:space="preserve">
     <value>&amp;No</value>
   </data>
   <data name="ShouldContinueNoHelp" xml:space="preserve">
-    <value>End the operation with an error.</value>
+    <value>Terminare l'operazione con un errore.</value>
   </data>
   <data name="ShouldContinueNoToAllLabel" xml:space="preserve">
-    <value>No to A&amp;ll</value>
+    <value>N&amp;o per tutti</value>
   </data>
   <data name="ShouldContinueNoToAllHelp" xml:space="preserve">
-    <value>End the operation with an error. Do not request to resume operation for this session.</value>
+    <value>Terminare l'operazione con un errore. Non richiedere di riprendere l'operazione per questa sessione.</value>
   </data>
   <data name="ShouldContinueSuspendLabel" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Sospendi</value>
   </data>
   <data name="ShouldContinueSuspendHelp" xml:space="preserve">
-    <value>Pause the current operation and enter a command prompt. Type "exit" to resume the paused operation.</value>
+    <value>Sospendere l'operazione corrente e immettere un prompt dei comandi. Digitare "exit" per riprendere l'operazione sospesa.</value>
   </data>
   <data name="ShouldContinuePromptMessage" xml:space="preserve">
-    <value>Continue with this operation?</value>
+    <value>Continuare con questa operazione?</value>
   </data>
   <data name="DefaultChoice" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(l'impostazione predefinita è ''{0}'')</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(le opzioni predefinite sono {0})</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>Opzione[{0}]: </value>
   </data>
   <data name="EmptyChoicesError" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>"{0}" deve avere almeno un elemento.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}" deve essere un indice valido in "{1}". "{2}" non è un indice valido.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>Non è possibile elaborare il tasto di scelta rapida perché il punto interrogativo ("?") non può essere usato come tasto di scelta rapida.</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>DETTAGLIATO: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>AVVISO: {0}</value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
     <value>DEBUG: {0}</value>
   </data>
   <data name="HostNotTranscribing" xml:space="preserve">
-    <value>The host is not currently transcribing.</value>
+    <value>L'host non è attualmente in fase di trascrizione.</value>
   </data>
   <data name="CommandStartTime" xml:space="preserve">
-    <value>Command start time: {0}</value>
+    <value>Ora di inizio comando: {0}</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username: {1}
-RunAs User: {2}
-Configuration Name: {3}
-Machine: {4} ({5})
-Host Application: {6}
-Process ID: {7}
+Avvio della trascrizione di PowerShell
+Ora di inizio: {0:yyyyMMddHHmmss}
+Nome utente: {1}
+Utente RunAs: {2}
+Nome configurazione: {3}
+Computer: {4} ({5})
+Applicazione host: {6}
+ID processo: {7}
 {8}
 **********************</value>
   </data>
   <data name="MinimalTranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
+Avvio della trascrizione di PowerShell
+Ora di inizio: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+Fine della trascrizione di PowerShell
+Ora di fine: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InvalidTranscriptFilePath" xml:space="preserve">
-    <value>File path {0} resolves to a directory.</value>
+    <value>Il percorso del file {0} viene risolto in una directory.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/Metadata.it.resx
+++ b/src/System.Management.Automation/resources/it/Metadata.it.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>Non è possibile inizializzare gli attributi per "{0}": "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>Non è possibile convalidare l'argomento perché il tipo "{0}" non è dello stesso tipo ({1}) dei limiti massimo e minimo del parametro. Verificare che l'argomento sia di tipo {1} quindi riprovare.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>Non è possibile convalidare l'argomento "{0}" perché il relativo valore non è maggiore di zero.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>Non è possibile convalidare l'argomento "{0}" perché il relativo valore non è maggiore di o uguale a zero.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>Non è possibile convalidare l'argomento "{0}" perché il relativo valore non è minore di zero.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>Non è possibile convalidare l'argomento "{0}" perché il relativo valore non è minore di o uguale a zero.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>Non è possibile accettare l'intervallo minimo specificato ({0}) perché non è dello stesso tipo dell'intervallo massimo specificato ({1}). Aggiornare l'attributo ValidateRange per il parametro.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>Non è possibile accettare i tipi di parametro MaxRange e MinRange. Entrambi i parametri devono essere oggetti che implementano un'interfaccia IComparable.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>Non è possibile accettare l'intervallo massimo specificato perché è minore dell'intervallo minimo specificato. Aggiornare l'attributo ValidateRange per il parametro.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>L'argomento {0} è maggiore dell'intervallo massimo consentito di {1}. Specificare un argomento minore o uguale a {1}, quindi riprovare.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>L'argomento {0} è inferiore all'intervallo minimo consentito di {1}. Specificare un argomento maggiore o uguale a {1}, quindi riprovare.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>L'argomento "{0}" non corrisponde al criterio "{1}". Specificare un argomento corrispondente a "{1}" e riprovare.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>Non è possibile applicare l'attributo ValidateCount a un parametro non di matrice. Rimuovere l'attributo dal parametro o impostare il parametro come parametro di matrice.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>Il parametro richiede esattamente {0} valori- sono stati specificati {1} valori.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>Il parametro richiede almeno {0} valori e non più di {1} valori: sono stati forniti {2} valori.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>Il numero massimo specificato di argomenti per un parametro è inferiore al numero minimo di argomenti specificato. Aggiornare l'attributo ValidateRange per il parametro.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>La lunghezza massima specificata per l'argomento è inferiore alla lunghezza minima specificata per i caratteri dell'argomento. Aggiornare l'attributo ValidateLength per il parametro.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>Non è possibile applicare l'attributo ValidateLength a un parametro che non è un parametro string o string[]. Impostare il parametro come stringa o parametro string[].</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>La lunghezza in caratteri ({1}) dell'argomento è troppo breve. Specificare un argomento di lunghezza maggiore di o uguale a "{0}", quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>La lunghezza in caratteri ({1}) dell'argomento è troppo lungo. Specificare un argomento di lunghezza minore di o uguale a "{0}", quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>L'argomento "{0}" non appartiene al set "{1}" specificato dall'attributo ValidateSet. Specificare un argomento incluso nel set, quindi riprovare.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>Il generatore di valori validi restituisce un valore Null.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>Errore di "{0}" sulla proprietà "{1}" {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>Non è possibile ottenere o eseguire il comando. È stato superato il numero massimo di set di parametri per questo comando.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>Non è possibile elaborare l'argomento perché il valore dell'argomento non è una stringa. I valori degli argomenti di parametro con ArgumentTransformationAttribute specificato devono essere stringhe.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>Non è possibile convalidare la variabile perché il valore {1} non è un valore valido per la variabile {0}.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>Non è possibile aggiungere l'attributo perché la variabile {0} con valore {1} non sarebbe più valida.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>L'argomento è Null. Specificare un valore valido per l'argomento, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>L'argomento ha un valore Null o un elemento della raccolta di argomenti contiene un valore Null. Specificare una raccolta che non contenga valori Null, quindi riprovare.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>Argomento Null o vuoto. Specificare un argomento non Null o vuoto, quindi riprovare.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>L'argomento è Null, vuoto o un elemento della raccolta di argomenti contiene un valore Null. Specificare una raccolta che non contenga valori Null, quindi riprovare.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>L'argomento è Null, vuoto o è costituito solo da spazi vuoti. Specificare un argomento contenente caratteri non spazi vuoti, quindi riprovare.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Un elemento della raccolta di argomenti è Null, vuoto o è costituito solo da spazi vuoti. Specificare una raccolta che non contenga tali valori, quindi riprovare.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>Un parametro denominato ''{0}'' è stato definito più volte per il comando.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>Non è possibile specificare l'alias del parametro perché un alias con il nome ''{0}'' è già stato definito più volte per il comando.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>Impossibile specificare il parametro ''{0}'' perché è in conflitto con l'alias del parametro con lo stesso nome per il parametro ''{1}''.</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>Lo script di convalida "{1}" per l'argomento con valore "{0}" non ha restituito il risultato True. Determinare il motivo per cui lo script di convalida non è riuscito, quindi riprovare.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>L'argomento "{0}" non contiene una versione di PowerShell valida. Specificare un numero di versione valido, quindi riprovare.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>Non è possibile convalidare l'argomento ''{0}'' perché non è un nome di variabile valido.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>Il tipo di conversione del processo deve derivare da IAstToScriptBlockConverter.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>L'argomento del percorso non è valido. Specificare un argomento di percorso di tipo stringa.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>L'unità argomento percorso {0} non appartiene al set di unità approvate: {1}. Specificare un argomento di percorso con un'unità approvata.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>L'argomento del percorso contiene caratteri non validi.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>L'argomento del percorso non ha un'unità radice.  Specificare un argomento di percorso completo con un'unità radice.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>Il valore dell'argomento per il parametro ''{0}'' non può essere Null o una stringa vuota.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Il membro Enum ''{0}'' non è un valore valido per il parametro ''{1}''. Specificare uno dei membri seguenti e riprovare: {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>Non è possibile elaborare l'input. L'argomento "{0}" non è attendibile.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>Errore di controllo dell'attributo ValidateTrustedData</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>L'argomento del parametro ''{0}'' non è attendibile e non riuscirà il controllo dell'attributo del parametro ValidateTrustedData in modalità linguaggio vincolato.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/MiniShellErrors.it.resx
+++ b/src/System.Management.Automation/resources/it/MiniShellErrors.it.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UpdateNotSupportedForConfigurationCategory" xml:space="preserve">
-    <value>The update is not supported for the runspace configuration category {0}. </value>
+    <value>L'aggiornamento non è supportato per la categoria di configurazione dello spazio di esecuzione {0}. </value>
   </data>
   <data name="UpdateAssemblyErrors" xml:space="preserve">
-    <value>The following errors occurred when updating the assembly list for the runspace: {0}.</value>
+    <value>Si sono verificati gli errori seguenti durante l'aggiornamento della lista assemblaggio per lo spazio di esecuzione: {0}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/Modules.it.resx
+++ b/src/System.Management.Automation/resources/it/Modules.it.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo specificato '{0}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo specificato '{0}' con versione '{1}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Il valore specificato per MaximumVersion '{0}' non è corretto. Se si usa '*', MaximumVersion supporta un solo '*' e deve essere sempre posizionato alla fine di MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo specificato '{0}' con MaximumVersion '{1}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo specificato '{0}' con MinimumVersion '{1}' e MaximumVersion '{2}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>Il valore MinimumVersion '{0}' non deve essere maggiore di MaximumVersion '{1}'.</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>L'assembly '{0}' non è stato caricato perché non è stato trovato un assembly con questo nome. Verificare il nome dell'assembly, quindi riprovare.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Il modulo da elaborare '{0}', elencato nel campo '{1}' del manifesto del modulo '{2}', non è stato elaborato perché nelle directory dei moduli non è stato trovato alcun modulo valido.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Non è stato restituito alcun oggetto personalizzato per il modulo '{0}' perché il parametro -AsCustomObject può essere usato solo con i moduli di script.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Il manifesto del modulo '{0}' non è stato elaborato perché non è un file manifesto del modulo PowerShell valido. Rimuovere gli elementi non consentiti: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>L'elaborazione del file manifesto del modulo '{0}' non ha prodotto un oggetto manifesto valido. Aggiornare il file in modo che contenga un manifesto del modulo PowerShell valido. È possibile creare un manifesto valido usando il cmdlet New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Non è possibile importare il modulo '{0}' perché il relativo manifesto contiene uno o più membri non validi. I membri del manifesto validi sono ({1}). Rimuovere i membri non validi ({2}), quindi riprovare a importare il modulo.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>La tabella hash che descrive un modulo contiene uno o più membri non validi. I membri validi sono ({0}). Rimuovere i membri non validi ({1}), quindi riprovare.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Non è possibile caricare il modulo '{0}' perché il limite di annidamento dei moduli è stato superato. I moduli possono essere annidati solo per {1} livelli. Valutare e modificare l'ordine di caricamento dei moduli per evitare di superare il limite di annidamento, quindi riprovare a eseguire lo script.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Il membro 'ModuleVersion' non è presente nel manifesto del modulo. Questo membro deve esistere e deve avere un numero di versione nel formato 'n.n.n.n'. Aggiungere il membro mancante al file '{0}'.</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Il membro '{0}' non è valido nel file manifesto del modulo '{2}': {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>La versione '{0}' del modulo '{1}' non soddisfa il requisito della versione minima '{2}'. Verificare che il numero di versione sia supportato, quindi provare di nuovo a caricare il modulo.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>La versione di PowerShell installata in questo computer è '{0}'. Il modulo '{1}' richiede una versione minima di PowerShell di '{2}' per l'esecuzione. Verificare che sia installata la versione minima richiesta di PowerShell, quindi riprovare.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Non è possibile usare il membro del manifesto del modulo 'NestedModules' se il membro 'ModuleToProcess' è un modulo binario. Modificare il file manifesto del modulo in '{0}', quindi riprovare.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Il membro '{0}' nel manifesto del modulo non è valido: {1}. Verificare che sia specificato un valore valido per questo campo nel file '{2}'.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Il percorso del manifesto del modulo '{0}' non è valido. Il valore dell'argomento Path deve essere risolto in un unico file con estensione '.psd1'. Modificare il valore dell'argomento Path in modo che punti a un file psd1 valido, quindi riprovare.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>La chiave ModuleVersion nel manifesto del modulo '{0}' specifica la versione del modulo '{1}', che non corrisponde al nome della cartella della versione in '{2}'. Modificare il valore della chiave ModuleVersion in modo che corrisponda al nome della cartella della versione.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La voce NestedModule specificata '{0}' nel manifesto del modulo '{1}' non è valida. Riprovare dopo aver aggiornato la voce con valori validi.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La voce RequiredAssemblies specificata '{0}' nel manifesto del modulo '{1}' non è valida. Riprovare dopo aver aggiornato la voce con valori validi.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La voce FileList specificata '{0}' nel manifesto del modulo '{1}' non è valida. Riprovare dopo aver aggiornato la voce con valori validi.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La voce RequiredModules specificata '{0}' nel manifesto del modulo '{1}' non è valida. Riprovare dopo aver aggiornato la voce con valori validi.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>La voce ModuleList specificata '{0}' nel manifesto del modulo '{1}' non è valida. Riprovare dopo aver aggiornato la voce con valori validi.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Il manifesto del modulo '{0}' è specificato con la chiave CompatiblePSEditions, che è supportata solo in PowerShell versione '5.1' o successiva. Aggiornare il valore della chiave PowerShellVersion a '5.1' o versione successiva e riprovare.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>Il valore specificato '{0}' per CompatiblePSEditions contiene nomi di edizione di PowerShell duplicati. Riprovare dopo aver rimosso i nomi delle edizioni di PowerShell duplicati.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>La versione specificata nella chiave ModuleVersion è uguale al nome della cartella della versione.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>La cartella della versione {0} nel modulo {1} verrà ignorata perché non dispone di un file manifesto del modulo valido.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Il membro 'ModuleName' non esiste nella tabella hash che descrive questo modulo.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>I membri 'ModuleVersion', 'MaximumVersion' e 'RequiredVersion' non esistono nella tabella hash che descrive questo modulo. Uno di questi tre membri deve esistere e deve avere un numero di versione nel formato 'n.n.n.n'.</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Il modulo richiesto '{1}' non è caricato. Caricare il modulo oppure rimuoverlo da 'RequiredModules' nel file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Il modulo obbligatorio '{1}' con GUID '{2}' non è caricato. Caricare il modulo oppure rimuoverlo da 'RequiredModules' nel file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Il modulo obbligatorio '{1}' con versione '{2}' non è caricato. Caricare il modulo oppure rimuoverlo da 'RequiredModules' nel file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Il modulo obbligatorio '{1}' con MaximumVersion '{2}' non è caricato. Caricare il modulo oppure rimuoverlo da 'RequiredModules' nel file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Il modulo richiesto '{1}' con MinimumVersion '{2}' e MaximumVersion '{3}' non è stato caricato. Caricare il modulo oppure rimuoverlo da 'RequiredModules' nel file '{0}'.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Non è possibile trovare il modulo '{0}' con ModuleVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Non è possibile trovare il modulo '{0}' con RequiredVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Non è possibile trovare il modulo '{0}' con MaximumVersion '{1}'.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Non è possibile trovare il modulo '{0}' con ModuleVersion '{1}' e MaximumVersion '{2}'.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Non è possibile trovare il modulo '{0}'.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Nessun modulo è stato rimosso. Verificare che la specifica dei moduli da rimuovere sia corretta e che tali moduli esistano nello spazio di esecuzione.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Non è possibile rimuovere il membro '{0}', importato dal modulo '{1}', per il motivo seguente: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Non è possibile rimuovere il modulo '{0}' perché è di sola lettura. Aggiungere il parametro Force al comando per rimuovere i moduli di sola lettura.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Non è possibile rimuovere il modulo '{0}' perché è contrassegnato come 'constant'. Un modulo non può essere rimosso se è contrassegnato come 'constant'.</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Non è possibile rimuovere il modulo '{0}' perché è richiesto da '{1}'. Aggiungere il parametro Force al comando per rimuovere il modulo.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Il cmdlet Export-ModuleMember può essere chiamato solo dall'interno di un modulo.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>L'estensione '{0}' non è un'estensione del modulo valida. Le estensioni del modulo supportate sono '.dll', '.ps1', '.psm1', '.psd1' e '.cdxml'. Correggere l'estensione, quindi provare ad aggiungere di nuovo il file '{1}'.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Non è possibile eseguire questa operazione su un modulo binario. Può essere eseguita solo su un modulo di script.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Il file '{0}' non è consentito perché non ha l'estensione '.ps1'.</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Sconosciuto</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Tutti i diritti sono riservati.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Rimozione della funzione "{0}" importata.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Rimozione dell'alias "{0}" importato.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Rimozione della variabile "{0}" importata.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Caricamento del modulo dal percorso '{0}'.</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Caricamento di '{0}' dal percorso '{1}'.</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Dot-sourcing del file di script '{0}'.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Importazione della funzione '{0}'.</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Importazione del cmdlet '{0}'.</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Importazione dell'alias '{0}'.</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Importazione della variabile '{0}'.</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Esportazione del cmdlet '{0}'.</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Esportazione della funzione '{0}'.</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Esportazione dell'alias '{0}'.</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Esportazione della variabile '{0}'.</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>I nomi di alcuni comandi importati dal modulo '{0}' includono verbi non approvati che potrebbero renderli meno individuabili. Per trovare i comandi con verbi non approvati, eseguire di nuovo il comando Import-Module con il parametro Verbose. Per un elenco dei verbi approvati, digitare Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Il comando '{0}' nel modulo {1}' è stato importato, ma poiché il nome non include un verbo approvato, potrebbe risultare difficile da trovare. Per un elenco dei verbi approvati, digitare Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Il comando '{0}' nel modulo {2}' è stato importato, ma poiché il nome non include un verbo approvato, potrebbe risultare difficile da trovare. I verbi alternativi suggeriti sono "{1}".</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Alcuni nomi di comandi importati contengono uno o più dei caratteri non consentiti seguenti: # , ( ) {{ }} [ ] &amp; - / \ $ ^; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Il nome del comando '{0}' del modulo '{1}' contiene uno o più dei seguenti caratteri non consentiti: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Creazione del file manifesto del modulo "{0}".</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (Percorso: '{1}')</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>L'architettura del processore corrente è: {0}. Il modulo '{1}' richiede l'architettura seguente: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Il nome dell'host di PowerShell corrente è: '{0}'. Il modulo '{1}' richiede l'host di PowerShell seguente: '{2}'.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>L'host di PowerShell corrente è: '{0}' (versione {1}). Il modulo '{2}' richiede una versione dell'host di PowerShell minima di '{3}' per l'esecuzione.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Manifesto del modulo per il modulo '{0}'</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Generato da: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Data di generazione: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>File del modulo di script o del modulo binario associato a questo manifesto.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Moduli da importare come moduli annidati del modulo specificato in RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>ID usato per identificare in modo univoco il modulo</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Autore di questo modulo</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Società o fornitore di questo modulo</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Informativa sul copyright per questo modulo</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Numero di versione di questo modulo.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Descrizione delle funzionalità fornite da questo modulo</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Versione minima del motore di PowerShell richiesta da questo modulo</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Versione minima del Common Language Runtime (CLR) richiesta da questo modulo. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Moduli che devono essere importati nell'ambiente globale prima di importare questo modulo</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>File di script (.ps1) eseguiti nell'ambiente del chiamante prima dell'importazione di questo modulo.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>File di tipo (.ps1xml) da caricare durante l'importazione di questo modulo</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>File di formato (.ps1xml) da caricare durante l'importazione di questo modulo</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Assembly da caricare prima di importare questo modulo</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Elenco di tutti i file inclusi in questo modulo</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Dati privati da passare al modulo specificato in RootModule/ModuleToProcess. Può anche contenere una tabella hash PSData con i metadati del modulo aggiuntivi usati da PowerShell.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Tag applicati a questo modulo. Sono utili per l'individuazione dei moduli nelle raccolte online.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>URL del sito Web principale di questo progetto.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>URL della licenza di questo modulo.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>URL di un'icona che rappresenta questo modulo.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>ReleaseNotes di questo modulo</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Stringa della versione preliminare di questo modulo</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Flag per indicare se il modulo richiede l'accettazione esplicita da parte dell'utente per l'installazione, l'aggiornamento o il salvataggio</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Moduli dipendenti esterni di questo modulo</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Fine della tabella hash {0}</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>Il valore del parametro PrivateData deve essere una tabella hash per creare il manifesto del modulo con i valori di parametro seguenti: Tags, ProjectUri, LicenseUri, IconUri o ReleaseNotes. Rimuovere i valori dei parametri Tags, ProjectUri, LicenseUri, IconUri o ReleaseNotes oppure eseguire il wrapping del contenuto di PrivateData in una tabella hash.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData deve essere definito come tabella hash, ma questo manifesto del modulo lo definisce come oggetto. Provare a eseguire il wrapping del contenuto di PrivateData in una tabella hash. In questo modo sarà possibile aggiungere le proprietà Tags, ProjectUri, LicenseUri, IconUri e ReleaseNotes al manifesto del modulo in un secondo momento.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Il valore specificato '{0}' non è valido. Riprovare con un valore valido.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Funzioni da esportare da questo modulo. Per ottenere prestazioni ottimali, non usare caratteri jolly e non eliminare la voce. Usare una matrice vuota se non sono presenti funzioni da esportare.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Alias da esportare da questo modulo. Per ottenere prestazioni ottimali, non usare caratteri jolly e non eliminare la voce. Usare una matrice vuota se non sono presenti alias da esportare.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Cmdlet da esportare da questo modulo. Per ottenere prestazioni ottimali, non usare caratteri jolly e non eliminare la voce. Usare una matrice vuota se non sono presenti cmdlet da esportare.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Variabili da esportare da questo modulo</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Risorse DSC da esportare da questo modulo</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>PSEditions supportate</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Architettura del processore (None, X86, Amd64) richiesta da questo modulo</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Elenco di tutti i moduli inclusi in questo modulo</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Versione minima di Microsoft .NET Framework richiesta da questo modulo. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Nome dell'host di PowerShell richiesto da questo modulo</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Versione minima dell'host di PowerShell richiesta da questo modulo</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>URI HelpInfo di questo modulo</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Poiché il modulo {0} fornisce PSDrive nella sessione corrente di PowerShell, non è stato rimosso alcun modulo. Modificare il provider PSDrive corrente, quindi riprovare a rimuovere i moduli.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Il cmdlet '{0}' non è stato importato perché nell'ambito corrente è presente un membro con lo stesso nome.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>L'alias '{0}' non è stato importato perché nell'ambito corrente è presente un membro con lo stesso nome.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>La funzione '{0}' non è stata importata perché nell'ambito corrente è presente un membro con lo stesso nome.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>La variabile '{0}' non è stata importata perché nell'ambito corrente è presente un membro con lo stesso nome.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>I caratteri jolly non sono consentiti nei membri 'ModuleToProcess', 'RootModule' o 'NestedModules' nel manifesto del modulo '{0}'.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Il modulo '{0}' è un modulo principale per PowerShell. Aggiungere il parametro Force al comando per rimuovere i moduli principali.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Il manifesto del modulo non può contenere entrambi i membri 'ModuleToProcess' e 'RootModule'. Modificare il file manifesto del modulo per rimuoverne uno in '{0}', quindi riprovare.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Il membro del manifesto del modulo 'ModuleToProcess' è deprecato. Usare invece il membro 'RootModule'.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Prefisso predefinito per i comandi esportati da questo modulo. Eseguire l'override del prefisso predefinito con Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>I parametri 'Global' e 'Scope' non possono essere specificati insieme. Rimuovere uno di questi parametri, quindi riprovare a eseguire il comando.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Il modulo richiesto '{0}' non è caricato. Il modulo '{0}' ha un elemento requiredModule '{1}' nel manifesto del modulo '{2}' che punta a una dipendenza ciclica.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo richiesto '{0}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Alcuni comandi del modulo {0} non possono essere importati tramite una CimSession. Per ottenere tutti i comandi, verificare che nel server remoto sia abilitata la gestione remota di PowerShell, quindi provare ad aggiungere il parametro PSSession a un cmdlet Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Il modulo {0} viene caricato in Windows PowerShell usando una sessione di comunicazione remota {1}. Notare che tutti gli input e gli output dei comandi di questo modulo saranno oggetti deserializzati. Se si vuole caricare questo modulo in PowerShell, usare la sintassi 'Import-Module -SkipEditionCheck'.</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>È stata rilevata la versione di Windows PowerShell {0}. Per caricare moduli usando la funzionalità di compatibilità di Windows PowerShell è richiesto Windows PowerShell 5.1. Installare Windows Management Framework (WMF) 5.1 da https://aka.ms/WMF5Download per abilitare questa funzionalità.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Il caricamento del modulo '{0}' tramite la funzionalità di compatibilità di Windows PowerShell è bloccato da un'impostazione 'WindowsPowerShellCompatibilityModuleDenyList' nel file di configurazione di PowerShell.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Non è possibile importare il modulo {0} tramite CimSession. Provare a usare il parametro PSSession del cmdlet Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>Il valore dell'architettura del processore di {0} non è supportato. Eseguire di nuovo il comando New-ModuleManifest, specificando uno dei valori di enumerazione supportati seguenti per l'architettura del processore: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>L'esecuzione del cmdlet Get-Module su un computer remoto consente di elencare solo i moduli disponibili. Aggiungere il parametro ListAvailable al comando, quindi riprovare.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Il modulo '{0}' non è stato importato perché lo snap-in '{0}' era già stato importato.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>I caratteri jolly non sono consentiti nel membro 'RequiredAssemblies' del manifesto del modulo '{0}'.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>Il valore della chiave {0} in {1} è {2} e il modulo contiene moduli annidati. Quando un file CDXML è il modulo radice, il comando Import-Module ha esito negativo perché i comandi nei moduli annidati non possono essere esportati. Spostare il file CDXML nella chiave NestedModules e riprovare a eseguire il comando.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Errore del comando remoto: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Non è possibile generare proxy per il modulo remoto '{0}'. {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Non è possibile elaborare il modulo remoto {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Non è possibile ricevere i dati del modulo dalla CimSession remota. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Il modulo richiesto '{0}' con GUID '{1}' e versione '{2}' non è stato caricato perché nelle directory dei moduli non è stato trovato alcun file di modulo valido.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Non è stato trovato alcun provider CIM per l'individuazione dei moduli nel server CIM. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>No è possibile verificare la versione di Microsoft .NET Framework {0} perché non è inclusa nell'elenco delle versioni consentite.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Analisi di {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Preparazione dei moduli per il primo utilizzo.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Ricerca dei moduli disponibili in corso</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Ricerca nella condivisione UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>L'esecuzione del cmdlet Get-Module su un computer remoto può essere eseguita solo per i nomi di modulo che non includono un percorso. Il parametro Name contiene l'elemento '{0}', che viene risolto in un percorso. Aggiornare il parametro Name in modo che non contenga elementi di percorso, quindi riprovare.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>L'esecuzione del cmdlet Get-Module senza il parametro ListAvailable non è supportata per i nomi di modulo che includono un percorso. Il parametro Name contiene l'elemento '{0}', che viene risolto in un percorso. Aggiornare il parametro Name in modo che non contenga elementi di percorso, quindi riprovare.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Il modulo specificato '{0}' non è stato trovato. Aggiornare il parametro Name in modo che punti a un percorso valido, quindi riprovare. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Popolamento della proprietà RepositorySourceLocation per il modulo {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Il modulo da elaborare '{0}', elencato nel campo '{1}' del manifesto del modulo '{2}', non è stato elaborato. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Questo prerequisito è valido solo per l'edizione Desktop di PowerShell.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Il modulo '{0}' non supporta l'edizione corrente di PowerShell '{1}'. Le edizioni supportate sono '{2}'. Usare 'Import-Module -SkipEditionCheck' per ignorare il controllo di compatibilità di questo modulo.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Il modulo '{0}' supporta l'edizione di PowerShell '{1}' e non può essere caricato in modo implicito usando la funzionalità di compatibilità con Windows perché è disabilitata nel file delle impostazioni. Usare 'Import-Module -UseWindowsPowerShell' per caricare questo modulo con Windows PowerShell oppure 'Import-Module -SkipEditionCheck' per provare a caricare il modulo con PowerShell corrente.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Per una funzionalità sperimentale dichiarata nel manifesto del modulo è necessario specificare un valore stringa non vuoto.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Sono stati trovati uno o più nomi di funzionalità sperimentali non validi: {0}. Il nome di una funzionalità sperimentale del modulo deve seguire questa convenzione: 'ModuleName.FeatureName'.</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Il parametro opzionale -SkipEditionCheck non può essere usato senza il parametro opzionale -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>L'importazione di file *.ps1 come moduli non è consentita in modalità ConstrainedLanguage.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Si è verificato un errore durante il caricamento del modulo di script {0} perché ha una modalità di linguaggio diversa rispetto al manifesto del modulo. La modalità di linguaggio del manifesto è {1} e la modalità di linguaggio del modulo è {2}. Assicurarsi che tutti i file del modulo siano firmati o facciano comunque parte della configurazione dell'elenco di elementi consentiti dell'applicazione.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Questo modulo usa l'operatore dot-source per esportare funzioni utilizzando caratteri jolly e questo non è consentito quando nel sistema è applicata la verifica delle applicazioni.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Non è possibile esportare membri del modulo da un modulo con una modalità linguaggio diversa da quella della sessione in esecuzione.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Non è possibile creare un nuovo modulo mentre la sessione è in modalità ConstrainedLanguage.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Non è possibile trovare il modulo predefinito '{0}' compatibile con l'edizione 'Core'. Assicurarsi che i moduli predefiniti di PowerShell siano disponibili. In genere sono inclusi nel pacchetto PowerShell nel percorso del modulo $PSHOME e sono necessari per il corretto funzionamento di PowerShell.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Cmdlet Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>L'esportazione dei membri del modulo avrà esito negativo in modalità linguaggio vincolato perché il modulo '{0}', ha una modalità di linguaggio '{1}' diversa rispetto a quella della sessione corrente '{2}'.</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Esportazione implicita di funzioni del modulo</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>L'esportazione implicita delle funzioni per il modulo '{0}' verrà negata, perché è attendibile (viene eseguito in modalità linguaggio completo), ma la sessione non è attendibile (viene eseguita in modalità linguaggio vincolato). È consigliabile esportare sempre le funzioni del modulo singolarmente usando il nome completo.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Importazione del file di script come modulo</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>L'importazione del file di script '{0}' come modulo non sarà consentita in modalità ConstrainedLanguage.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Il modulo contiene l'operatore dot-source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>L'importazione del modulo '{0}' avrà esito negativo in modalità linguaggio vincolato perché esporta le funzioni usando caratteri jolly e usando anche l'operatore dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"Funzioni di esportazione del modulo</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Il modulo '{0}' esporta funzioni usando caratteri jolly nel nome. I nomi di funzione dei moduli annidati verranno rimossi quando si esegue il codice in modalità linguaggio vincolato.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"Cmdlet New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>A un nuovo modulo di una sessione di linguaggio vincolato non attendibile verrà impedito di fornire il blocco di script FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"Modalità di linguaggio del modulo non corrispondenti</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>È in corso il caricamento di un modulo dipendente con una modalità di linguaggio diversa da quella del modulo padre. Questa operazione non sarà consentita in modalità linguaggio vincolato.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/RunspaceStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/RunspaceStrings.it.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>Lo stato dello spazio di esecuzione non è valido per questa operazione.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>Non è possibile aprire lo spazio di esecuzione perché lo stato dello spazio di esecuzione non è BeforeOpen. Lo stato corrente dello spazio di esecuzione è ''{0}''.</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Non è possibile eseguire l'operazione perché lo spazio di esecuzione non è nello stato Opened. Lo stato corrente dello spazio di esecuzione è ''{0}''.</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Non è possibile richiamare la pipeline perché lo spazio di esecuzione non è nello stato Opened. Lo stato corrente dello spazio di esecuzione è ''{0}''.</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>Lo stato della pipeline non è valido per questa operazione.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>Non è possibile richiamare la pipeline perché è già stata richiamata.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>Il valore valido per il parametro è PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>La pipeline non contiene un comando.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>La pipeline non è stata eseguita perché una pipeline è già in esecuzione. Le pipeline non possono essere eseguite contemporaneamente.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>Una pipeline annidata non può essere richiamata in modo asincrono. Usare il metodo Invoke.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>È consigliabile eseguire solo una pipeline annidata all'interno di una pipeline in esecuzione.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>Non è possibile chiudere lo spazio di esecuzione mentre è in corso una chiamata al metodo SessionStateProxy.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>Non è possibile richiamare la pipeline mentre è in corso una chiamata al metodo SessionStateProxy.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>È in corso una chiamata al metodo SessionStateProxy. Le chiamate simultanee al metodo SessionStateProxy non sono consentite.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Una pipeline è già in esecuzione. Le chiamate simultanee al metodo SessionStateProxy non sono consentite.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Impossibile modificare questa proprietà dopo l'apertura dello spazio di esecuzione.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Si sono verificati uno o più errori durante l'elaborazione del modulo ''{0}'' specificato nell'oggetto InitialSessionState usato per creare questo spazio di esecuzione. Per un elenco completo degli errori, vedere la proprietà ErrorRecords. Il primo errore è stato: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>Le opzioni del thread possono essere modificate solo se lo stato dell'apartment è multithreading apartment (MTA), le opzioni correnti sono UseNewThread o UseCurrentThread e il nuovo valore è ReuseThread.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>{0} non può essere false quando la modalità lingua è {1} o {2}.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>Non è possibile disconnettere uno spazio di esecuzione solo locale.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>L'operazione di connessione non è supportata negli spazi di esecuzione locali.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>La sessione è occupata. Si verrà connessi alla sessione non appena sarà disponibile. Per annullare il comando Enter-PSSession, premere CTRL+C.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>Impossibile completare il comando. La chiamata di script non è supportata in questa configurazione di sessione. Questo problema può verificarsi se la configurazione della sessione è in modalità senza linguaggio.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>Non puoi usare le operazioni Disconnect e Connect negli spazi di esecuzione locali.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>Non è possibile connettere la pipeline perché lo spazio di esecuzione non è nello stato Opened.  Lo stato corrente dello spazio di esecuzione è ''{0}''.</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>Non è possibile costruire un oggetto RemoteRunspace. L'oggetto RunspacePool specificato non è valido.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>Nessun comando disconnesso associato a questo spazio di esecuzione.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>L'operazione di disconnessione non è supportata nel computer remoto. Per supportare la disconnessione, il computer remoto deve eseguire Windows PowerShell 3.0 o una versione successiva di Windows PowerShell e usare il trasporto WSMan.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>Non è possibile connettere psSession perché la sessione non si trova nello stato Disconnesso o non è disponibile per la connessione.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>Il valore per il parametro non può essere PipelineResultTypes.None o PipelineResultTypes.Output.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>I valori validi per il parametro sono PipelineResultTypes.Output o PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>Il reindirizzamento del flusso di debug non è supportato nel computer remoto di destinazione.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>Il dettagliato del flusso di debug non è supportato nel computer remoto di destinazione.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>Il reindirizzamento del flusso di avviso non è supportato nel computer remoto di destinazione.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>Il reindirizzamento del flusso di informazioni non è supportato nel computer remoto di destinazione.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>È stata immessa una sessione occupata durante l'esecuzione di un comando o uno script.  Poiché l'output viene instradato al processo "{0}", l'output non verrà visualizzato nella console.  È possibile attendere il completamento del comando in esecuzione oppure annullare il comando e ottenere un prompt di input premendo CTRL+C.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>È stata immessa una sessione occupata durante l'esecuzione di un comando o di uno script e l'output verrà visualizzato nella console.  È possibile attendere il completamento o l'annullamento del comando in esecuzione e ottenere un prompt di input premendo CTRL+C.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>È stata immessa una sessione attualmente arrestata in corrispondenza di un punto di interruzione di debug all'interno di un comando o uno script in esecuzione.  Usare il debugger della riga di comando di PowerShell per continuare il debug.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace deve essere un LocalRunspace</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>La proprietà statica PrimaryRunspace può essere impostata una sola volta ed è già stata impostata.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/SessionStateProviderBaseStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/SessionStateProviderBaseStrings.it.resx
@@ -118,39 +118,39 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetItemAction" xml:space="preserve">
-    <value>Set Item</value>
+    <value>Imposta elemento</value>
   </data>
   <data name="SetItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Value: {1}</value>
+    <value>Elemento: {0} Valore: {1}</value>
   </data>
   <data name="ClearItemAction" xml:space="preserve">
-    <value>Clear Item</value>
+    <value>Cancella elemento</value>
   </data>
   <data name="ClearItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Elemento: {0}</value>
   </data>
   <data name="RemoveItemAction" xml:space="preserve">
-    <value>Remove Item</value>
+    <value>Rimuovi elemento</value>
   </data>
   <data name="RemoveItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Elemento: {0}</value>
   </data>
   <data name="NewItemAction" xml:space="preserve">
-    <value>New Item</value>
+    <value>Nuovo elemento</value>
   </data>
   <data name="NewItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Type: {1} Value: {2}</value>
+    <value>Elemento: {0} Tipo: {1} Valore: {2}</value>
   </data>
   <data name="CopyItemAction" xml:space="preserve">
-    <value>Copy Item</value>
+    <value>Copia elemento</value>
   </data>
   <data name="CopyItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Elemento: {0} Destinazione: {1}</value>
   </data>
   <data name="RenameItemAction" xml:space="preserve">
-    <value>Rename Item</value>
+    <value>Rinomina elemento</value>
   </data>
   <data name="RenameItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} NewName: {1}</value>
+    <value>Elemento: {0} NewName: {1}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/TabCompletionStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/TabCompletionStrings.it.resx
@@ -118,154 +118,154 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>Non è possibile deserializzare correttamente il risultato del completamento tramite TAB perché lo spazio di esecuzione remoto non contiene un'istanza di TypeTable.</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>Non è possibile accedere alle proprietà in un'istanza Null di tipo CompletionResult.</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>NOT bit per bit</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>NOT logico. Nega l'istruzione che lo segue.</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è uguale all'operando destro.</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è uguale all'operando destro.</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Uguale a, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è uguale all'operando destro.</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Diverso da, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non sono uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non è uguale all'operando destro.</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Diverso da, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non sono uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non è uguale all'operando destro.</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Diverso da, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non sono uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non è uguale all'operando destro.</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Maggiore o uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore o uguale all'operando destro.</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Maggiore o uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore o uguale all'operando destro.</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Maggiore o uguale a, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore o uguale all'operando destro.</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Maggiore di, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore dell'operando destro.</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Maggiore di, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore dell'operando destro.</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Maggiore di, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta maggiori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è maggiore dell'operando destro.</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Minore di, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore dell'operando destro.</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Minore di, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore dell'operando destro.</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Minore di, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori dell'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore dell'operando destro.</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Minore o uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore o uguale all'operando destro.</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Minore o uguale a, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore o uguale all'operando destro.</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Minore o uguale a, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta minori o uguali all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro è minore o uguale all'operando destro.</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza con caratteri jolly, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro corrisponde all'operando destro.</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, senza distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operatore di corrispondenza tramite espressioni regolari, con distinzione maiuscole/minuscole. Quando l'operando sinistro è una raccolta, restituisce i valori della raccolta che non corrispondono all'operando destro; in caso contrario, restituisce TRUE se l'operando sinistro non corrisponde all'operando destro.</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operatore di sostituzione, senza distinzione maiuscole/minuscole. Modifica l'operando sinistro. Esempio: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operatore di sostituzione, senza distinzione maiuscole/minuscole. Modifica l'operando sinistro. Esempio: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operatore di sostituzione, con distinzione maiuscole/minuscole. Modifica l'operando sinistro. Esempio: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando destro) corrisponde esattamente ad almeno uno dei valori nell'operando sinistro.</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando destro) corrisponde esattamente ad almeno uno dei valori nell'operando sinistro.</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operatore di contenimento, con distinzione maiuscole/minuscole. Restituisce TRUE solo quando il valore di test (operando destro) corrisponde esattamente ad almeno uno dei valori nell'operando sinistro.</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando destro) non corrisponde esattamente ad alcuno dei valori nell'operando sinistro.</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando destro) non corrisponde esattamente ad alcuno dei valori nell'operando sinistro.</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operatore di contenimento, con distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando destro) non corrisponde esattamente ad alcuno dei valori nell'operando sinistro.</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) corrisponde esattamente ad almeno uno dei valori nell'operando destro.</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) corrisponde esattamente ad almeno uno dei valori nell'operando destro.</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operatore di contenimento, con distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) corrisponde esattamente ad almeno uno dei valori nell'operando destro.</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operatore di contenimento, con distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) non corrisponde esattamente ad alcuno dei valori nell'operando destro.</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operatore di contenimento, senza distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) non corrisponde esattamente ad alcuno dei valori nell'operando destro.</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operatore di contenimento, con distinzione maiuscole/minuscole. Restituisce TRUE quando il valore di test (operando sinistro) non corrisponde esattamente ad alcuno dei valori nell'operando destro.</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>Divisione, senza distinzione maiuscole/minuscole. Divide una o più stringhe in sottostringhe.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -273,7 +273,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>Divisione, senza distinzione maiuscole/minuscole. Divide una o più stringhe in sottostringhe.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -281,7 +281,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
+    <value>Divisione, con distinzione maiuscole/minuscole. Divide una o più stringhe in sottostringhe.
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -289,103 +289,103 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>Restituisce TRUE quando l'operando sinistro non è un'istanza del tipo .NET Framework specificato (operando destro).</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>Restituisce TRUE quando l'operando sinistro è un'istanza del tipo .NET Framework specificato (operando destro).</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>Converte l'operando sinistro nel tipo .NET Framework specificato (operando destro).</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>Formatta le stringhe usando il metodo di formato degli oggetti stringa.</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>AND logico. Restituisce TRUE quando entrambe le istruzioni sono TRUE.</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>AND bit per bit</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>OR logico. TRUE quando una o entrambe le istruzioni sono TRUE.</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>OR bit per bit (inclusivo)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>XOR logico. Restituisce TRUE quando una delle istruzioni è TRUE e l'altra è FALSE.</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>OR bit per bit (esclusivo)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
+    <value>Join - combina più stringhe in un'unica stringa.
 -Join &lt;String[]&gt;
 &lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>Operatore di spostamento bit a sinistra. Inserisce uno zero nella posizione del bit più a destra.</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>Operatore di spostamento bit a destra. Inserisce uno zero nella posizione del bit più a sinistra. Per i valori con segno, il bit di segno viene preservato.</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Specifica il nome della proprietà da creare.</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+Specifica il nome della proprietà da creare.</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
     <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+Blocco di script usato per calcolare il valore della nuova proprietà.</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+Definisce la modalità di visualizzazione dei valori in una colonna.
+I valori validi sono 'left', 'center' o 'right'.</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+Specifica una stringa di formato che definisce la formattazione del valore nell'output.</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+Specifica la larghezza massima delle colonne in una tabella quando viene visualizzato il valore.
+Il valore deve essere maggiore di 0.</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+La chiave di profondità specifica la profondità di espansione per proprietà.</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Specifica l'ordine di ordinamento per una o più proprietà.</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+Specifica l'ordine di ordinamento per una o più proprietà.</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+Specifica i nomi dei log da cui ottenere gli eventi.
+Supporta caratteri jolly.</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+Specifica i provider del registro eventi da cui ottenere gli eventi.
+Supporta caratteri jolly.</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+Specifica i percorsi dei file di log da cui ottenere gli eventi.
+I formati di file validi sono: .etl, .evt ed .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
     <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+Seleziona gli eventi con le maschere di bit delle parole chiave specificate.
+Di seguito sono riportate le parole chiave standard:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,213 +398,213 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+Seleziona gli eventi con gli ID evento specificati.</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
-2: Error
-3: Warning
-4: Informational
-5: Verbose</value>
+Seleziona gli eventi con i livelli di log specificati.
+I livelli di log seguenti sono validi:
+1: Critico
+2: Errore
+3: Avviso
+4: Informativo
+5: Dettagliato</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created after the specified date and time.</value>
+Seleziona gli eventi creati dopo la data e l'ora specificate.</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created before the specified date and time.</value>
+Seleziona gli eventi creati prima della data e dell'ora specificate.</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+Seleziona gli eventi generati dall'utente specificato.
+Può trattarsi di una rappresentazione in formato stringa di un SID o di un dominio e nome utente nel formato DOMINIO\NOMEUTENTE o NOMEUTENTE@DOMINIO</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
     <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+Seleziona gli eventi con uno dei valori specificati nella sezione EventData.</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
     <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+Esclude gli eventi che corrispondono ai valori specificati nella tabella hash.</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[string] o [hashtable]
+Specifica una matrice di moduli di PowerShell richiesti dallo script.
+Ogni elemento può essere una stringa con il nome del modulo come valore o una tabella hash con le chiavi seguenti:
+Name: nome del modulo
+GUID: GUID del modulo
+Uno dei seguenti:
+ModuleVersion: specifica una versione minima accettabile del modulo.
+RequiredVersion: specifica una versione esatta e obbligatoria del modulo.
+MaximumVersion: specifica la versione massima accettabile del modulo.</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
     <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+Specifica un'edizione di PowerShell richiesta dallo script.
+I valori validi sono "Core" e "Desktop"</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
     <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+Specifica che PowerShell deve essere in esecuzione come amministratore in Windows.
+Deve essere l'ultimo parametro nella riga dell'istruzione #requires.</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
     <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+Specifica la versione minima di PowerShell richiesta dallo script.</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>Specifica che lo script richiede PowerShell 7 o versione successiva per l'esecuzione.</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>Specifica che lo script richiede Windows PowerShell 5.1 per l'esecuzione.</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
     <value>[string]
-Required. Specifies the module name.</value>
+Obbligatorio. Specifica il nome del modulo.</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
     <value>[string]
-Optional. Specifies the GUID of the module.</value>
+Facoltativo. Specifica il GUID del modulo.</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+Specifica una versione minima accettabile del modulo.</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies an exact, required version of the module.</value>
+Specifica una versione esatta e obbligatoria del modulo.</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+Specifica la versione massima accettabile del modulo.</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Breve descrizione della funzione o dello script.
+Questa parola chiave può essere usata una sola volta in ogni argomento.</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Descrizione dettagliata della funzione o dello script.
+Questa parola chiave può essere usata una sola volta in ogni argomento.</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
     <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+Descrizione di un parametro.
+Aggiungere una parola chiave .PARAMETER per ogni parametro nella sintassi della funzione o dello script.</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>Comando di esempio che usa la funzione o lo script, seguito facoltativamente da un output di esempio e da una descrizione.
+Ripetere questa parola chiave per ogni esempio.</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>Tipi .NET di oggetti che possono essere inviati tramite pipe alla funzione o allo script.
+È anche possibile includere una descrizione degli oggetti di input.</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>Tipo .NET degli oggetti restituiti dal cmdlet.
+È anche possibile includere una descrizione degli oggetti restituiti.</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>Informazioni aggiuntive sulla funzione o sullo script.</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>Nome di un argomento correlato.
+Ripetere la parola chiave .LINK per ogni argomento correlato.
+Il contenuto della parola chiave .Link può includere anche un URI alla versione online dello stesso argomento della Guida.</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>Nome della tecnologia o della funzionalità usata dalla funzione o dallo script, oppure a cui la funzione o lo script sono correlati.</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>Nome del ruolo utente per l'argomento della Guida.</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>Parole chiave che descrivono l'uso previsto della funzione.</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+Reindirizza all'argomento della Guida per il comando specificato.</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+Specifica la categoria della Guida dell'elemento in .ForwardHelpTargetName</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+Specifica una sessione che contiene l'argomento della Guida.
+Immettere una variabile che contiene un oggetto PSSession.</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+La parola chiave .ExternalHelp è obbligatoria quando una funzione o uno script è documentato in file XML.</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>Specifica il percorso di un assembly .NET da caricare.
 
 using assembly &lt;.NET-assembly-path&gt;</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>Specifica un modulo di PowerShell da cui caricare le classi.
 
 using module &lt;ModuleName or Path&gt;
 
 using module &lt;ModuleSpecification hashtable&gt;</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>Specifica uno spazio dei nomi .NET da cui risolvere i tipi o un alias dello spazio dei nomi.
 
 using namespace &lt;.NET-namespace&gt;
 
 using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>Specifica un alias per un tipo .NET.
 
 using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>Stringa normale.</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>Stringa contenente riferimenti non espansi a variabili di ambiente che vengono espanse quando viene recuperato il valore.</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>Dati binari in qualsiasi forma.</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>Numero binario a 32 bit.</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>Matrice di stringhe.</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>Numero binario a 64 bit.</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>Tipo di dati del Registro di sistema non supportato.</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
-    <value>',' - Comma</value>
+    <value>',' - Virgola</value>
   </data>
   <data name="SeparatorCommaSpaceToolTip" xml:space="preserve">
-    <value>', ' - Comma-Space</value>
+    <value>', ' - Virgola spazio</value>
   </data>
   <data name="SeparatorSemiColonToolTip" xml:space="preserve">
-    <value>';' - Semi-Colon</value>
+    <value>';' - Punto e virgola</value>
   </data>
   <data name="SeparatorSemiColonSpaceToolTip" xml:space="preserve">
-    <value>'; ' - Semi-Colon-Space</value>
+    <value>'; ' - Punto e virgola-spazio</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
-    <value>{0} - Newline</value>
+    <value>{0} - Nuova riga</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
-    <value>'-' - Dash</value>
+    <value>'-' - Trattino</value>
   </data>
   <data name="SeparatorSpaceToolTip" xml:space="preserve">
-    <value>' ' - Space</value>
+    <value>' ' - Spazio</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/it/VerbDescriptionStrings.it.resx
+++ b/src/System.Management.Automation/resources/it/VerbDescriptionStrings.it.resx
@@ -118,303 +118,303 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Add" xml:space="preserve">
-    <value>Adds a resource to a container, or attaches an item to another item</value>
+    <value>Aggiunge una risorsa a un contenitore o collega un elemento a un altro elemento</value>
   </data>
   <data name="Approve" xml:space="preserve">
-    <value>Confirms or agrees to the status of a resource or process</value>
+    <value>Conferma o accetta lo stato di una risorsa o di un processo</value>
   </data>
   <data name="Assert" xml:space="preserve">
-    <value>Affirms the state of a resource</value>
+    <value>Afferma lo stato di una risorsa</value>
   </data>
   <data name="Backup" xml:space="preserve">
-    <value>Stores data by replicating it</value>
+    <value>Archivia i dati eseguendone la replica</value>
   </data>
   <data name="Block" xml:space="preserve">
-    <value>Restricts access to a resource</value>
+    <value>Limita l'accesso a una risorsa</value>
   </data>
   <data name="Build" xml:space="preserve">
-    <value>Creates an artifact (usually a binary or document) out of some set of input files (usually source code or declarative documents)</value>
+    <value>Crea un artefatto, in genere un file binario o un documento, da un set di file di input, in genere codice sorgente o documenti dichiarativi</value>
   </data>
   <data name="Checkpoint" xml:space="preserve">
-    <value>Creates a snapshot of the current state of the data or of its configuration</value>
+    <value>Crea uno snapshot dello stato corrente dei dati o della relativa configurazione</value>
   </data>
   <data name="Clear" xml:space="preserve">
-    <value>Removes all the resources from a container but does not delete the container</value>
+    <value>Rimuove tutte le risorse da un contenitore, ma non elimina il contenitore</value>
   </data>
   <data name="Close" xml:space="preserve">
-    <value>Changes the state of a resource to make it inaccessible, unavailable, or unusable</value>
+    <value>Modifica lo stato di una risorsa per renderla inaccessibile, non disponibile o inutilizzabile</value>
   </data>
   <data name="Compare" xml:space="preserve">
-    <value>Evaluates the data from one resource against the data from another resource</value>
+    <value>Valuta i dati di una risorsa in base a quelli di un'altra risorsa</value>
   </data>
   <data name="Complete" xml:space="preserve">
-    <value>Concludes an operation</value>
+    <value>Conclude un'operazione</value>
   </data>
   <data name="Compress" xml:space="preserve">
-    <value>Compacts the data of a resource</value>
+    <value>Compatta i dati di una risorsa</value>
   </data>
   <data name="Confirm" xml:space="preserve">
-    <value>Acknowledges, verifies, or validates the state of a resource or process</value>
+    <value>Conferma, verifica o convalida lo stato di una risorsa o di un processo</value>
   </data>
   <data name="Connect" xml:space="preserve">
-    <value>Creates a link between a source and a destination</value>
+    <value>Crea un collegamento tra un'origine e una destinazione</value>
   </data>
   <data name="Convert" xml:space="preserve">
-    <value>Changes the data from one representation to another when the cmdlet supports bidirectional conversion or when the cmdlet supports conversion between multiple data types</value>
+    <value>Modifica i dati da una rappresentazione a un'altra quando il cmdlet supporta la conversione bidirezionale o quando il cmdlet supporta la conversione tra più tipi di dati</value>
   </data>
   <data name="ConvertFrom" xml:space="preserve">
-    <value>Converts one primary type of input (the cmdlet noun indicates the input) to one or more supported output types</value>
+    <value>Converte un tipo di input primario (il nome del cmdlet indica l'input) in uno o più tipi di output supportati</value>
   </data>
   <data name="ConvertTo" xml:space="preserve">
-    <value>Converts from one or more types of input to a primary output type (the cmdlet noun indicates the output type)</value>
+    <value>Esegue la conversione da uno o più tipi di input a un tipo di output primario (il nome del cmdlet indica il tipo di output)</value>
   </data>
   <data name="Copy" xml:space="preserve">
-    <value>Copies a resource to another name or to another container</value>
+    <value>Copia una risorsa in un altro nome o in un altro contenitore</value>
   </data>
   <data name="Debug" xml:space="preserve">
-    <value>Examines a resource to diagnose operational problems</value>
+    <value>Esamina una risorsa per diagnosticare problemi operativi</value>
   </data>
   <data name="Deny" xml:space="preserve">
-    <value>Refuses, objects, blocks, or opposes the state of a resource or process</value>
+    <value>Rifiuta, blocca, obietta o si oppone allo stato di una risorsa o di un processo</value>
   </data>
   <data name="Deploy" xml:space="preserve">
-    <value>Sends an application, website, or solution to a remote target[s] in such a way that a consumer of that solution can access it after deployment is complete</value>
+    <value>Invia un'applicazione, un sito Web o una soluzione a una o più destinazioni remote in modo che un utente di tale soluzione possa accedervi al termine della distribuzione</value>
   </data>
   <data name="Disable" xml:space="preserve">
-    <value>Configures a resource to an unavailable or inactive state</value>
+    <value>Configura una risorsa su uno stato non disponibile o inattivo</value>
   </data>
   <data name="Disconnect" xml:space="preserve">
-    <value>Breaks the link between a source and a destination</value>
+    <value>Interrompe il collegamento tra un'origine e una destinazione</value>
   </data>
   <data name="Dismount" xml:space="preserve">
-    <value>Detaches a named entity from a location</value>
+    <value>Scollega un'entità denominata da un percorso</value>
   </data>
   <data name="Edit" xml:space="preserve">
-    <value>Modifies existing data by adding or removing content</value>
+    <value>Modifica i dati esistenti aggiungendo o rimuovendo contenuto</value>
   </data>
   <data name="Enable" xml:space="preserve">
-    <value>Configures a resource to an available or active state</value>
+    <value>Configura una risorsa su uno stato disponibile o attivo</value>
   </data>
   <data name="Enter" xml:space="preserve">
-    <value>Specifies an action that allows the user to move into a resource</value>
+    <value>Specifica un'azione che consente all'utente di spostarsi in una risorsa</value>
   </data>
   <data name="Exit" xml:space="preserve">
-    <value>Sets the current environment or context to the most recently used context</value>
+    <value>Imposta l'ambiente o il contesto corrente sul contesto usato più di recente</value>
   </data>
   <data name="Expand" xml:space="preserve">
-    <value>Restores the data of a resource that has been compressed to its original state</value>
+    <value>Ripristina i dati di una risorsa che è stata compressa allo stato originale</value>
   </data>
   <data name="Export" xml:space="preserve">
-    <value>Encapsulates the primary input into a persistent data store, such as a file, or into an interchange format</value>
+    <value>Incapsula l'input primario in un archivio dati persistente, ad esempio un file, o in un formato di interscambio</value>
   </data>
   <data name="Find" xml:space="preserve">
-    <value>Looks for an object in a container that is unknown, implied, optional, or specified</value>
+    <value>Cerca un oggetto in un contenitore sconosciuto, implicito, facoltativo o specificato</value>
   </data>
   <data name="Format" xml:space="preserve">
-    <value>Arranges objects in a specified form or layout</value>
+    <value>Dispone gli oggetti in una forma o un layout specificato</value>
   </data>
   <data name="Get" xml:space="preserve">
-    <value>Specifies an action that retrieves a resource</value>
+    <value>Specifica un'azione che recupera una risorsa</value>
   </data>
   <data name="Grant" xml:space="preserve">
-    <value>Allows access to a resource</value>
+    <value>Consente l'accesso a una risorsa</value>
   </data>
   <data name="Group" xml:space="preserve">
-    <value>Arranges or associates one or more resources</value>
+    <value>Dispone o associa una o più risorse</value>
   </data>
   <data name="Hide" xml:space="preserve">
-    <value>Makes a resource undetectable</value>
+    <value>Rende una risorsa non rilevabile</value>
   </data>
   <data name="Import" xml:space="preserve">
-    <value>Creates a resource from data that is stored in a persistent data store (such as a file) or in an interchange format</value>
+    <value>Crea una risorsa da dati archiviati in un archivio dati permanente (ad esempio un file) o in un formato di interscambio</value>
   </data>
   <data name="Initialize" xml:space="preserve">
-    <value>Prepares a resource for use, and sets it to a default state</value>
+    <value>Prepara una risorsa per l'uso e la imposta su uno stato predefinito</value>
   </data>
   <data name="Install" xml:space="preserve">
-    <value>Places a resource in a location, and optionally initializes it</value>
+    <value>Inserisce una risorsa in un percorso e, facoltativamente, la inizializza</value>
   </data>
   <data name="Invoke" xml:space="preserve">
-    <value>Performs an action, such as running a command or a method</value>
+    <value>Esegue un'azione, come l'esecuzione di un comando o di un metodo</value>
   </data>
   <data name="Join" xml:space="preserve">
-    <value>Combines resources into one resource</value>
+    <value>Combina le risorse in un'unica risorsa</value>
   </data>
   <data name="Limit" xml:space="preserve">
-    <value>Applies constraints to a resource</value>
+    <value>Applica vincoli a una risorsa</value>
   </data>
   <data name="Lock" xml:space="preserve">
-    <value>Secures a resource</value>
+    <value>Protegge una risorsa</value>
   </data>
   <data name="Measure" xml:space="preserve">
-    <value>Identifies resources that are consumed by a specified operation, or retrieves statistics about a resource</value>
+    <value>Identifica le risorse usate da un'operazione specificata o recupera le statistiche relative a una risorsa</value>
   </data>
   <data name="Merge" xml:space="preserve">
-    <value>Creates a single resource from multiple resources</value>
+    <value>Crea un'unica risorsa da più risorse</value>
   </data>
   <data name="Mount" xml:space="preserve">
-    <value>Attaches a named entity to a location</value>
+    <value>Collega un'entità denominata a un percorso</value>
   </data>
   <data name="Move" xml:space="preserve">
-    <value>Moves a resource from one location to another</value>
+    <value>Sposta una risorsa da un percorso a un altro</value>
   </data>
   <data name="New" xml:space="preserve">
-    <value>Creates a resource</value>
+    <value>Crea una risorsa</value>
   </data>
   <data name="Open" xml:space="preserve">
-    <value>Changes the state of a resource to make it accessible, available, or usable</value>
+    <value>Modifica lo stato di una risorsa per renderla accessibile, disponibile o utilizzabile</value>
   </data>
   <data name="Optimize" xml:space="preserve">
-    <value>Increases the effectiveness of a resource</value>
+    <value>Aumenta l'efficacia di una risorsa</value>
   </data>
   <data name="Out" xml:space="preserve">
-    <value>Sends data out of the environment</value>
+    <value>Invia dati all'esterno dell'ambiente</value>
   </data>
   <data name="Ping" xml:space="preserve">
-    <value>Use the Test verb</value>
+    <value>Usa il verbo Test</value>
   </data>
   <data name="Pop" xml:space="preserve">
-    <value>Removes an item from the top of a stack</value>
+    <value>Rimuove un elemento dall'inizio di uno stack</value>
   </data>
   <data name="Protect" xml:space="preserve">
-    <value>Safeguards a resource from attack or loss</value>
+    <value>Protegge una risorsa da attacchi o perdite</value>
   </data>
   <data name="Publish" xml:space="preserve">
-    <value>Makes a resource available to others</value>
+    <value>Rende una risorsa disponibile ad altri utenti</value>
   </data>
   <data name="Push" xml:space="preserve">
-    <value>Adds an item to the top of a stack</value>
+    <value>Aggiunge un elemento all'inizio di uno stack</value>
   </data>
   <data name="Read" xml:space="preserve">
-    <value>Acquires information from a source</value>
+    <value>Acquisisce informazioni da un'origine</value>
   </data>
   <data name="Receive" xml:space="preserve">
-    <value>Accepts information sent from a source</value>
+    <value>Accetta le informazioni inviate da un'origine</value>
   </data>
   <data name="Redo" xml:space="preserve">
-    <value>Resets a resource to the state that was undone</value>
+    <value>Reimposta una risorsa sullo stato che è stato annullato</value>
   </data>
   <data name="Register" xml:space="preserve">
-    <value>Creates an entry for a resource in a repository such as a database</value>
+    <value>Crea una voce per una risorsa in un repository, ad esempio un database</value>
   </data>
   <data name="Remove" xml:space="preserve">
-    <value>Deletes a resource from a container</value>
+    <value>Elimina una risorsa da un contenitore</value>
   </data>
   <data name="Rename" xml:space="preserve">
-    <value>Changes the name of a resource</value>
+    <value>Modifica il nome di una risorsa</value>
   </data>
   <data name="Repair" xml:space="preserve">
-    <value>Restores a resource to a usable condition</value>
+    <value>Riporta una risorsa a una condizione utilizzabile</value>
   </data>
   <data name="Request" xml:space="preserve">
-    <value>Asks for a resource or asks for permissions</value>
+    <value>Richiede una risorsa o chiede le autorizzazioni</value>
   </data>
   <data name="Reset" xml:space="preserve">
-    <value>Sets a resource back to its original state</value>
+    <value>Ripristina lo stato originale di una risorsa</value>
   </data>
   <data name="Resize" xml:space="preserve">
-    <value>Changes the size of a resource</value>
+    <value>Modifica la dimensione di una risorsa</value>
   </data>
   <data name="Resolve" xml:space="preserve">
-    <value>Maps a shorthand representation of a resource to a more complete representation</value>
+    <value>Esegue il mapping di una rappresentazione abbreviata di una risorsa a una rappresentazione più completa</value>
   </data>
   <data name="Restart" xml:space="preserve">
-    <value>Stops an operation and then starts it again</value>
+    <value>Arresta un'operazione, quindi la avvia nuovamente</value>
   </data>
   <data name="Restore" xml:space="preserve">
-    <value>Sets a resource to a predefined state, such as a state set by Checkpoint</value>
+    <value>Imposta una risorsa su uno stato predefinito, come uno stato impostato da Checkpoint</value>
   </data>
   <data name="Resume" xml:space="preserve">
-    <value>Starts an operation that has been suspended</value>
+    <value>Avvia un'operazione precedentemente sospesa</value>
   </data>
   <data name="Revoke" xml:space="preserve">
-    <value>Specifies an action that does not allow access to a resource</value>
+    <value>Specifica un'azione che non consente l'accesso a una risorsa</value>
   </data>
   <data name="Save" xml:space="preserve">
-    <value>Preserves data to avoid loss</value>
+    <value>Conserva i dati per evitare perdite</value>
   </data>
   <data name="Search" xml:space="preserve">
-    <value>Creates a reference to a resource in a container</value>
+    <value>Crea un riferimento a una risorsa in un contenitore</value>
   </data>
   <data name="Select" xml:space="preserve">
-    <value>Locates a resource in a container</value>
+    <value>Individua una risorsa in un contenitore</value>
   </data>
   <data name="Send" xml:space="preserve">
-    <value>Delivers information to a destination</value>
+    <value>Recapita le informazioni a una destinazione</value>
   </data>
   <data name="Set" xml:space="preserve">
-    <value>Replaces data on an existing resource or creates a resource that contains some data</value>
+    <value>Sostituisce i dati in una risorsa esistente o crea una risorsa contenente alcuni dati</value>
   </data>
   <data name="Show" xml:space="preserve">
-    <value>Makes a resource visible to the user</value>
+    <value>Rende visibile una risorsa all'utente</value>
   </data>
   <data name="Sync" xml:space="preserve">
-    <value>Assures that two or more resources are in the same state</value>
+    <value>Assicura che due o più risorse si trovino nello stesso stato</value>
   </data>
   <data name="Skip" xml:space="preserve">
-    <value>Bypasses one or more resources or points in a sequence</value>
+    <value>Ignora una o più risorse o punti in una sequenza</value>
   </data>
   <data name="Split" xml:space="preserve">
-    <value>Separates parts of a resource</value>
+    <value>Separa le parti di una risorsa</value>
   </data>
   <data name="Start" xml:space="preserve">
-    <value>Initiates an operation</value>
+    <value>Avvia un'operazione</value>
   </data>
   <data name="Step" xml:space="preserve">
-    <value>Moves to the next point or resource in a sequence</value>
+    <value>Passa al punto o alla risorsa successiva in una sequenza</value>
   </data>
   <data name="Stop" xml:space="preserve">
-    <value>Discontinues an activity</value>
+    <value>Interrompe un'attività</value>
   </data>
   <data name="Submit" xml:space="preserve">
-    <value>Presents a resource for approval</value>
+    <value>Presenta una risorsa per l'approvazione</value>
   </data>
   <data name="Suspend" xml:space="preserve">
-    <value>Pauses an activity</value>
+    <value>Sospende un'attività</value>
   </data>
   <data name="Switch" xml:space="preserve">
-    <value>Specifies an action that alternates between two resources, such as to change between two locations, responsibilities, or states</value>
+    <value>Specifica un'azione che si alterna tra due risorse, ad esempio per passare da una posizione, responsabilità o stato all'altro</value>
   </data>
   <data name="Test" xml:space="preserve">
-    <value>Verifies the operation or consistency of a resource</value>
+    <value>Verifica l'operazione o la coerenza di una risorsa</value>
   </data>
   <data name="Trace" xml:space="preserve">
-    <value>Tracks the activities of a resource</value>
+    <value>Tiene traccia delle attività di una risorsa</value>
   </data>
   <data name="Unblock" xml:space="preserve">
-    <value>Removes restrictions to a resource</value>
+    <value>Rimuove le restrizioni per una risorsa</value>
   </data>
   <data name="Undo" xml:space="preserve">
-    <value>Sets a resource to its previous state</value>
+    <value>Imposta una risorsa sullo stato precedente</value>
   </data>
   <data name="Uninstall" xml:space="preserve">
-    <value>Removes a resource from an indicated location</value>
+    <value>Rimuove una risorsa da una posizione indicata</value>
   </data>
   <data name="Unlock" xml:space="preserve">
-    <value>Releases a resource that was locked</value>
+    <value>Rilascia una risorsa bloccata</value>
   </data>
   <data name="Unprotect" xml:space="preserve">
-    <value>Removes safeguards from a resource that were added to prevent it from attack or loss</value>
+    <value>Rimuove le misure di sicurezza di una risorsa aggiunte per impedirne l'attacco o la perdita</value>
   </data>
   <data name="Unpublish" xml:space="preserve">
-    <value>Makes a resource unavailable to others</value>
+    <value>Rende una risorsa non disponibile ad altri utenti</value>
   </data>
   <data name="Unregister" xml:space="preserve">
-    <value>Removes the entry for a resource from a repository</value>
+    <value>Rimuove la voce di una risorsa da un repository</value>
   </data>
   <data name="Update" xml:space="preserve">
-    <value>Brings a resource up-to-date to maintain its state, accuracy, conformance, or compliance</value>
+    <value>Tiene aggiornata una risorsa per mantenerne lo stato, l'accuratezza e la conformità</value>
   </data>
   <data name="Use" xml:space="preserve">
-    <value>Uses or includes a resource to do something</value>
+    <value>Usa o include una risorsa per eseguire un'operazione</value>
   </data>
   <data name="Wait" xml:space="preserve">
-    <value>Pauses an operation until a specified event occurs</value>
+    <value>Sospende un'operazione fino a quando non si verifica un evento specificato</value>
   </data>
   <data name="Watch" xml:space="preserve">
-    <value>Continually inspects or monitors a resource for changes</value>
+    <value>Controlla o monitora continuamente una risorsa per individuare eventuali modifiche</value>
   </data>
   <data name="Write" xml:space="preserve">
-    <value>Adds information to a target</value>
+    <value>Aggiunge informazioni a una destinazione</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/CoreClrStubResources.ja.resx
+++ b/src/System.Management.Automation/resources/ja/CoreClrStubResources.ja.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentIllegalEnvVarName" xml:space="preserve">
-    <value>Environment variable name cannot contain equal character.</value>
+    <value>環境変数名に等号を含めることはできません。</value>
   </data>
   <data name="ArgumentLongEnvVarValue" xml:space="preserve">
-    <value>Environment variable name or value is too long.</value>
+    <value>環境変数の名前または値が長すぎます。</value>
   </data>
   <data name="ArgumentStringFirstCharIsZero" xml:space="preserve">
-    <value>The first char in the string is the null character.</value>
+    <value>文字列の最初の文字が null 値です。</value>
   </data>
   <data name="ArgumentStringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
+    <value>文字列を 0 文字にすることはできません。</value>
   </data>
   <data name="CannotGetComputerName" xml:space="preserve">
-    <value>Computer name could not be obtained.</value>
+    <value>コンピューター名を取得できませんでした。</value>
   </data>
   <data name="CannotGetDomainName" xml:space="preserve">
-    <value>Current user's domain name could not be obtained.</value>
+    <value>現在のユーザーのドメイン名を取得できませんでした。</value>
   </data>
   <data name="UnknownErrorNumber" xml:space="preserve">
-    <value>Unknown error "{0}".</value>
+    <value>不明なエラー "{0}"。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/CredUI.ja.resx
+++ b/src/System.Management.Automation/resources/ja/CredUI.ja.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>PowerShell 資格情報の要求 </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>資格情報を入力してください。</value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>資格情報を入力してください。</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>キャプションの最大長は {0} 文字です。</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>メッセージの最大長は {0} 文字です。</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>ユーザー名の最大長は {0} 文字です。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/EtwLoggingStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/EtwLoggingStrings.ja.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>コマンド {0} は {1} です。</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>エンジンの状態が {0} から {1} に変わりました。</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>完全修飾エラー ID = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>エラー メッセージ = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>推奨されるアクション = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>実行ポリシー</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>ジョブ コマンド = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>ジョブ ID = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>ジョブ インスタンス ID = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>ジョブの場所 = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>ジョブ名 = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>ジョブの状態 = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        コマンド名 = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        コマンド パス = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        コマンドの種類 = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        エンジンのバージョン = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        ホスト ID = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        ホスト名 = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        ホスト アプリケーション = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        ホスト バージョン = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        パイプライン ID = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        実行空間 ID = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        スクリプト名 = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        シーケンス番号 = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        重大度 = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        シェル ID = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        時刻 = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        ユーザー = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        接続されたユーザー = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>NULL ジョブ</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>プロバイダー名</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>プロバイダー {0} の状態が {1} に変更されました。</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>スクリプトの実行は {0} です。</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>変数 {0} が {1} から {2} に変更されました。</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>変数 {0} は {1} に変更されました。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/ExperimentalFeatureStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/ExperimentalFeatureStrings.ja.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>'{0}' という名前に一致する試験的な機能は見つかりませんでした。</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>試験的な機能の有効化と無効化は、PowerShell を次回起動するまで反映されません。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/FileSystemProviderStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/FileSystemProviderStrings.ja.resx
@@ -118,240 +118,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvokeItemAction" xml:space="preserve">
-    <value>Invoke Item</value>
+    <value>Invoke-Item</value>
   </data>
   <data name="InvokeItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>項目: {0}</value>
   </data>
   <data name="RemoveItemActionFile" xml:space="preserve">
-    <value>Remove File</value>
+    <value>ファイルの削除</value>
   </data>
   <data name="RemoveItemActionDirectory" xml:space="preserve">
-    <value>Remove Directory</value>
+    <value>ディレクトリの削除</value>
   </data>
   <data name="CopyItemActionFile" xml:space="preserve">
-    <value>Copy File</value>
+    <value>ファイルをコピーする</value>
   </data>
   <data name="CopyItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>項目: {0} 宛先: {1}</value>
   </data>
   <data name="CopyItemActionDirectory" xml:space="preserve">
-    <value>Copy Directory</value>
+    <value>ディレクトリのコピー</value>
   </data>
   <data name="RenameItemActionFile" xml:space="preserve">
-    <value>Rename File</value>
+    <value>ファイル名を変更する</value>
   </data>
   <data name="RenameItemActionDirectory" xml:space="preserve">
-    <value>Rename Directory</value>
+    <value>ディレクトリ名の変更</value>
   </data>
   <data name="RenameItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>項目: {0} 宛先: {1}</value>
   </data>
   <data name="MoveItemActionFile" xml:space="preserve">
-    <value>Move File</value>
+    <value>ファイルの移動</value>
   </data>
   <data name="MoveItemActionDirectory" xml:space="preserve">
-    <value>Move Directory</value>
+    <value>ディレクトリの移動</value>
   </data>
   <data name="MoveItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>項目: {0} 宛先: {1}</value>
   </data>
   <data name="SetPropertyActionFile" xml:space="preserve">
-    <value>Set Property File</value>
+    <value>プロパティ ファイルの設定</value>
   </data>
   <data name="SetPropertyActionDirectory" xml:space="preserve">
-    <value>Set Property Directory</value>
+    <value>プロパティ ディレクトリの設定</value>
   </data>
   <data name="SetPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1} Value: {2}</value>
+    <value>項目: {0} プロパティ {1}: 値: {2}</value>
   </data>
   <data name="ClearPropertyActionFile" xml:space="preserve">
-    <value>Clear Property File</value>
+    <value>プロパティ ファイルをクリア</value>
   </data>
   <data name="ClearPropertyActionDirectory" xml:space="preserve">
-    <value>Clear Property Directory</value>
+    <value>プロパティ ディレクトリのクリア</value>
   </data>
   <data name="ClearPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1}</value>
+    <value>項目: {0} プロパティ: {1}</value>
   </data>
   <data name="NewItemActionFile" xml:space="preserve">
-    <value>Create File</value>
+    <value>ファイルの作成</value>
   </data>
   <data name="NewItemActionDirectory" xml:space="preserve">
-    <value>Create Directory</value>
+    <value>ディレクトリの作成</value>
   </data>
   <data name="NewItemActionTemplate" xml:space="preserve">
-    <value>Destination: {0}</value>
+    <value>宛先: {0}</value>
   </data>
   <data name="ClearContentActionFile" xml:space="preserve">
-    <value>Clear Content</value>
+    <value>コンテンツのクリア</value>
   </data>
   <data name="ClearContentesourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>項目: {0}</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>Could not find item {0}.</value>
+    <value>項目 {0} が見つかりませんでした。</value>
   </data>
   <data name="CannotRemoveItem" xml:space="preserve">
-    <value>Cannot remove item {0}: {1}</value>
+    <value>アイテム {0} を削除できません: {1}</value>
   </data>
   <data name="CannotRestoreAttributes" xml:space="preserve">
-    <value>Cannot restore attributes on item {0}: {1}</value>
+    <value>項目 {0}の属性を復元できません: {1}</value>
   </data>
   <data name="ItemDoesNotExist" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist.</value>
+    <value>指定されたパス {0} のオブジェクトは存在しません。</value>
   </data>
   <data name="DirectoryNotEmpty" xml:space="preserve">
-    <value>Directory {0} cannot be removed because it is not empty.</value>
+    <value>ディレクトリ {0} は空ではないので、削除できません。</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>この型は、ファイル システムの既知の型ではありません。"file"、"directory" または "symboliclink" のみを指定できます。</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
-    <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>
+    <value>指定されたパスが basePath の外部にある項目を参照しているため、パスを処理できません。</value>
   </data>
   <data name="DriveRootError" xml:space="preserve">
-    <value>The specified drive root "{0}" either does not exist, or it is not a folder.</value>
+    <value>指定されたドライブ ルート "{0}" が存在しないか、フォルダーではありません。</value>
   </data>
   <data name="DirectoryExist" xml:space="preserve">
-    <value>An item with the specified name {0} already exists.</value>
+    <value>指定された名前 {0} の項目は既に存在します。</value>
   </data>
   <data name="DelimiterError" xml:space="preserve">
-    <value>A delimiter cannot be specified when reading the stream one byte at a time.</value>
+    <value>ストリームを一度に 1 バイトずつ読み取る場合、区切り記号を指定することはできません。</value>
   </data>
   <data name="CopyError" xml:space="preserve">
-    <value>Cannot overwrite the item {0} with itself.</value>
+    <value>項目 {0} をそれ自体で上書きすることはできません。</value>
   </data>
   <data name="RenameError" xml:space="preserve">
-    <value>Cannot rename the specified target, because it represents a path or device name.</value>
+    <value>指定したターゲットは、パスまたはデバイス名を表しているため、名前を変更できません。</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property {0} does not exist or was not found.</value>
+    <value>プロパティ {0} が存在しないか、見つかりませんでした。</value>
   </data>
   <data name="PermissionError" xml:space="preserve">
-    <value>You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.</value>
+    <value>この操作を実行するための十分なアクセス権がないか、項目が非表示、システム、または読み取り専用です。</value>
   </data>
   <data name="AttributesNotSupported" xml:space="preserve">
-    <value>The attribute cannot be set because attributes are not supported. Only the following attributes can be set: Archive, Hidden, Normal, ReadOnly, or System.</value>
+    <value>属性がサポートされていないため、属性を設定できません。設定できる属性は、Archive、Hidden、Normal、ReadOnly、または System のみです。</value>
   </data>
   <data name="CannotClearProperty" xml:space="preserve">
-    <value>The property cannot be cleared because the property is not supported. Only the Attributes property can be cleared.</value>
+    <value>プロパティがサポートされていないため、プロパティをクリアできません。Attributes プロパティのみをクリアできます。</value>
   </data>
   <data name="TargetCannotContainDeviceName" xml:space="preserve">
-    <value>Cannot process path '{0}' because the target represents a reserved device name.</value>
+    <value>ターゲットが予約済みデバイス名を表しているため、パス '{0}' を処理できません。</value>
   </data>
   <data name="EncodingNotUsed" xml:space="preserve">
-    <value>Encoding not used when '-AsByteStream' specified.</value>
+    <value>エンコードは、'-AsByteStream' が指定されている場合は使用されません。</value>
   </data>
   <data name="ByteEncodingError" xml:space="preserve">
-    <value>Cannot proceed with byte encoding. When using byte encoding the content must be of type byte.</value>
+    <value>バイト エンコードを続行できません。バイト エンコードを使用する場合、コンテンツはバイト型である必要があります。</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>Cannot process the file because the file {0} was not found.</value>
+    <value>ファイル {0} が見つからなかったため、ファイルを処理できません。</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
-    <value>    Directory: </value>
+    <value>    ディレクトリ:</value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
-    <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>
+    <value>ファイルのエンコードを検出できません。指定されたエンコード {0} は、コンテンツを逆方向に読み取る場合にはサポートされていません。</value>
   </data>
   <data name="AlternateDataStreamNotFound" xml:space="preserve">
-    <value>Could not open the alternate data stream '{0}' of the file '{1}'.</value>
+    <value>ファイル '{1}' の代替データ ストリーム '{0}' を開けませんでした。</value>
   </data>
   <data name="StreamAction" xml:space="preserve">
-    <value>Stream '{0}' of file '{1}'.</value>
+    <value>ファイル '{1}' のストリーム '{0}'。</value>
   </data>
   <data name="RawAndWaitCannotCoexist" xml:space="preserve">
-    <value>The Raw and Wait parameters cannot be specified in the same command.</value>
+    <value>Raw パラメーターと Wait パラメーターを同じコマンドで指定することはできません。</value>
   </data>
   <data name="InvalidDriveName" xml:space="preserve">
-    <value>To use the Persist switch parameter, the drive name must be supported by the operating system (for example, drive letters A-Z).</value>
+    <value>Persist スイッチ パラメーターを使用するには、オペレーティング システムでドライブ名がサポートされている必要があります (ドライブ文字 A ~ Z など)。</value>
   </data>
   <data name="PersistNotSupported" xml:space="preserve">
-    <value>When you use the Persist parameter, the root must be a file system location on a remote computer.</value>
+    <value>Persist パラメーターを使用する場合、ルートはリモート コンピューター上のファイル システムの場所である必要があります。</value>
   </data>
   <data name="NoFirstLastWaitForRaw" xml:space="preserve">
-    <value>The '{0}' and '{1}' parameters cannot be specified in the same command.</value>
+    <value>'{0}' パラメーターと '{1}' パラメーターを同じコマンドで指定することはできません。</value>
   </data>
   <data name="ItemNotDirectory" xml:space="preserve">
-    <value>A directory is required for the operation. The item '{0}' is not a directory.</value>
+    <value>この操作にはディレクトリが必要です。項目 '{0}' はディレクトリではありません。</value>
   </data>
   <data name="NewItemActionJunction" xml:space="preserve">
-    <value>Create Junction</value>
+    <value>ジャンクションの作成</value>
   </data>
   <data name="NewItemActionSymbolicLink" xml:space="preserve">
-    <value>Create Symbolic Link</value>
+    <value>シンボリック リンクの作成</value>
   </data>
   <data name="ElevationRequired" xml:space="preserve">
-    <value>Administrator privilege required for this operation.</value>
+    <value>この操作には管理者特権が必要です。</value>
   </data>
   <data name="NewItemActionHardLink" xml:space="preserve">
-    <value>Create Hard Link</value>
+    <value>ハード リンクの作成</value>
   </data>
   <data name="ItemNotFile" xml:space="preserve">
-    <value>A file is required for the operation. The item '{0}' is not a file.</value>
+    <value>この操作にはファイルが必要です。項目 '{0}' はファイルではありません。</value>
   </data>
   <data name="HardLinkNotSupported" xml:space="preserve">
-    <value>Hard links are not supported for the specified path.</value>
+    <value>ハード リンクは、指定されたパスではサポートされていません。</value>
   </data>
   <data name="SymbolicLinkNotSupported" xml:space="preserve">
-    <value>Symbolic links are not supported for the specified path.</value>
+    <value>シンボリック リンクは、指定されたパスではサポートされていません。</value>
   </data>
   <data name="CopyItemRemotelyProgressActivity" xml:space="preserve">
     <value>{0} を {1} にコピーしています</value>
   </data>
   <data name="CopyItemRemoteDestinationIsFile" xml:space="preserve">
-    <value>Destination path {0} is a file that already exists on the target destination.</value>
+    <value>宛先パス {0} は、ターゲットの宛先に既に存在するファイルです。</value>
   </data>
   <data name="CopyItemRemotelyFailed" xml:space="preserve">
-    <value>Failed to copy file {0} to remote target destination.</value>
+    <value>ファイル {0} をリモート ターゲットのコピー先にコピーできませんでした。</value>
   </data>
   <data name="CopyItemRemotelyStatusDescription" xml:space="preserve">
     <value>{0} から {1} へ</value>
   </data>
   <data name="CopyItemRemotelyDestinationIsFile" xml:space="preserve">
-    <value>Cannot copy a directory '{0}' to file '{0}'</value>
+    <value>ディレクトリ '{0}' をファイル '{0}' にコピーできません</value>
   </data>
   <data name="CopyItemRemotelyFailedToGetDirectoryChildItems" xml:space="preserve">
-    <value>Failed to get directory {0} child items.</value>
+    <value>ディレクトリ {0} の子項目を取得できませんでした。</value>
   </data>
   <data name="CopyItemRemotelyFailedToReadFile" xml:space="preserve">
-    <value>Failed to read remote file '{0}'.</value>
+    <value>リモート ファイル '{0}' を読み取ることができませんでした。</value>
   </data>
   <data name="CopyItemRemotelyFailedToValidateIfDestinationIsFile" xml:space="preserve">
-    <value>Cannot validate if remote destination {0} is a file.</value>
+    <value>リモートの宛先 {0} がファイルかどうかを検証できません。</value>
   </data>
   <data name="CopyItemRemotelyFailedToCreateDirectory" xml:space="preserve">
-    <value>Failed to create directory '{0}' on remote destination.</value>
+    <value>リモート宛先にディレクトリ '{0}' を作成できませんでした。</value>
   </data>
   <data name="DriveMaxSizeError" xml:space="preserve">
-    <value>Maximum size for drive has been exceeded: {0}.</value>
+    <value>ドライブの最大サイズを超えました: {0}。</value>
   </data>
   <data name="SymlinkItemExists" xml:space="preserve">
-    <value>Cannot create link because the path already exists: {0}.</value>
+    <value>パスが既に存在するため、リンクを作成できません: {0}。</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Skip already-visited directory {0}.</value>
+    <value>既にアクセス済みのディレクトリ {0} をスキップします。</value>
   </data>
   <data name="TargetCannotBeSubdirectoryOfSource" xml:space="preserve">
-    <value>Destination path cannot be a subdirectory of the source or the source itself: {0}.</value>
+    <value>宛先パスをソースのサブディレクトリまたはソース自体にすることはできません: {0}。</value>
   </data>
   <data name="NewItemTargetIsSameAsLink" xml:space="preserve">
-    <value>The target and path cannot be the same.</value>
+    <value>ターゲットとパスを同じにすることはできません。</value>
   </data>
   <data name="CopyingLocalFileActivity" xml:space="preserve">
-    <value>Copied {0} of {1} files</value>
+    <value>{1} 個のファイルのうち {0} 個がコピーされました</value>
   </data>
   <data name="CopyingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0}/{1} ({2:0.0} MB/秒)</value>
   </data>
   <data name="RemovingLocalFileActivity" xml:space="preserve">
-    <value>Removed {0} of {1} files</value>
+    <value>{1} 個中 {0} 個のファイルを削除しました</value>
   </data>
   <data name="RemovingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0}/{1} ({2:0.0} MB/秒)</value>
   </data>
   <data name="JunctionAbsolutePath" xml:space="preserve">
-    <value>Creating a junction requires an absolute path for the target.</value>
+    <value>ジャンクションを作成するには、ターゲットの絶対パスが必要です。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/HelpDisplayStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/HelpDisplayStrings.ja.resx
@@ -121,157 +121,157 @@
     <value>名前</value>
   </data>
   <data name="Synopsis" xml:space="preserve">
-    <value>SYNOPSIS</value>
+    <value>概要</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
-    <value>DESCRIPTION</value>
+    <value>説明</value>
   </data>
   <data name="Syntax" xml:space="preserve">
-    <value>SYNTAX</value>
+    <value>構文</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>パラメーター</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>入力</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>出力</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>強制終了になるエラー</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>終了しないエラー</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>注</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>例</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>例</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>例</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>OUTPUT</value>
+    <value>出力</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>関連リンク</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>概要</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>タイトル:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>質問:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>回答</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>期間:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>定義:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>内容:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>プロバイダー名</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
-    ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
-    about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
+    <value>    このコマンドレットは、次の共通パラメーターをサポートしています: Verbose、Debug、
+    ErrorAction、ErrorVariable、WarningAction、WarningVariable、
+    OutBuffer、PipelineVariable、OutVariable。詳細については、次を参照してください 
+    about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216)。</value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>必要ですか?                   </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>位置は?                   </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>型:</value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>ターゲット オブジェクトの型  </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>既定値                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>パイプライン入力の受け入れますか?      </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>ワイルドカード文字を受け入れますか? </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(カテゴリ:</value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>提案されているアクション:</value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>詳細については、次のように入力してください:</value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>技術情報については、次のように入力してください:</value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>例を表示するには、次のように入力してください:</value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>オンライン ヘルプについては、次のように入力してください:</value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
   </data>
   <data name="RemarksSection" xml:space="preserve">
-    <value>REMARKS</value>
+    <value>注釈</value>
   </data>
   <data name="TrueShort" xml:space="preserve">
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>名前付き</value>
   </data>
   <data name="Drives" xml:space="preserve">
     <value>DRIVES</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>機能</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>タスク</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>タスク:</value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>フィルター</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>動的パラメーター</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>サポートされているコマンドレット:</value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>別名</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Get-Help は、このコンピューター上でこのコマンドレットのヘルプ ファイルを見つけることができません。部分的なヘルプのみを表示しています。
+    -- このコマンドレットを含むモジュールのヘルプ ファイルをダウンロードしてインストールするには、Update-Help を使用してください。
+    -- このコマンドレットのヘルプ トピックをオンラインで表示するには、"Get-Help {0} -Online" と入力するか、
+       {1} へ移動してください。</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>なし</value>
@@ -280,13 +280,13 @@
     <value>Aliases                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>Dynamic?                    </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>パラメーター セット名           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>UI カルチャ {0} の HelpInfo XML ファイルを取得できません。モジュール マニフェストの HelpInfoUri プロパティが有効であることを確認するか、ネットワーク接続を確認してからコマンドを再試行してください。</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
@@ -298,176 +298,176 @@
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>指定されたカルチャはサポートされていません: {0}。次の一覧からカルチャを指定してください: {{{1}}}。</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>エラーを延期し、フォールバック カルチャを試行すると、すべてのフォールバックがサポートされていない場合はエラーとして表示されます: 
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>ModuleBase ディレクトリが見つかりません。ディレクトリを確認して、もう一度やり直してください。</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>パス {0} は有効なディレクトリではありません。ディレクトリが存在することを確認してから、再試行してください。</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>ヘルプ URI には、10 個を超えるリダイレクトを含めることはできません。有効なヘルプ URI を指定してください。</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>ヘルプの更新</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>ヘルプ コンテンツに接続しています...</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>ヘルプ コンテンツをダウンロードしています...</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>ヘルプ コンテンツをインストールしています...</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>ヘルプ コンテンツを検索しています...</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(すべて)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>次のパターンに一致する PowerShell モジュールが見つかりませんでした: {0}。パターンを確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>指定された FullyQualifiedModule {0}に一致する PowerShell モジュールが見つかりませんでした。FullyQualifiedModule 値を確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>ヘルプ コンテンツが見つかりません。サーバーが使用可能であり、ヘルプ コンテンツの場所が HelpInfo XML で正しく定義されていることを確認してください。</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>指定されたモジュールが更新可能なヘルプをサポートしていないため、Update-Help コマンドが失敗しました。Get-Help -Online を使用するか、このモジュールのコマンドのヘルプをオンラインで検索してください。</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>次のパラメーターを null または空にすることはできません: Module。</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>次のパラメーターを null または空にすることはできません: Path。</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Update-Help が正常に完了しました。</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>ヘルプ コンテンツの抽出中にエラーが発生しました。</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>ヘルプ コンテンツに接続できません。ヘルプ コンテンツが保存されているサーバーが使用できない可能性があります。サーバーが使用可能であることを確認するか、サーバーがオンラインに戻るまで待ってから、コマンドを再試行してください。</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>指定した場所のヘルプ コンテンツが無効です。有効なヘルプ コンテンツを含む場所を指定してください。</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>HelpInfo XML が無効です。有効な HelpInfo XML を指定してください。</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>ヘルプ コンテンツが次の場所に正常に保存されました: {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>ヘルプ コンテンツ XSD ファイルが {0} で見つかりませんでした。指定した場所に XSD ファイルが存在することを確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
+    <value>次のモジュールのヘルプを更新できませんでした:
 '{0}'
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>ヘルプの保存</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>ヘルプ コンテンツに無効なファイルが含まれています。.txt ファイルと.xml ファイルのみがサポートされています。</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>モジュール '{0}' のヘルプを保存できませんでした: {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>UI カルチャ {{{1}}} でモジュール '{0}' のヘルプを保存できませんでした: {2}。
+英語 (米国) のヘルプ コンテンツが利用でき、Save-Help -UICulture en-US を使用して保存できます。</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>UI カルチャ {{{1}}} でモジュール '{0}' のヘルプを更新できませんでした: {2}。
+英語 (米国) のヘルプ コンテンツが利用でき、Update-Help -UICulture en-US を使用してインストールできます。</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>現在のカルチャは ({0}) であり、どの言語にも関連付けられていないため、システム カルチャを変更するか、Update-Help -UICulture en-US を使用して英語 (米国) のヘルプ コンテンツをインストールすることを検討してください。</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
     <value>false</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>-Recurse パラメーターは、ソース パスが指定されている場合にのみ使用できます。</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>{0} パスに FileSystem プロバイダーが含まれていません。指定したパスに FileSystem プロバイダーが含まれていることを確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>{0} のヘルプを検索しています...</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>次のパターンに一致する UI カルチャが見つかりませんでした: {0}。パターンを確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>このコンピューターで過去 24 時間以内に Save-Help コマンドが実行されたため、モジュール {0} のヘルプは保存されませんでした。
+ヘルプをもう一度保存するには、Force パラメーターをコマンドに追加してください。</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>このコンピューターで Update-Help コマンドが過去 24 時間以内に実行されたため、モジュール {0} のヘルプは更新されませんでした。
+ヘルプをもう一度更新するには、Force パラメーターをコマンドに追加してください。</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>最新のヘルプ ファイルが既にインストールされています。</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}。カルチャ {2} バージョン {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>{0} を更新しました</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>モジュール マニフェストの HelpInfoUri キーの値は、ヘルプ ファイルが格納されている Web サイトのコンテナーまたはルート URL に解決する必要があります。HelpInfoUri '{0}' はコンテナーに解決されません。</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>ヘルプ コンテンツは名前空間 {0} に含まれている必要があります。</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Get-Help は、このコンピューター上でこのコマンドレットのヘルプ ファイルを見つけることができません。部分的なヘルプのみを表示しています。
+    -- このコマンドレットを含むモジュールのヘルプ ファイルをダウンロードしてインストールするには、Update-Help を使用してください。</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>最新のヘルプ ファイルが既にダウンロードされています。</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>{0} を保存しました</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>HelpInfoURI {0} は HTTP で始まっていません。</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>ヘルプ コンテンツのルート レベル要素は "helpItems" である必要があります。</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>モジュール {0} のヘルプを保存しています</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>モジュール {0} のヘルプを更新しています</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>URI: "{0}" を解決中です</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>ヘルプ URI: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}、現在のバージョン: {1}、使用可能なバージョン: {2}、UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>プロパティ</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>メソッド</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/Metadata.ja.resx
+++ b/src/System.Management.Automation/resources/ja/Metadata.ja.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>"{0}" の属性を初期化できません: "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>引数の型 "{0}" がパラメーターの最大および最小制限と同じ型 ({1}) ではないため、引数を検証できません。引数の型が {1} であることを確認してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>引数 "{0}" の値が 0 以下であるため、検証できません。</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>引数 "{0}" の値が 0 以上でないため、検証できません。</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>引数 "{0}" の値が 0 以下でないため、検証できません。</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>引数 "{0}" の値が 0 以下でないため、検証できません。</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>指定された最小範囲 ({0}) は、指定された最大範囲 ({1}) と同じ型ではないため、受け入れられません。パラメーターの ValidateRange 属性を更新してください。</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>MaxRange および MinRange パラメーター型を受け入れることはできません。どちらのパラメーターも、IComparable インターフェイスを実装するオブジェクトである必要があります。</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>指定された最大範囲は、指定された最小範囲より小さいため受け入れられません。パラメーターの ValidateRange 属性を更新してください。</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>{0} 引数が {1}の最大許容範囲を超えています。{1} 以下の引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>{0} 引数が {1}の最小許容範囲を下回っています。{1} 以上の引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>引数 "{0}" が "{1}" パターンと一致しません。"{1}" と一致する引数を指定して、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>ValidateCount 属性を配列以外のパラメーターに適用することはできません。パラメーターから属性を削除するか、パラメーターを配列パラメーターにしてください。</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>パラメーターには正確に {0} 個の値が必要ですが、{1} 個の値が指定されました。</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>パラメーターには少なくとも {0} 個の値が必要であり、{1} 個以下である必要があります。{2} 個の値が指定されました。</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>パラメーターに指定された引数の最大数が、指定された引数の最小数より少なくなっています。パラメーターの ValidateCount 属性を更新してください。</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>引数の指定された最大文字数が、指定された最小引数文字の長さよりも短くなっています。パラメーターの ValidateLength 属性を更新してください。</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>ValidateLength 属性は、文字列または string[] パラメーターではないパラメーターには適用できません。パラメーターを文字列または string[] パラメーターにしてください。</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>引数の文字の長さ ({1}) が短すぎます。長さが "{0}" 以上の引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>引数の文字数 ({1}) が長すぎます。長さが "{0}" 以下の引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>引数 "{0}" は ValidateSet 属性で指定されたセット "{1}" に属していません。セットでに属する引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>有効な値ジェネレーターは null 値を返します。</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>プロパティ "{1}" で "{0}" が失敗しました {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>コマンドを取得または実行できません。このコマンドのパラメーター セットの最大数を超えました。</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>引数の値が文字列ではないため、引数を処理できません。ArgumentTransformationAttribute が指定されているパラメーター引数の値は文字列である必要があります。</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>値 {1} が {0} 変数の有効な値ではないため、変数を検証できません。</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>値が {1} の変数 {0} が無効になるため、属性を追加できません。</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>引数が null です。引数に有効な値を指定してから、コマンドを再実行してください。</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>引数に null 値が含まれているか、引数コレクションの要素に null 値が含まれています。null 値を含まないコレクションを指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>引数が null か空です。null または空でない引数を指定して、コマンドを再度実行してください。</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>引数が null または空であるか、引数コレクションの要素に null 値が含まれています。null 値を含まないコレクションを指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>引数が null、空、または空白文字のみで構成されています。空白文字以外の文字を含む引数を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>引数コレクションの要素が null、空、または空白文字のみで構成されています。これらの値を含まないコレクションを指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>'{0}' という名前のパラメーターがコマンドに対して複数回定義されました。</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>'{0}' という名前のエイリアスがコマンドに対して既に複数回定義されているため、パラメーター エイリアスを指定できません。</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>パラメーター '{0}' は、パラメーター '{1}' の同じ名前のパラメーター エイリアスと競合しているため、指定できません。</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>値が "{0}" の引数の "{1}" 検証スクリプトは True の結果を返しませんでした。検証スクリプトが失敗した理由を特定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>"{0}" 引数に有効な PowerShell バージョンが含まれていません。有効なバージョン番号を指定してから、コマンドを再試行してください。</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>引数 '{0}' は有効な変数名ではないため、検証できません。</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>ジョブ変換の型は、IAstToScriptBlockConverter から派生する必要があります。</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>path 引数が無効です。文字列型の path 引数を指定してください。</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>パス引数ドライブ {0} は、承認済みドライブのセット: {1} に属していません。承認済みドライブにパス引数を指定してください。</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>path 引数に無効な文字が含まれています。</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>path 引数にルート ドライブがありません。 ルート ドライブを含む完全なパスを指定してください。</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>パラメーター '{0}' の引数値を null または空の文字列にすることはできません。</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Enum メンバー '{0}' は、パラメーター '{1}' の有効な値ではありません。次のいずれかのメンバーを指定して、もう一度お試しください: {2}。</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>入力を処理できません。引数 "{0}" は信頼されていません。</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>ValidateTrustedData 属性チェック エラー</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>パラメーター引数 '{0}' は信頼されていないため、制約言語モードでの ValidateTrustedData パラメーター属性のチェックに失敗します。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/Modules.ja.resx
+++ b/src/System.Management.Automation/resources/ja/Modules.ja.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>指定されたモジュール '{0}' は、モジュール ディレクトリに有効なモジュール ファイルが見つからなかったため読み込まれませんでした。</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>バージョン '{1}' で指定されたモジュール '{0}' は、モジュール ディレクトリに有効なモジュール ファイルが見つからなかったため読み込まれませんでした。</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>指定された MaximumVersion '{0}' が正しくありません。'*' を使用している場合、MaximumVersion は 1 つの '*' のみをサポートし、常に MaximumVersion の末尾に配置する必要があります。</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>MinimumVersion '{1}' で指定されたモジュール '{0}' は、モジュール ディレクトリに有効なモジュール ファイルが見つからなかったため読み込まれませんでした。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>MinimumVersion '{1}' および MaximumVersion '{2}' で指定されたモジュール '{0}' は、モジュール ディレクトリに有効なモジュール ファイルが見つからなかったため読み込まれませんでした。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion '{0}' は MaximumVersion '{1}'より大きくすることはできません。</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>アセンブリ '{0}' は読み込まれませんでした。その名前のアセンブリが見つかりませんでした。アセンブリ名を確認してから、もう一度やり直してください。</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>モジュール マニフェスト '{2}' のフィールド '{1}' にリストされている '{0}' を処理するモジュールは、モジュール ディレクトリに有効なモジュールが見つからなかったため、処理されませんでした。</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>-AsCustomObject パラメーターはスクリプト モジュールでのみ使用できるため、モジュール '{0}' に対してカスタム オブジェクトが返されませんでした。</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>モジュール マニフェスト '{0}' は有効な PowerShell モジュール マニフェスト ファイルではないため、処理できませんでした。許可されていない要素を削除します: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>モジュール マニフェスト ファイル '{0}' を処理しても、有効なマニフェスト オブジェクトが生成されませんでした。有効な PowerShell モジュール マニフェストを含むようにファイルを更新してください。有効なマニフェストは、New-ModuleManifest コマンドレットを使用して作成できます。</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>'{0}' モジュールは、マニフェストに無効なメンバーが 1 つ以上含まれているため、インポートできません。有効なマニフェスト メンバーは ({1}) です。無効なメンバー ({2}) を削除してから、モジュールのインポートを再試行してください。</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>モジュールを記述するハッシュタグに 1 つ以上の無効なメンバーが含まれています。有効なメンバーは ({0}) です。無効なメンバー ({1}) を削除してから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>モジュールの入れ子の制限を超えたため、モジュール '{0}' を読み込めません。モジュールは、{1} レベルにのみ入れ子にできます。モジュールを読み込む順序を評価して変更し、入れ子の制限を超えないようにしてから、スクリプトを再実行してください。</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>メンバー 'ModuleVersion' はモジュール マニフェストに存在しません。このメンバーは存在する必要があり、'n.n.n.n' という形式のバージョン番号が割り当てられている必要があります。見つからないメンバーをファイル '{0}' に追加してください。</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>モジュール マニフェスト ファイル '{2}' のメンバー '{0}' が無効です: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>モジュール '{1}' のバージョン '{0}' は、必要な最小バージョン '{2}' を満たしていません。バージョン番号がサポートされていることを確認してから、モジュールの読み込みを再試行してください。</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>このコンピューターの PowerShell のバージョンは '{0}' です。モジュール '{1}' を実行するには、PowerShell の最小バージョン '{2}' が必要です。最低限必要なバージョンの PowerShell がインストールされていることを確認してから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>モジュール マニフェスト メンバー 'NestedModules' は、'ModuleToProcess' メンバーがバイナリ モジュールの場合は使用できません。'{0}' でモジュール マニフェスト ファイルを編集してから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>モジュール マニフェストのメンバー '{0}' が無効です: {1}。'{2}' ファイルのこのフィールドに有効な値が指定されていることを確認します。</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>モジュール マニフェスト パス '{0}' が無効です。"Path" 引数の値は、拡張子が '.psd1' の 1 つのファイルに解決される必要があります。有効な psd1 ファイルを指すように "Path" 引数の値を変更してから、もう一度やり直してください。</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>モジュール マニフェスト '{0}' の ModuleVersion キーは、'{2}' のバージョン フォルダー名と一致しないモジュール バージョン '{1}' を指定します。バージョン フォルダー名と一致するように ModuleVersion キーの値を変更します。</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>モジュール マニフェスト '{1}' で指定された NestedModule エントリ '{0}' が無効です。有効な値でこのエントリを更新した後、もう一度お試しください。</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>モジュール マニフェスト '{1}' で指定された RequiredAssemblies エントリ '{0}' が無効です。有効な値でこのエントリを更新した後、もう一度お試しください。</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>モジュール マニフェスト '{1}' で指定された FileList エントリ '{0}' が無効です。有効な値でこのエントリを更新した後、もう一度お試しください。</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>モジュール マニフェスト '{1}' で指定された RequiredModules エントリ '{0}' が無効です。有効な値でこのエントリを更新した後、もう一度お試しください。</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>モジュール マニフェスト '{1}' で指定された ModuleList エントリ '{0}' が無効です。有効な値でこのエントリを更新した後、もう一度お試しください。</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>モジュール マニフェスト '{0}' は、PowerShell バージョン '5.1' 以降でのみサポートされている CompatiblePSEditions キーで指定されています。PowerShellVersion キーの値を '5.1' 以上に更新してから、もう一度やり直してください。</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>CompatiblePSEditions に指定された値 '{0}' に重複する PowerShell Edition 名が含まれています。重複する PowerShell Edition 名を削除した後、もう一度お試しください。</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>ModuleVersion キーで指定されたバージョンは、バージョン フォルダー名と同じです。</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>有効なモジュール マニフェスト ファイルがないため、[モジュール {1}] の [バージョン] フォルダー {0} をスキップしています。</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>'ModuleName' メンバーは、このモジュールを記述するハッシュテーブルに存在しません。</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>'ModuleVersion' メンバー、'MaximumVersion' メンバー、'RequiredVersion' メンバーは、このモジュールを記述するハッシュテーブルに存在しません。これら 3 つのメンバーのいずれかが存在し、'n.n.n.n' という形式のバージョン番号が割り当てられている必要があります。</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>必要なモジュール '{1}' が読み込まれていません。モジュールを読み込むか、ファイル '{0}' の 'RequiredModules' からモジュールを削除します。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>GUID '{2}' の必要なモジュール '{1}' は読み込まれていません。モジュールを読み込むか、ファイル '{0}' の 'RequiredModules' からモジュールを削除します。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>バージョン '{2}' の必要なモジュール '{1}' は読み込まれていません。モジュールを読み込むか、ファイル '{0}' の 'RequiredModules' からモジュールを削除します。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>MaximumVersion '{2}' の必要なモジュール '{1}' は読み込まれていません。モジュールを読み込むか、ファイル '{0}' の 'RequiredModules' からモジュールを削除します。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>MinimumVersion '{2}' および MaximumVersion '{3}' の必須モジュール '{1}' は読み込まれていません。モジュールを読み込むか、ファイル '{0}' の 'RequiredModules' からモジュールを削除します。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>モジュール '{0}' が ModuleVersion '{1}' で見つかりません。</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>RequiredVersion '{1}' のモジュール '{0}' が見つかりません。</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>モジュール '{0}' が MaximumVersion '{1}' で見つかりません。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>ModuleVersion '{1}' および MaximumVersion '{2}' のモジュール '{0}' が見つかりません。</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>モジュール '{0}' が見つかりません。</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>モジュールは削除されませんでした。削除するモジュールの仕様が正しいことと、それらのモジュールが実行空間に存在することを確認してください。</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>モジュール '{1}' からインポートされた '{0}' メンバーは、次の理由により削除できません: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>モジュール '{0}' は読み取り専用であるため、削除できません。Force パラメーターをコマンドに追加して、読み取り専用モジュールを削除します。</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>モジュール '{0}' は 'constant' としてマークされているため、削除できません。モジュールが 'constant' とマークされている場合、モジュールを削除できません。</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>モジュール '{0}' は '{1}' で必要なため削除できません。Force パラメーターをコマンドに追加して、このモジュールを削除します。</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Export-ModuleMember コマンドレットは、モジュール内からのみ呼び出すことができます。</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>拡張機能 '{0}' は有効なモジュール拡張機能ではありません。サポートされているモジュール拡張機能は、'.dll'、'.ps1'、'.psm1'、'.psd1'、.cdxml' です。拡張子を修正してから、ファイル '{1}' をもう一度追加してみてください。</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>この操作はバイナリ モジュールでは実行できません。スクリプト モジュールでのみ実行できます。</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>ファイル '{0}' には拡張子 '.ps1' がないため、使用できません。</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>不明</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}.All rights reserved.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>インポートされた "{0}" 関数を削除しています。</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>インポートされた "{0}" エイリアスを削除しています。</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>インポートされた "{0}" 変数を削除しています。</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>パス '{0}' からモジュールを読み込んでいます。</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>'{0}' をパス '{1}' から読み込んでいます。</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>スクリプト ファイル '{0}' をドットソーシングしています。</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>関数 '{0}' をインポートしています。</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>コマンドレット '{0}' をインポートしています。</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>エイリアス '{0}' をインポートしています。</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>変数 '{0}' をインポートしています。</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>コマンドレット '{0}' をエクスポートしています。</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>関数 '{0}' をエクスポートしています。</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>エイリアス '{0}' をエクスポートしています。</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>変数 '{0}' をエクスポートしています。</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>モジュール '{0}' からインポートされたコマンドの名前には、検出不能になる可能性のある未承認の動詞が含まれています。未承認の動詞を含むコマンドを見つけるには、Verbose パラメーターを指定して Import-Module コマンドをもう一度実行します。承認された動詞の一覧については、「Get-Verb」と入力します。</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>'{1}' モジュールの '{0}' コマンドがインポートされましたが、その名前に承認済みの動詞が含まれていないため、見つけにくい場合があります。承認された動詞の一覧については、「Get-Verb」と入力します。</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>'{2}' モジュールの '{0}' コマンドがインポートされましたが、その名前に承認済みの動詞が含まれていないため、見つけにくい場合があります。推奨される代替動詞は "{1}" です。</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>一部のインポートされたコマンド名には、次の制限文字が 1 つ以上含まれています: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ;: " ' &lt; &gt; | ?@ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>モジュール '{1}' のコマンド名 '{0}' には、次の制限文字が 1 つ以上含まれています: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ;: " ' &lt; &gt; | ?@ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>"{0}" モジュール マニフェスト ファイルを作成しています。</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (パス: '{1}')</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>現在のプロセッサ アーキテクチャは {0} です。モジュール '{1}' には、次のアーキテクチャが必要です: {2}。</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>現在の PowerShell ホストの名前は '{0}' です。モジュール '{1}' には、次の PowerShell ホストが必要です: '{2}'。</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>現在の PowerShell ホストは '{0}' (バージョン {1}) です。モジュール '{2}' を実行するには、PowerShell ホストの最小バージョン '{3}' が必要です。</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>モジュール '{0}' のモジュール マニフェスト</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>生成元: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>生成日: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>このマニフェストに関連付けられているスクリプト モジュールまたはバイナリ モジュール ファイル。</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>RootModule/ModuleToProcess で指定されたモジュールの入れ子になったモジュールとしてインポートするモジュール</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>このモジュールを一意に識別するために使用される ID</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>このモジュールの作成者</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>このモジュールの会社またはベンダー</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>このモジュールの著作権に関する声明</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>このモジュールのバージョン番号。</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>このモジュールによって提供される機能の説明</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>このモジュールで必要な PowerShell エンジンの最小バージョン</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>このモジュールに必要な共通言語ランタイム (CLR) の最小バージョン。{0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>このモジュールをインポートする前にグローバル環境にインポートする必要があるモジュール</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>このモジュールをインポートする前に呼び出し元の環境で実行されるスクリプト ファイル (.ps1)。</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>このモジュールのインポート時に読み込まれる型ファイル (.ps1xml)</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>このモジュールのインポート時に読み込まれるフォーマット ファイル (.ps1xml)</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>このモジュールをインポートする前に読み込む必要があるアセンブリ</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>このモジュールでパッケージ化されたすべてのファイルの一覧</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>RootModule/ModuleToProcess で指定されたモジュールに渡す非公開データ。これには、PowerShell で使用される追加のモジュール メタデータを含む PSData ハッシュテーブルも含まれる場合があります。</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>このモジュールに適用されるタグ。これらは、オンライン ギャラリーでのモジュール検出に役立ちます。</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>このプロジェクトのメイン Web サイトの URL。</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>このモジュールのライセンスの URL。</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>このモジュールを表すアイコンの URL。</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>このモジュールの ReleaseNotes</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>このモジュールのプレリリース文字列</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>モジュールがインストール/更新/保存に明示的なユーザーの同意を必要とするかどうかを示すフラグ</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>このモジュールの外部依存モジュール</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>{0} ハッシュテーブルの終わり</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>PrivateData パラメーター値は、次のパラメーター値 Tags、ProjectUri、LicenseUri、IconUri、または ReleaseNotes を含むモジュール マニフェストを作成するためのハッシュ テーブルである必要があります。Tags、ProjectUri、LicenseUri、IconUri、または ReleaseNotes パラメーター値を削除するか、PrivateData の内容をハッシュテーブルにラップします。</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData はハッシュテーブルとして定義する必要がありますが、このモジュール マニフェストではこれをオブジェクトとして定義します。PrivateData の内容をハッシュテーブルにラップすることを検討してください。これにより、後で Tags、ProjectUri、LicenseUri、IconUri、ReleaseNotes の各プロパティをモジュール マニフェストに追加できます。</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>指定された値 '{0}' は無効です。有効な値でもう一度お試しください。</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>このモジュールからエクスポートする関数は、最適なパフォーマンスを得るためにワイルドカードを使用せず、エントリを削除しないでください。エクスポートする関数がない場合は空の配列を使用します。</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>このモジュールからエクスポートするエイリアスは、最適なパフォーマンスを得るためにワイルドカードを使用せず、エントリを削除しないでください。エクスポートするエイリアスがない場合は空の配列を使用します。</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>このモジュールからエクスポートするコマンドレットは、最適なパフォーマンスを得るためにワイルドカードを使用せず、エントリを削除しないでください。エクスポートするコマンドレットがない場合は空の配列を使用します。</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>このモジュールからエクスポートする変数</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>このモジュールからエクスポートする DSC リソース</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>サポートされている PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>このモジュールで必要なプロセッサ アーキテクチャ (なし、X86、Amd64)</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>このモジュールでパッケージ化されたすべてのモジュールの一覧</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>このモジュールで必要な Microsoft .NET Framework の最小バージョン。{0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>このモジュールで必要な PowerShell ホストの名前</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>このモジュールで必要な PowerShell ホストの最小バージョン</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>このモジュールの HelpInfo の URI</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>{0} モジュールは現在の PowerShell セッションで PSDrive を提供しているため、モジュールは削除されませんでした。現在の PSDrive プロバイダーを変更してから、モジュールを削除し直してください。</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>現在のスコープに同じ名前のメンバーが存在するため、コマンドレット '{0}' はインポートされませんでした。</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>現在のスコープに同じ名前のメンバーが存在するため、エイリアス '{0}' はインポートされませんでした。</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>現在のスコープに同じ名前のメンバーが存在するため、関数 '{0}' はインポートされませんでした。</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>現在のスコープに同じ名前のメンバーが存在するため、変数 '{0}' はインポートされませんでした。</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>ワイルドカード文字は、モジュール マニフェスト '{0}' のメンバー 'ModuleToProcess'、'RootModule'、または 'NestedModules' では使用できません。</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>モジュール '{0}' は PowerShell のコア モジュールです。Force パラメーターをコマンドに追加して、コア モジュールを削除します。</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>モジュール マニフェストに 'ModuleToProcess' メンバーと 'RootModule' メンバーの両方を含めることはできません。モジュール マニフェスト ファイルを変更して、'{0}' にあるこれらのメンバーのいずれかを削除してから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>モジュール マニフェスト メンバー 'ModuleToProcess' は非推奨になりました。代わりに 'RootModule' メンバーを使用してください。</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>このモジュールからエクスポートされたコマンドの既定のプレフィックス。Import-Module -Prefix を使用して既定のプレフィックスをオーバーライドします。</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>'Global' パラメーターと 'Scope' パラメーターを同時に指定することはできません。これらのパラメーターのいずれかを削除してから、コマンドを再実行してください。</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>必要なモジュール '{0}' が読み込まれていません。モジュール '{0}' のモジュール マニフェスト '{2}' に、循環依存関係を指す requiredModule '{1}' があります。</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>必要なモジュール '{0}' は、モジュール ディレクトリに有効なモジュール ファイルが見つからなかったため読み込まれませんでした。</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>モジュール {0} の一部のコマンドを CimSession 経由でインポートすることはできません。すべてのコマンドを取得するには、リモート サーバーで PowerShell リモート管理が有効になっていることを確認してから、Import-Module コマンドレットに PSSession パラメーターを追加してみてください。</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>モジュール {0} は、{1} リモート処理セッションを使用してWindows PowerShell に読み込まれます。このモジュールからのコマンドの入力と出力はすべて逆シリアル化されるオブジェクトであることに注意してください。このモジュールを PowerShell に読み込む場合は、'Import-Module -SkipEditionCheck' 構文を使用してください。</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Windows PowerShell のバージョン {0} を検出しました。Windows PowerShell 互換性機能を使用してモジュールを読み込むには、Windows PowerShell 5.1 が必要です。https://aka.ms/WMF5Download から Windows Management Framework (WMF) 5.1 をインストールして、この機能を有効にしてください。</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>モジュール '{0}' は、PowerShell 構成ファイルの 'WindowsPowerShellCompatibilityModuleDenyList' 設定によって Windows PowerShell 互換性機能を使用して読み込むことがブロックされています。</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>モジュール {0} を CimSession 経由でインポートすることはできません。Import-Module コマンドレットの PSSession パラメーターを使用してみてください。</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>{0} のプロセッサ アーキテクチャ値はサポートされていません。New-ModuleManifest コマンドをもう一度実行し、プロセッサ アーキテクチャでサポートされている列挙値 (None、MSIL、X86、Amd64、Arm) のいずれかを指定します</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>リモート コンピューターに対して Get-Module コマンドレットを実行すると、使用可能なモジュールのみを一覧表示できます。ListAvailable パラメーターをコマンドに追加してから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>'{0}' スナップインが既にインポートされているため、'{0}' モジュールはインポートされませんでした。</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>ワイルドカード文字は、モジュール マニフェスト '{0}' のメンバー 'RequiredAssemblies' では使用できません。</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>{1} の {0} キーの値が {2} であり、モジュールに入れ子になったモジュールがあります。CDXML ファイルがルート モジュールの場合、入れ子になったモジュール内のコマンドをエクスポートできないため、Import-Module コマンドは失敗します。CDXML ファイルを NestedModules キーに移動し、コマンドを再試行してください。</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>リモート コマンドからのエラー: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>リモート モジュール '{0}' のプロキシを生成できませんでした。{{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>リモート モジュール {0} を処理できませんでした。{1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>リモート CimSession からモジュール データを受信できませんでした。{0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>有効なモジュール ファイルがモジュール ディレクトリに見つからなかったため、GUID '{1}' およびバージョン '{2}' の必要なモジュール '{0}' は読み込まれませんでした。</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>モジュール検出用の CIM プロバイダーが CIM サーバーで見つかりませんでした。{0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Microsoft .NET Framework のバージョン {0} は、許可されているバージョンの一覧に含まれていないため確認できません。</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>{0} を分析しています。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>初めて使用するモジュールを準備しています。</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>使用可能なモジュールを検索しています</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>UNC 共有 {0} を検索しています。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>リモート コンピューターに対する Get-Module コマンドレットの実行は、パスを含まないモジュール名に対してのみ実行できます。Name パラメーターには、次の要素 '{0}' があります。これはパスに解決されます。Name パラメーターを更新してパス要素を持たないようにしてから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>ListAvailable パラメーターを指定せずに Get-Module コマンドレットを実行することは、パスを含むモジュール名ではサポートされていません。Name パラメーターには、次の要素 '{0}' があります。これはパスに解決されます。Name パラメーターを更新してパス要素を持たないようにしてから、もう一度やり直してください。</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>指定されたモジュール '{0}' が見つかりませんでした。有効なパスを指すように Name パラメーターを更新してから、もう一度やり直してください。</value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>モジュール {0} の RepositorySourceLocation プロパティを設定しています。</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>処理するモジュール '{0}' は、モジュール マニフェスト '{2}' のフィールド '{1}' に一覧表示されましたが、処理されませんでした。{3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>この前提条件は、PowerShell Desktop エディションでのみ有効です。</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>モジュール '{0}' は現在の PowerShell エディション '{1}' をサポートしていません。サポートされているエディションは '{2}' です。このモジュールの互換性を無視するには、'Import-Module -SkipEditionCheck' を使用します。</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>モジュール '{0}' は PowerShell エディション '{1}' をサポートしており、Windows 互換性機能を使用して暗黙的に読み込むことはできません。これは、設定ファイルで無効になっています。'Import-Module -UseWindowsPowerShell' を使用してこのモジュールを Windows PowerShell または 'Import-Module -SkipEditionCheck' で読み込み、現在の PowerShell でモジュールを読み込もうとします。</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>モジュール マニフェストで宣言された試験的機能には、空でない文字列値を指定する必要があります。</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>1 つ以上の無効な試験的特徴名が見つかりました: {0}。モジュールの試験的機能名は、次の規則に従う必要があります: 'ModuleName.FeatureName'。</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>-SkipEditionCheck スイッチ パラメーターは、-ListAvailable スイッチ パラメーターなしでは使用できません。</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>*.ps1 ファイルをモジュールとしてインポートすることは、ConstrainedLanguage モードでは許可されていません。</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>スクリプト モジュール {0} の読み込み中にエラーが発生しました。モジュール マニフェストが言語モードが異なるためです。マニフェスト言語モードは {1} で、モジュール言語モードが {2} です。すべてのモジュール ファイルが署名されているか、アプリケーションの許可リスト構成の一部であることを確認してください。</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>このモジュールでは、ワイルドカード文字を使用して関数をエクスポートするときにドットソース演算子を使用します。これは、システムがアプリケーション検証の適用下にある場合は許可されません。</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>実行中のセッションとは異なる言語モードのモジュールからモジュール メンバーをエクスポートすることはできません。</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>セッションが ConstrainedLanguage モードの間は、新しいモジュールを作成できません。</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>'Core' エディションと互換性のある組み込みモジュール '{0}' が見つかりません。PowerShell 組み込みモジュールが使用可能であることを確認してください。これらは通常、$PSHOME モジュール パスの下に PowerShell パッケージが付属しており、PowerShell が正常に機能するために必要です。</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Export-ModuleMember コマンドレット</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>モジュール '{0}'、言語モード '{1}' が現在のセッション '{2}' とは異なるため、モジュール メンバーのエクスポートは制約付き言語モードで失敗します。</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>モジュールの暗黙的な関数のエクスポート</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>モジュール '{0}' の暗黙的な関数エクスポートは、信頼されている (完全言語モードで実行される) が、セッションが信頼されていない (制約言語モードで実行される) ため、拒否されます。モジュール関数は常にフル ネームで個別にエクスポートすることをお勧めします。</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>モジュールとしてスクリプト ファイルをインポートしています</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>スクリプト ファイル '{0}' をモジュールとしてインポートすることは、ConstrainedLanguage モードでは許可されません。</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>モジュールにドットソース演算子が含まれています</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>モジュール '{0}' のインポートは、ドットソース演算子を使用しながらワイルドカード文字を使用して関数をエクスポートするため、制約付き言語モードで失敗します。</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"モジュールエクスポート関数</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>モジュール '{0}' は、名前のワイルドカード文字を使用して関数をエクスポートします。入れ子になったモジュール関数名は、制約付き言語モードで実行すると削除されます。</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"New-Module コマンドレット</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>信頼されていない制約言語セッションからの新しいモジュールは、FullLanguage スクリプト ブロックの提供をブロックされます。</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"モジュールの言語モードが一致しません</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>親とは異なる言語モードの依存モジュールが読み込まれています。これは、制約付き言語モードでは許可されません。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/PSConfigurationStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/PSConfigurationStrings.ja.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell はセキュリティ上の問題により動作を停止しました: 構成ファイル {0} を読み取れません</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/PSStyleStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/PSStyleStrings.ja.resx
@@ -59,12 +59,12 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="TextContainsContent" xml:space="preserve">
-    <value>The specified string contains printable content when it should only contain ANSI escape sequences: {0}</value>
+    <value>指定された文字列に、ANSI エスケープ シーケンスのみを含める必要があるにもかかわらず、印刷可能なコンテンツが含まれています: {0}</value>
   </data>
   <data name="ProgressWidthTooSmall" xml:space="preserve">
-    <value>The MaxWidth for the Progress rendering must be at least 18 to render correctly.</value>
+    <value>進行状況バーを正しく表示するには、最大幅を 18 以上にする必要があります。</value>
   </data>
   <data name="ExtensionNotStartingWithPeriod" xml:space="preserve">
-    <value>When adding or removing extensions, the extension must start with a period.</value>
+    <value>拡張子を追加または削除するときは、拡張子の先頭にピリオドを付ける必要があります。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/PathUtilsStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/PathUtilsStrings.ja.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>エンコード 'UTF-7' は非推奨です。UTF-8 を使用してください。</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>ファイル {0} は既に存在し、{1} が指定されました。</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>現在のプロバイダー ({0}) がファイルを開くことができないため、ファイルを開けません。</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>パスが複数のファイルに解決されたため、操作を実行できません。このコマンドは、複数のファイルに適用することはできません。</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>ワイルドカード パス {0} がファイルに解決されなかったため、操作を実行できません。</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>不明なエンコード {0}。有効な値は {1} です。</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>ディレクトリ '{0}' は既に存在します。 ディレクトリおよびその中のファイルを上書きする場合は、-Force パラメーターを使用してください。</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>ユーザー モジュールのパスが存在しないため、指定されたモジュール名 '{0}' のモジュール フォルダーを作成できません。</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>次の理由により、モジュール {0} を作成できません: {1}。-OutputModule パラメーターに別の引数を指定して、再試行してください。</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>このモジュールは、互換性のないバージョンの {0} コマンドレットで生成されているため、読み込めません。現在のセッションの {0} コマンドレットを使用してモジュールを生成し、もう一度読み込んでください。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/RemotingErrorIdStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/RemotingErrorIdStrings.ja.resx
@@ -1471,7 +1471,7 @@ Microsoft.PowerShell や Register-PSSessionConfiguration コマンドレット�
     <value>指定された出力ストリーム セットが無効です。{0} のみが出力ストリームとしてサポートされます。</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>指定された WSMAN_SENDER_DETAILS は無効です。null 値の WSMAN_SENDER_DETAILS を処理できません。</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
     <value>指定されたシェル コンテキストが無効です。</value>
@@ -1498,7 +1498,7 @@ Microsoft.PowerShell や Register-PSSessionConfiguration コマンドレット�
     <value>PowerShell プラグインは、オプション {0} を理解していません。クライアントがビルド {1} および PowerShell のプロトコル バージョン {2} と互換性があることを確認します。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>{0} という名前のオプションがクライアントに必要です。クライアントがビルド {1} および PowerShell のプロトコル バージョン {2} と互換性があることを確認します。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
     <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell プラグインは、クライアントによって要求されたプロトコル バージョン {2} をサポートしていません。&lt;/PSProtocolVersionError&gt;</value>
@@ -1507,7 +1507,7 @@ Microsoft.PowerShell や Register-PSSessionConfiguration コマンドレット�
     <value>WSMan サービスへのコンテキストの報告中に、Powershell プラグインで致命的なエラーが発生しました。</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>マネージド サーバー セッションを作成できません。</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
     <value>PowerShell プラグインで、シャットダウン通知の待機ハンドルの登録中に致命的なエラーが発生しました。</value>

--- a/src/System.Management.Automation/resources/ja/RunspaceStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/RunspaceStrings.ja.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>この操作では、実行空間の状態が無効です。</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>実行空間が BeforeOpen 状態ではないため、開くことができません。実行空間の現在の状態は '{0}' です。</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>実行空間プールがオープン状態ではないため、操作を実行できません。実行空間の現在の状態は '{0}' です。</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>実行空間がオープン状態ではないため、パイプラインを呼び出せません。実行空間の現在の状態は '{0}' です。</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>この操作では、パイプラインの状態が無効です。</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>パイプラインは既に呼び出されているため、呼び出せません。</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>パラメーターの有効な値は PipelineResultTypes.Output です。</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>パイプラインにコマンドが含まれていません。</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>パイプラインは既に実行中のものがあるため実行されませんでした。Pipelines は同時に実行できません。</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>入れ子になったパイプラインを非同期的に呼び出すことはできません。呼び出しメソッドを使用してください。</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>入れ子になったパイプラインは、実行中のパイプライン内からのみ実行してください。</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy メソッド呼び出しの進行中は、実行空間を閉じることはできません。</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy メソッド呼び出しの進行中は、パイプラインを呼び出すことはできません。</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>SessionStateProxy メソッド呼び出しが進行中です。SessionStateProxy メソッドの同時呼び出しは許可されていません。</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>パイプラインは既に実行されています。SessionStateProxy メソッドの同時呼び出しは許可されていません。</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>このプロパティは、実行空間を開いた後は変更できません。</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>この実行空間の作成に使用された InitialSessionState オブジェクトで指定されたモジュール '{0}' の処理中に、1 つ以上のエラーが発生しました。全エラーの一覧については、ErrorRecords プロパティを参照してください。最初のエラーは次のとおりです: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>スレッド オプションを変更できるのは、アパートメント状態がマルチスレッド アパートメント (MTA) で、現在のオプションが UseNewThread または UseCurrentThread、かつ新しい値が ReuseThread の場合のみです。</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>言語モードが {1} または {2} の場合、{0}を false にすることはできません。</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>ローカル専用の実行空間は切断できません。</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>接続操作は、ローカルの実行空間ではサポートされていません。</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>セッションはビジー状態です。利用可能になり次第、セッションに接続されます。Enter-PSSession コマンドをキャンセルするには、Ctrl キーを押しながら C キーを押します。</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>コマンドを完了できません。スクリプトの呼び出しは、このセッション構成ではサポートされていません。これは、セッション構成が no-language モードの場合に発生することがあります。</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>ローカルの実行空間では、切断および接続の操作は使用できません。</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>実行空間がオープンの状態ではないため、パイプラインを接続できません。 実行空間の現在の状態は '{0}' です。</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>RemoteRunspace を構築できません。指定された RunspacePool オブジェクトが無効です。</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>この実行空間に関連付けられている切断されたコマンドはありません。</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>リモート コンピューターでは切断操作はサポートされていません。切断をサポートするには、リモート コンピューターで Windows PowerShell 3.0 以降の Windows PowerShell を実行し、WSMan トランスポートを使用している必要があります。</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>セッションが切断済みの状態ではないか、接続に使用できないため、PSSession に接続できません。</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>パラメーターの値を PipelineResultTypes.None または PipelineResultTypes.Output にすることはできません。</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>パラメーターの有効な値は PipelineResultTypes.Output または PipelineResultTypes.Null です。</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>デバッグ ストリームのリダイレクトは、対象のリモート コンピューターではサポートされていません。</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>詳細ストリームのリダイレクトは、対象のリモート コンピューターではサポートされていません。</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>警告ストリームのリダイレクトは、対象のリモート コンピューターではサポートされていません。</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>情報ストリームのリダイレクトは、対象のリモート コンピューターではサポートされていません。</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>コマンドまたはスクリプトの実行中でビジー状態のセッションに入りました。 出力はジョブ "{0}" にルーティングされるため、コンソールには表示されません。 実行中のコマンドの完了を待つか、Ctrl-C を押してキャンセルし、入力プロンプトを表示します。
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>コマンドまたはスクリプトの実行がビジー状態のセッションに入りました。出力はコンソールに表示されます。 実行中のコマンドの完了を待つか、Ctrl-C を押してキャンセルし、入力プロンプトを表示します。
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>実行中のコマンドまたはスクリプト内のデバッグ ブレークポイントで現在停止しているセッションに入りました。 PowerShell コマンド ライン デバッガーを使用して、デバッグを続行してください。
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace は LocalRunspace である必要があります</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>静的な PrimaryRunspace プロパティは 1 回しか設定できず、既に設定されています。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/SessionStateStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/SessionStateStrings.ja.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>プロバイダーの Start メソッドから返された情報が、渡されたプロバイダーとは異なるプロバイダーに対して返されたため、返された情報を処理できません。</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>プロバイダーの Start メソッドから返された情報が null 値のため、返された情報を処理できません。</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetItems 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで SetItems 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>SetItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで ClearItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで InvokeDefaultAction 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>InvokeDefaultAction 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで Exists 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ItemExists 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで IsValidPath 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで IsItemContainer 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで RemoveItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetChildItems 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetChildItems 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetChildNames 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetChildNames 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで RenameItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>RenameItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで NewItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>NewItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで HasChildItems 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで CopyItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>CopyItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetParentPath 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで NormalizeRelativePath 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで MakePath 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetChildName 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで MoveItem 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>MoveItem 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetProperty 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで SetProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>SetProperty 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで ClearProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ClearProperty 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで NewProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>NewProperty 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで RemoveProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>RemoveProperty 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで CopyProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーに対して CopyProperty 操作の動的パラメーターを取得できません。{2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで MoveProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーに対して MoveProperty 操作の動的パラメーターを取得できません。{2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで RenameProperty 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーの RenameProperty の動的パラメーターを取得できません。 {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーのコンテンツ リーダーを取得できません。{2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーに対して GetContentReader 操作の動的パラメーターを取得できません。{2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーのコンテンツ ライターを取得できません。{2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>パス '{1}' の '{0}' プロバイダーに対して GetContentWriter 操作の動的パラメーターを取得できません。{2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>ディレクトリであるため、コンテンツを取得できません: '{0}'。代わりに 'Get-ChildItem' を使用してください。</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>ディレクトリであるため、コンテンツを書き込めません: '{0}'。</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>後ろに進む場所の履歴は残っていません。</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>前に進む場所の履歴は残っていません。</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack が空です。</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで ClearContent 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>'{0}' はディレクトリであるため、その内容をクリアできません。Clear-Content はファイルでのみサポートされます。</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ClearContent 操作の動的パラメーターは、パス '{1}' の '{0}' プロバイダーから取得できません。{2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで GetSecurityDescriptor 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで SetSecurityDescriptor 操作を実行しようとしましたが、パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>'{0}' プロバイダーで開始操作を実行できませんでした。{1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>'{0}' プロバイダーで InitializeDefaultDrives 操作を実行できませんでした。</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>'{0}' プロバイダーで NewDrive 操作を実行しようとしましたが、ルート '{1}' のドライブに対して失敗しました。{2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>'{0}' プロバイダーの NewDrive の動的パラメーターを取得できません。{1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>'{0}' プロバイダーでの RemoveDrive の呼び出しに失敗しました。{1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>ドライブ '{0}' を削除できません。プロバイダー '{1}' によって防止されました。</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>パス '{0}' は、ベース '{1}' の外側にある項目を参照しました。</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーのコンテンツ ライターで Seek の呼び出しがパス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーのコンテンツ リーダーまたはライターで Close を呼び出せませんでした。パス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーのコンテンツ リーダーで Read の呼び出しがパス '{1}' に失敗しました。{2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>'{0}' プロバイダーのコンテンツ ライターで Write の呼び出しがパス '{1}' に対して失敗しました。{2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>プロバイダー '{0}' を使用して、変数構文を使用してデータを取得または設定することはできません。{2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>プロバイダーを使用して、変数構文を使用してデータを取得または設定することはできません。{2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>エイリアス {0} は読み取り専用または定数であり、書き込むことができないため、エイリアスは書き込み可能ではありません。</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>読み取り専用または定数であるため、関数 {0} に書き込めません。</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>変数 {0} は読み取り専用または定数であるため、上書きできません。</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>変数 '${0}' はプライベート変数であるため、アクセスできません。</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>非公開コマンドであるため、コマンド '{0}' にアクセスできません。</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>プライベート コマンドであるため、コマンドにアクセスできません。</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>セッション状態リソースは非公開リソースであるため、アクセスできません。</value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>エイリアス {0} が定数または読み取り専用であるため、エイリアスは削除されませんでした。</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>関数 {0} は定数であるため、削除できません。</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>変数 {0} は定数または読み取り専用であるため、削除できません。変数が読み取り専用の場合は、Force オプションを指定して操作を再試行してください。</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>エイリアス {0} は定数のため変更できません。</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>エイリアス {0} は読み取り専用のため変更できません。</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>関数 {0} は定数であるため、変更できません。</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>関数 {0} は読み取り専用のため、変更できません。</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>エイリアス {0} は、作成後に定数にすることはできません。エイリアスは作成時にのみ定数にできます。</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>既存の関数 {0} を定数にすることはできません。関数は、作成時にのみ定数にすることができます。</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>既存の変数 {0} を定数にすることはできません。変数は、作成時にのみ定数にすることができます。</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>AllScope オプションをエイリアス '{0}' から削除することはできません。</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>AllScope オプションを関数 '{0}' から削除することはできません。</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>AllScope オプションを変数 '{0}' から削除することはできません。</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>関数定義 '{0}' にスコープ修飾子が含まれていましたが、関数名が含まれていませんでした。</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>プロバイダー {0} を削除できません。プロバイダー {0} を削除する前に、プロバイダー {0} に関連付けられているすべてのドライブを削除する必要があります。</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>ドライブ名に無効な次の文字が 1 つ以上含まれているため、ドライブ名を処理できません: ;~ / \ .:</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>プロバイダーが新しいドライブの作成を許可していないため、新しいドライブの作成に失敗しました。</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>指定された値 '{0}' は複数の場所スタックに解決されました。</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>場所スタック '{0}' が見つかりません。存在しないか、コンテナーではありません。</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>パス '{0}' は存在しないため、見つかりません。</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>エイリアス '{0}' が存在しないため、エイリアスが見つかりません。</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>パス '{0}' が複数のコンテナーに解決されたため、場所を設定できません。一度に設定できるコンテナーは 1 つだけです。</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>変数パス '{0}' が複数の項目に解決されたため、変数を処理できません。変数値は、一度に 1 つの項目のみを取得または設定できます。</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>ドライブが見つかりません。'{0}' という名前のドライブは存在しません。</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>'{0}' という名前のプロバイダーが見つかりません。</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>'{0}' という名前のプロバイダーが見つかりません。名前の形式が正しくありません。プロバイダー名には、英数字、または 1 つの '\' の後に英数字が続く PowerShell スナップイン名のみを指定できます。</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>'{0}' が複数のプロバイダー名に解決されました。一致の可能性は次のとおりです:{1}。</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>プロバイダーのインスタンスの作成でエラーが発生しました。'{0}' のプロバイダー型名がアセンブリに見つかりませんでした。</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>無効な次の文字が 1 つ以上含まれているため、指定されたプロバイダー名 '{0}' を使用できません: \ [ ] ?* :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>プロバイダー '{0}' のインスタンスの作成中にエラーが発生しました。{1}</value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>'{0}' という名前の変数が見つかりません。</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>'{0}' という名前のトレース ソースが見つかりません。</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>'{0}' という名前のドライブは既に存在します。</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>名前 '{0}' の変数は既に存在します。</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>'{0}' という名前のエイリアスが既に存在するため、エイリアスは使用できません。</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>'{0}' という名前のコマンドレット プロバイダーが既に存在するため、コマンドレット プロバイダーを登録できません。</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>パスはファイル システム パスを参照していません。</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>グローバル スコープを削除できません。</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>スコープ番号 '{0}' がアクティブなスコープの数を超えています。</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>PSDriveInfo を比較できません。PSDriveInfo インスタンスは、別の PSDriveInfo インスタンスとのみ比較できます。</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>コマンドレット プロバイダーは、出力のストリーミングに使用するコマンドレットが指定されていないため、結果をストリームできません。</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>コマンドレット プロバイダーは、エラーのストリーミングに使用するコマンドレットが指定されていないため、結果をストリームできません。</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>このプロバイダーのホームの場所が設定されていません。ホームの場所を設定するには、"(get-psprovider'{0}') を呼び出します。ホーム = 'path'"。</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>パスが不適切な形式です。プロバイダー パスには、プロバイダー ID と "::" の後にプロバイダー固有のパスが含まれている必要があります。</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>移動先のパスは 1 つのパスにのみ解決できるため、項目を移動できません。</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>ソース パスと宛先パスが同じプロバイダーに解決されなかったため、項目を移動できません。</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>ソース パスが 1 つ以上の項目を指しており、宛先パスがコンテナーではないため、項目を移動できません。宛先パスがコンテナーであることを確認してから、もう一度やり直してください。</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>宛先が複数のパスに解決されたため、項目を移動できません。1 つの宛先に解決される宛先パスを指定してから、もう一度お試しください。</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>コンテナーを既存のリーフ項目にコピーすることはできません。</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>コンテナーを別のコンテナーにコピーすることはできません。-Recurse パラメーターまたは -Container パラメーターが指定されていません。</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>ソース パスと宛先パスが同じプロバイダーに解決されませんでした。</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>パスが複数の項目に解決されたため、項目の名前を変更できません。一度に名前を変更できる項目は 1 つだけです。</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>プロバイダーでエラーが発生したため、プロバイダー '{0}' を使用してパス '{1}' を解決することはできません。</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>インターフェイスを使用できません。IContentCmdletProvider インターフェイスは、このプロバイダーによって実装されていません。</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>インターフェイスを使用できません。IPropertyCmdletProvider インターフェイスは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>インターフェイスを使用できません。IDynamicPropertyCmdletProvider インターフェイスは、このプロバイダーによって実装されていません。</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>NavigationCmdletProvider メソッドは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>プロバイダー メソッドが処理されませんでした。ContainerCmdletProvider メソッドは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>メソッドを呼び出せません。ItemCmdletProvider メソッドは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>DriveCmdletProvider メソッドは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>プロバイダーがこの操作をサポートしていないため、プロバイダー操作が停止しました。</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>プロバイダーが 'Depth' パラメーターをサポートしていないため、プロバイダー操作が停止しました。</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>メソッドを呼び出すことはできません。コンテンツ シーク メソッドは、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>ClearContent 操作を実行できません。ClearContent 操作は、このプロバイダーではサポートされていません。</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>プロバイダーは資格情報の使用をサポートしていません。資格情報を指定せずに操作をもう一度実行してください。</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>FileSystem プロバイダーは、New-PSDrive コマンドレットでのみ資格情報をサポートします。資格情報を指定せずに操作をもう一度実行してください。</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>プロバイダーはトランザクションをサポートしていません。-UseTransaction パラメーターを指定せずに操作をもう一度実行します。</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>メソッドを呼び出すことはできません。プロバイダーはフィルターの使用をサポートしていません。</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>ドライブを作成できません。プロバイダーは資格情報の使用をサポートしていません。</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>パス '{0}' の項目は既に存在します。</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>項目をコピーできません。パス '{0}' の項目が存在しません。</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>パス '{0}' の項目が存在しません。</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>セッション状態に格納されているエイリアスのビューを含むドライブ</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>プロセスの環境変数のビューを含むドライブ</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>セッション状態に格納されている関数のビューを含むドライブ</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>セッション状態に格納されているそれらの変数のビューを含むドライブ</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>現在のユーザーの一時ディレクトリ パスにマップされるドライブ</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>ターゲット値が指定されていないため、リンク '{0}' を作成できません。</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>null 変数への参照は、常に null 値を返します。割り当ては無効です。</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>セッションで保持する履歴オブジェクトの最大数</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>関数 {0} が読み取り専用または定数であるため、関数の名前を変更できません。</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>エイリアスの名前を変更できません。エイリアス {0} は読み取り専用または定数です。</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>変数 {0} が読み取り専用または定数であるため、変数の名前を変更できません。</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>ローカル変数 {0} にオプションを設定できません。New-Variable を使用して、オプションを設定できる変数を作成してください。</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>コマンドレット {0} は読み取り専用のため変更できません。</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>変数が最適化されており、削除できないため、変数 {0} を削除できません。Remove-Variable コマンドレット (エイリアスなし) を使用するか、変数を削除するために使用しているコマンドをドットソース化してみてください。</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>変数が最適化されているため、変数 {0} を上書きできません。New-Variable コマンドレットまたは Set-Variable コマンドレット (エイリアスなし) を使用するか、変数の設定に使用しているコマンドをドットソースで指定します。</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>{0} パラメーターと {1} パラメーターを一緒に使用することはできません。パラメーターを 1 つだけ指定してください。</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Tail パラメーターは現在、FileSystem プロバイダーでのみサポートされています。</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>'{0}' という名前のコマンドとコマンドの種類 '{1}' が既に存在するため、エイリアスは使用できません。</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>ソフトウェアを実行できません。アクセス許可が拒否されました。</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>'-{0}' と '-{1}' は相互に排他的であり、同時に指定することはできません。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>パス '{0}' が無効です。リモート コピー操作では、絶対パスのみがサポートされます。</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>リモート パス '{0}' を検証できません。</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>セッション {0} が {1} に設定されているため、操作を実行できません。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>'{0}' パラメーターを null 値や空にすることはできません。</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>セッション状態変数</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>変数 '{0}' スコープを AllScope に変更または作成することは、ConstrainedLanguage モードでは禁止されます。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/TabCompletionStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/TabCompletionStrings.ja.resx
@@ -118,154 +118,154 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>リモート実行空間に TypeTable インスタンスが含まれていないため、タブ補完の結果を正しく逆シリアル化できません。</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>CompletionResult 型の null インスタンスのプロパティにアクセスできません。</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>ビットごとの NOT</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>論理 Not。その後のステートメントを否定します。</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等しい - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランドと等しい値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと等しい場合は TRUE を返します。</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等しい - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランドと等しい値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと等しい場合は TRUE を返します。</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等しい - 大文字と小文字を区別します。左オペランドがコレクションの場合は、右オペランドと等しい値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと等しい場合は TRUE を返します。</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>等しくない - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランドと等しくない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと等しくない場合は TRUE を返します。</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>等しくない - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランドと等しくない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと等しくない場合は TRUE を返します。</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>等しくない - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右オペランドと等しくない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと等しくない場合は TRUE を返します。</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>以上 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランド以上の値をコレクションから返します。それ以外の場合、左オペランドが右オペランド以上の場合は TRUE を返します。</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>以上 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランド以上の値をコレクションから返します。それ以外の場合、左オペランドが右オペランド以上の場合は TRUE を返します。</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>以上 - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右オペランド以上の値をコレクションから返します。それ以外の場合、左オペランドが右オペランド以上の場合は TRUE を返します。</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>より大きい - 大文字と小文字が区別されません。左オペランドがコレクションの場合は、右オペランドより大きい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより大きい場合は TRUE を返します。</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>より大きい - 大文字と小文字が区別されません。左オペランドがコレクションの場合は、右オペランドより大きい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより大きい場合は TRUE を返します。</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>より大きい - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右オペランドより大きい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより大きい場合は TRUE を返します。</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>より小さい - 大文字と小文字が区別されません。左オペランドがコレクションの場合、右オペランドより小さい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより小さい場合は TRUE を返します。</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>より小さい - 大文字と小文字が区別されません。左オペランドがコレクションの場合、右オペランドより小さい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより小さい場合は TRUE を返します。</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>より小さい - 大文字と小文字が区別されます。左オペランドがコレクションの場合、右オペランドより小さい値をコレクションから返します。それ以外の場合、左オペランドが右オペランドより小さい場合は TRUE を返します。</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>以下 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランド以下の値をコレクションから返します。それ以外の場合は、左オペランドが右オペランド以下であれば TRUE を返します。</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>以下 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右オペランド以下の値をコレクションから返します。それ以外の場合は、左オペランドが右オペランド以下であれば TRUE を返します。</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>以下 - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右オペランド以下の値をコレクションから返します。それ以外の場合は、左オペランドが右オペランド以下であれば TRUE を返します。</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>ワイルドカード一致演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>ワイルドカード一致演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>ワイルドカード照合演算子 - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>ワイルドカード一致演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>ワイルドカード一致演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>ワイルドカード照合演算子 - 大文字と小文字が区別されます。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別します。左オペランドがコレクションの場合は、右側のオペランドに一致する値をコレクションから返します。それ以外の場合は、左オペランドが右オペランドと一致する場合は TRUE を返します。</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別しません。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>正規表現照合演算子 - 大文字と小文字を区別します。左オペランドがコレクションの場合は、右側のオペランドと一致しない値をコレクションから返します。それ以外の場合、左オペランドが右オペランドと一致しない場合は TRUE を返します。</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Replace 演算子 - 大文字と小文字を区別しません。左オペランドを変更します。例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Replace 演算子 - 大文字と小文字を区別しません。左オペランドを変更します。例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Replace 演算子 - 大文字と小文字を区別します。左オペランドを変更します。例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (右オペランド) が左オペランドの少なくとも 1 つの値と完全に一致する場合に TRUE を返します。</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (右オペランド) が左オペランドの少なくとも 1 つの値と完全に一致する場合に TRUE を返します。</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別します。テスト値 (右オペランド) が左オペランドの少なくとも 1 つの値と完全に一致する場合にのみ TRUE を返します。</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (右オペランド) が左オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (右オペランド) が左オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別します。テスト値 (右オペランド) が左オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (左オペランド) が右オペランドの少なくとも 1 つの値と完全に一致する場合に TRUE を返します。</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (左オペランド) が右オペランドの少なくとも 1 つの値と完全に一致する場合に TRUE を返します。</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別します。テスト値 (左オペランド) が右オペランドの少なくとも 1 つの値と完全に一致する場合に TRUE を返します。</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別します。テスト値 (左オペランド) が右オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別しません。テスト値 (左オペランド) が右オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Containment 演算子 - 大文字と小文字を区別します。テスト値 (左オペランド) が右オペランドの値と完全に一致しない場合に TRUE を返します。</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>分割 -大文字と小文字の区別しません。1 つ以上の文字列を部分文字列に分割します。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -273,7 +273,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>分割 -大文字と小文字の区別しません。1 つ以上の文字列を部分文字列に分割します。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -281,7 +281,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
+    <value>分割 - 大文字と小文字を区別します。1 つ以上の文字列を部分文字列に分割します。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -289,103 +289,103 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>左オペランドが指定した.NET Framework 型 (右オペランド) のインスタンスでない場合は TRUE を返します。</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>左オペランドが指定した .NET Framework 型 (右オペランド) のインスタンスである場合は TRUE を返します。</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>左オペランドを指定した.NET Framework 型 (右オペランド) に変換します。</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>文字列オブジェクトの format メソッドを使用して文字列を書式設定します。</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>論理 AND。両方のステートメントが TRUE の場合は TRUE を返します。</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>ビットごとの AND</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>論理 OR。いずれかのステートメントまたは両方のステートメントが TRUE の場合は TRUE です。</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>ビットごとの OR (両端を含む)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>論理排他的 or。ステートメントの 1 つが TRUE で、もう一方が FALSE の場合は TRUE を返します。</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>ビットごとの OR (排他的)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
+    <value>結合 - 複数の文字列を 1 つの文字列に結合します。
 -Join &lt;String[]&gt;
 &lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>左ビット演算子をシフトします。右端のビット位置に 0 を挿入します。</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>右ビット演算子をシフトします。左端のビット位置に 0 を挿入します。符号付き値の場合、符号ビットは保持されます。</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+作成するプロパティの名前を指定します。</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+作成するプロパティの名前を指定します。</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
     <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+新しいプロパティの値を計算するために使用されるスクリプト ブロックです。</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+列に値を表示する方法を定義します。
+有効な値は、'left'、'center'、または 'right' です。</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+値を出力用に書式設定する方法を定義する書式指定文字列を指定します。</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+値を表示するときのテーブルの列の最大幅を指定します。
+値は 0 より大きくする必要があります。</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+深度キーは、プロパティごとの展開の深さを指定します。</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+1 つ以上のプロパティの並べ替え順序を指定します。</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+1 つ以上のプロパティの並べ替え順序を指定します。</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+イベントを取得するログ名を指定します。
+ワイルドカードがサポートされます。</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+イベントを取得するイベント ログ プロバイダーを指定します。
+ワイルドカードがサポートされます。</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+イベントを取得するログ ファイルのファイル パスを指定します。
+有効なファイル形式: .etl、.evt、および .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
     <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+指定したキーワード ビットマスクを持つイベントを選択します。
+標準キーワードは次のとおりです:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,213 +398,213 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+指定したイベント ID を持つイベントを選択します。</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
-2: Error
-3: Warning
-4: Informational
-5: Verbose</value>
+指定したログ レベルのイベントを選択します。
+次のログ レベルが有効です: 
+1: クリティカル
+2: エラー
+3: 警告
+4: 情報
+5: 詳細</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created after the specified date and time.</value>
+指定した日時より後に作成されたイベントを選択します。</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created before the specified date and time.</value>
+指定した日時より前に作成されたイベントを選択します。</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+指定したユーザーによって生成されたイベントを選択します。
+これは、SID または DOMAIN\USERNAME または USERNAME@DOMAIN の形式のドメイン名とユーザー名を表す文字列のいずれかです</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
     <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+EventData セクションで指定した値のいずれかを持つイベントを選択します。</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
     <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+ハッシュテーブルで指定された値と一致するイベントを除外します。</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[string] または [hashtable]
+スクリプトに必要な PowerShell モジュールの配列を指定します。
+各要素には、モジュール名を値として含む文字列、または次のキーを持つハッシュテーブルを指定できます:
+名前: モジュールの名前
+GUID: モジュールの GUID
+次のいずれか:
+ModuleVersion: モジュールの最小許容バージョンを指定します。
+RequiredVersion: モジュールの正確で必要なバージョンを指定します。
+MaximumVersion: モジュールの許容される最大バージョンを指定します。</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
     <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+スクリプトに必要な PowerShell エディションを指定します。
+有効な値は "Core" と "Desktop" です</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
     <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+PowerShell が Windows で管理者として実行されている必要があることを指定します。
+これは、#requires ステートメント行の最後のパラメーターである必要があります。</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
     <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+スクリプトに必要な PowerShell の最小バージョンを指定します。</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>スクリプトの実行に PowerShell 7 以降が必要であることを指定します。</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>スクリプトの実行に Windows PowerShell 5.1 が必要であることを指定します。</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
     <value>[string]
-Required. Specifies the module name.</value>
+必須です。モジュール名を指定します。</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
     <value>[string]
-Optional. Specifies the GUID of the module.</value>
+省略可能です。モジュールの GUID を指定します。</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+モジュールの最小許容バージョンを指定します。</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies an exact, required version of the module.</value>
+モジュールの正確で必要なバージョンを指定します。</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+モジュールの許容される最大バージョンを指定します。</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>関数またはスクリプトの簡単な説明です。
+このキーワードは、各トピックで 1 回だけ使用できます。</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>関数またはスクリプトの詳細な説明。
+このキーワードは、各トピックで 1 回だけ使用できます。</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
     <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+パラメーターの説明。
+関数またはスクリプトの構文の各パラメーターに .PARAMETER キーワードを追加してください。</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>関数またはスクリプトを使用するサンプル コマンドです。必要に応じて、サンプル出力と説明が続きます。
+各例に対してこのキーワードを繰り返してください。</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>関数またはスクリプトにパイプできる .NET 型のオブジェクトです。
+入力オブジェクトの説明を含めることもできます。</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>コマンドレットが返すオブジェクトの .NET 型。
+返されるオブジェクトの説明を含めることもできます。</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>関数またはスクリプトに関する追加情報です。</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>関連トピックの名前。
+関連する各トピックの .LINK キーワードを繰り返します。
+.Link キーワード コンテンツには、同じヘルプ トピックのオンライン バージョンへの URI を含めることもできます。</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>関数またはスクリプトが使用するテクノロジーまたは機能の名前、または関連するテクノロジーまたは機能の名前です。</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>ヘルプ トピックのユーザー ロールの名前です。</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>関数の使用目的を説明するキーワードです。</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+指定したコマンドのヘルプ トピックにリダイレクトします。</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+.ForwardHelpTargetName の項目のヘルプ カテゴリを指定します</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+ヘルプ トピックを含むセッションを指定します。
+PSSession オブジェクトを含む変数を入力してください。</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+関数またはスクリプトが XML ファイルにドキュメント化されている場合は、.ExternalHelp キーワードが必要です。</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>読み込む .NET アセンブリへのパスを指定します。
 
-using assembly &lt;.NET-assembly-path&gt;</value>
+アセンブリ &lt;NET-assembly-path&gt; を使用します</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>クラスを読み込む PowerShell モジュールを指定します。
 
-using module &lt;ModuleName or Path&gt;
+モジュール &lt;ModuleName or Path&gt; を使用しています
 
-using module &lt;ModuleSpecification hashtable&gt;</value>
+モジュール &lt;ModuleSpecification hashtable&gt; を使用しています</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>型を解決する .NET 名前空間または名前空間エイリアスを指定します。
 
-using namespace &lt;.NET-namespace&gt;
+名前空間 &lt;NET-namespace&gt; を使用します 
 
-using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
+名前空間 &lt;AliasName&gt; = &lt;.NET-namespace&gt; を使用します</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>.NET 型のエイリアスを指定します。
 
-using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
+型 &lt;AliasName&gt; = &lt;.NET-type&gt; を使用しています</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>通常の文字列。</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>値が読み出されるときに展開される環境変数の展開されない参照を含む文字列です。</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>任意の形式のバイナリ データ。</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>32 ビットの2 進数。</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>文字列の配列。</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>64 ビットの 2 進数。</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>サポートされていないレジストリ データ型。</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
-    <value>',' - Comma</value>
+    <value>',' - コンマ</value>
   </data>
   <data name="SeparatorCommaSpaceToolTip" xml:space="preserve">
-    <value>', ' - Comma-Space</value>
+    <value>', ' -コンマと空白</value>
   </data>
   <data name="SeparatorSemiColonToolTip" xml:space="preserve">
-    <value>';' - Semi-Colon</value>
+    <value>';' - セミコロン</value>
   </data>
   <data name="SeparatorSemiColonSpaceToolTip" xml:space="preserve">
-    <value>'; ' - Semi-Colon-Space</value>
+    <value>'; ' - セミコロンと空白</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
-    <value>{0} - Newline</value>
+    <value>{0} - 改行</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
-    <value>'-' - Dash</value>
+    <value>'-' - ダッシュ</value>
   </data>
   <data name="SeparatorSpaceToolTip" xml:space="preserve">
-    <value>' ' - Space</value>
+    <value>' ' - 空白</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ja/TransactionStrings.ja.resx
+++ b/src/System.Management.Automation/resources/ja/TransactionStrings.ja.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>トランザクションを使用できません。アクティブなトランザクションはありません。</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>トランザクションをコミットできません。アクティブなトランザクションはありません。</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>アクティブなトランザクションがないため、トランザクションをロールバックできません。</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>トランザクションをロールバックできません。トランザクションは既にコミットされています。</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>トランザクションをコミットできません。トランザクションは既にコミットされています。</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>トランザクションをコミットできません。トランザクションはロールバックされたか、タイムアウトしました。</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>トランザクションをロールバックできません。トランザクションは既にロールバックされたか、タイムアウトしています。</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>アクティブなトランザクションを設定できません。トランザクションが作成されていません。</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>アクティブなトランザクションを設定できません。アクティブなトランザクションがロールバックされたか、タイムアウトしました。</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>このコマンドレットにはアクティブなトランザクションが必要です。現在のトランザクションは既にコミットまたはロールバックされています。</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>このコマンドレットにはトランザクションが必要です。-UseTransaction パラメーターを指定して、コマンドをもう一度実行してください。</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>トランザクションを使用できません。トランザクションが開始されていません。</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>トランザクションを使用できません。トランザクションがコミットされました。</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>トランザクションを使用できません。トランザクションはロールバックされたか、タイムアウトしました。</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>トランザクションを使用できません。トランザクションがタイムアウトしました。</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>ベース トランザクションが設定されていません。</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>ベース トランザクションがアクティブではありません。</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>他のトランザクションが作成された後は、ベース トランザクションを設定できません。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/AutomationExceptions.ko.resx
+++ b/src/System.Management.Automation/resources/ko/AutomationExceptions.ko.resx
@@ -118,93 +118,93 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Argument" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is not valid. Change the value of the "{0}" argument and run the operation again.</value>
+    <value>인수 "{0}"의 값이 유효하지 않아 인수를 처리할 수 없습니다. "{0}" 인수의 값을 변경한 다음 작업을 다시 실행하세요.</value>
   </data>
   <data name="InvalidScopeIdArgument" xml:space="preserve">
-    <value>Cannot process argument because the value of parameter "{0}" is not valid. Valid values are "Global", "Local", or "Script", or a number relative to the current scope (0 through the number of scopes where 0 is the current scope and 1 is its parent). Change the value of the "{0}" parameter and run the operation again.</value>
+    <value>매개 변수 "{0}"의 값이 유효하지 않아 인수를 처리할 수 없습니다. 유효한 값은 "Global", "Local", "Script" 또는 현재 범위와 관련된 수(0부터 범위 수까지, 여기서 0은 현재 범위이고 1은 그 상위 범위)입니다. "{0}" 매개 변수의 값을 변경한 다음 작업을 다시 실행하세요.</value>
   </data>
   <data name="ArgumentNull" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is null. Change the value of argument "{0}" to a non-null value.</value>
+    <value>인수 "{0}"의 값이 null이므로 인수를 처리할 수 없습니다. 인수 "{0}"의 값을 null이 아닌 값으로 변경하세요.</value>
   </data>
   <data name="ArgumentOutOfRange" xml:space="preserve">
-    <value>Cannot process argument because the value of argument "{0}" is out of range. Change argument "{0}" to a value that is within range.</value>
+    <value>인수 "{0}"의 값이 범위를 벗어났으므로 인수를 처리할 수 없습니다. 인수 "{0}"을(를) 범위 내의 값으로 변경하세요.</value>
   </data>
   <data name="InvalidOperation" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not valid. Remove operation "{0}", or investigate why it is not valid.</value>
+    <value>작업 "{0}"이(가) 유효하지 않아 작업을 수행할 수 없습니다. 작업 "{0}"을(를) 제거하거나 유효하지 않은 이유를 확인하세요.</value>
   </data>
   <data name="NotImplemented" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not implemented.</value>
+    <value>작업 "{0}"이(가) 구현되지 않았으므로 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="NotSupported" xml:space="preserve">
-    <value>Cannot perform operation because operation "{0}" is not supported.</value>
+    <value>"{0}" 작업은 지원되지 않으므로 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="ObjectDisposed" xml:space="preserve">
-    <value>Cannot perform operation because object "{0}" has already been disposed.</value>
+    <value>개체 "{0}"이(가) 이미 삭제되었으므로 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="ScriptBlockInvokeOnOneClauseOnly" xml:space="preserve">
-    <value>The script block cannot be invoked because it contains more than one clause. The Invoke() method can only be used on script blocks that contain a single clause.</value>
+    <value>스크립트 블록에 절이 두 개 이상 포함되어 있으므로 호출할 수 없습니다. Invoke() 메서드는 단일 절을 포함한 스크립트 블록에서만 사용할 수 있습니다.</value>
   </data>
   <data name="CanConvertOneClauseOnly" xml:space="preserve">
-    <value>The script block cannot be converted because it contains more than one clause. Expressions or control structures are not permitted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>스크립트 블록에 절이 두 개 이상 포함되어 있으므로 변환할 수 없습니다. 식이나 제어 구조는 허용되지 않습니다. 스크립트 블록에 정확히 하나의 파이프라인이나 명령이 포함되어 있는지 확인하세요.</value>
   </data>
   <data name="CantConvertEmptyPipeline" xml:space="preserve">
-    <value>An empty script block cannot be converted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>빈 스크립트 블록은 변환할 수 없습니다. 스크립트 블록에 정확히 하나의 파이프라인이나 명령이 포함되어 있는지 확인하세요.</value>
   </data>
   <data name="CanOnlyConvertOnePipeline" xml:space="preserve">
-    <value>Only a script block that contains exactly one pipeline or command can be converted. Expressions or control structures are not permitted. Verify that the script block contains exactly one pipeline or command.</value>
+    <value>정확히 하나의 파이프라인이나 명령을 포함한 스크립트 블록만 변환할 수 있습니다. 식이나 제어 구조는 허용되지 않습니다. 스크립트 블록에 정확히 하나의 파이프라인이나 명령이 포함되어 있는지 확인하세요.</value>
   </data>
   <data name="CantConvertScriptBlockWithTrap" xml:space="preserve">
-    <value>A script block that contains a top-level trap statement cannot be converted.</value>
+    <value>최상위 trap 문이 포함된 스크립트 블록은 변환할 수 없습니다.</value>
   </data>
   <data name="CantConvertWithUndeclaredVariables" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock dereferencing variables undeclared in the param(...) block.  Name of undeclared variable: {0}.</value>
+    <value>param(...) 블록에서 선언되지 않은 변수를 역참조하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.  선언되지 않은 변수의 이름: {0}.</value>
   </data>
   <data name="CantConvertWithNonConstantExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating non-constant expressions. Non-constant expression: {0}.</value>
+    <value>비상수 식을 평가하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다. 비상수 식: {0}.</value>
   </data>
   <data name="CantConvertWithDynamicExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock evaluating dynamic expressions. Dynamic expression: {0}.</value>
+    <value>동적 식을 평가하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다. 동적 식: {0}.</value>
   </data>
   <data name="CantConvertWithScriptBlocks" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that tries to pass other script blocks inside argument values.</value>
+    <value>인수 값 안에 다른 스크립트 블록을 전달하려는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="CantConvertWithCommandInvocations" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock which invokes pipelines, commands or functions to evaluate arguments of the main pipeline.</value>
+    <value>주 파이프라인의 인수를 평가하기 위해 파이프라인, 명령 또는 함수를 호출하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="CantConvertWithDotSourcing" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that uses dot sourcing.</value>
+    <value>도트 소싱을 사용하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="CantConvertWithScriptBlockInvocation" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that invokes other script blocks.</value>
+    <value>다른 스크립트 블록을 호출하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="CanConvertOneOutputErrorRedir" xml:space="preserve">
-    <value>The script block cannot be converted to a PowerShell object because it contains forbidden redirection operators.</value>
+    <value>금지된 리디렉션 연산자가 포함되어 있으므로 스크립트 블록을 PowerShell 개체로 변환할 수 없습니다.</value>
   </data>
   <data name="CantConvertScriptBlockWithNoContext" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that does not have an associated operation context.</value>
+    <value>연결된 작업 컨텍스트가 없는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="HaltCommandException" xml:space="preserve">
-    <value>The command was stopped by the user.</value>
+    <value>사용자가 명령을 중단했습니다.</value>
   </data>
   <data name="DynamicParametersWrongType" xml:space="preserve">
-    <value>Object "{0}" is the wrong type to return from the dynamicparam block. The dynamicparam block must return either $null, or an object with type [System.Management.Automation.RuntimeDefinedParameterDictionary].</value>
+    <value>"{0}" 개체는 dynamicparam 블록에서 반환할 수 있는 올바른 형식이 아닙니다. dynamicparam 블록은 $null 또는 [System.Management.Automation.RuntimeDefinedParameterDictionary] 형식의 개체를 반환해야 합니다.</value>
   </data>
   <data name="CantConvertScriptBlockToOpenGenericType" xml:space="preserve">
-    <value>The script block cannot be converted to an open generic type. Define an appropriate closed generic type, and then retry.</value>
+    <value>스크립트 블록을 개방형 제네릭 형식으로 변환할 수 없습니다. 적절한 닫힌 제네릭 형식을 정의한 다음 다시 시도하세요.</value>
   </data>
   <data name="CantConvertPipelineStartsWithExpression" xml:space="preserve">
-    <value>Cannot generate a PowerShell object for a ScriptBlock that starts a pipeline with an expression.</value>
+    <value>식으로 파이프라인을 시작하는 ScriptBlock에 대한 PowerShell 개체를 생성할 수 없습니다.</value>
   </data>
   <data name="UsingVariableIsUndefined" xml:space="preserve">
-    <value>The value of the using variable '$using:{0}' cannot be retrieved because it has not been set in the local session.</value>
+    <value>using 변수 '$using:{0}'은(는) 로컬 세션에 설정되어 있지 않으므로 값을 가져올 수 없습니다.</value>
   </data>
   <data name="CantGetUsingExpressionValueWithSpecifiedVariableDictionary" xml:space="preserve">
-    <value>Cannot get the value of the Using expression '{0}' in the specified variable dictionary. When creating a PowerShell instance from a script block, the Using expression cannot contain an indexing operation or member-accessing operation.</value>
+    <value>지정한 변수 사전에서 Using 식 '{0}'의 값을 가져올 수 없습니다. 스크립트 블록에서 PowerShell instance를 만들 때 Using 식에는 인덱싱 작업이나 멤버 액세스 작업을 포함할 수 없습니다.</value>
   </data>
   <data name="WDACCompiledScriptBlockLogTitle" xml:space="preserve">
-    <value>Compiled Script Block Dot Source</value>
+    <value>컴파일된 스크립트 블록 점 소스</value>
   </data>
   <data name="WDACCompiledScriptBlockLogMessage" xml:space="preserve">
-    <value>Script block '{0}' invocation into current scope will be disallowed in Constrained Language mode. Script language mode: {1}, Context language mode: {2}.</value>
+    <value>제한된 언어 모드에서는 스크립트 블록 '{0}'을(를) 현재 범위에 호출할 수 없습니다. 스크립트 언어 모드: {1}, 컨텍스트 언어 모드: {2}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/CimInstanceTypeAdapterResources.ko.resx
+++ b/src/System.Management.Automation/resources/ko/CimInstanceTypeAdapterResources.ko.resx
@@ -118,10 +118,10 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BaseObjectNotCimInstance" xml:space="preserve">
-    <value>Cannot convert "{0}" to an object of type "{1}".</value>
+    <value>"{0}"을(를) "{1}" 형식의 개체로 변환할 수 없습니다.</value>
   </data>
   <data name="ReadOnlyCIMProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>{0}은(는) 읽기 전용 속성입니다.</value>
     <comment>{0} gets property name</comment>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/ConsoleInfoErrorStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/ConsoleInfoErrorStrings.ko.resx
@@ -118,36 +118,36 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="BadMonadVersion" xml:space="preserve">
-    <value>Incorrect PowerShell version {0}. PowerShell version {1} is supported on this computer.</value>
+    <value>PowerShell 버전 {0}이(가) 잘못되었습니다. 이 컴퓨터에서는 PowerShell 버전 {1}이(가) 지원됩니다.</value>
   </data>
   <data name="ConsoleLoadFailure" xml:space="preserve">
-    <value>The following errors occurred when loading console {0}: {1}</value>
+    <value>콘솔 {0}을(를) 로드하는 동안 다음 오류가 발생했습니다. {1}</value>
   </data>
   <data name="PSSnapInLoadFailure" xml:space="preserve">
-    <value>Cannot load PowerShell snap-in {0} because of the following error: {1}</value>
+    <value>다음 오류 때문에 PowerShell 스냅인 {0}을(를) 로드할 수 없습니다. {1}</value>
   </data>
   <data name="PSSnapInLoadWarning" xml:space="preserve">
-    <value>PowerShell snap-in "{0}" loaded with the following warnings: {1}</value>
+    <value>PowerShell 스냅인 "{0}"이(가) 로드되었지만 다음 경고가 발생했습니다. {1}</value>
   </data>
   <data name="PSSnapInAssemblyNameMismatch" xml:space="preserve">
-    <value>The PowerShell snap-in module {0} does not have the required PowerShell snap-in strong name {1}.</value>
+    <value>PowerShell 스냅인 모듈 {0}에 필요한 PowerShell 스냅인 강력한 이름 {1}이(가) 없습니다.</value>
   </data>
   <data name="PSSnapInDuplicateCmdlets" xml:space="preserve">
-    <value>The cmdlet '{0}' should not occur more than once in PowerShell snap-in '{1}'.</value>
+    <value>cmdlet '{0}'은(는) PowerShell 스냅인 '{1}'에 두 번 이상 있으면 안 됩니다.</value>
   </data>
   <data name="PSSnapInDuplicateProviders" xml:space="preserve">
-    <value>PowerShell provider '{0}' should not occur more than once in PowerShell snap-in '{1}'.</value>
+    <value>PowerShell 공급자 '{0}'은(는) PowerShell 스냅인 '{1}'에 두 번 이상 있으면 안 됩니다.</value>
   </data>
   <data name="AddPSSnapInBadMonadVersion" xml:space="preserve">
-    <value>PowerShell {0} is not supported in the current console. PowerShell {1} is supported in the current console.</value>
+    <value>PowerShell {0}은(는) 현재 콘솔에서 지원되지 않습니다. PowerShell {1}은(는) 현재 콘솔에서 지원됩니다.</value>
   </data>
   <data name="FileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>파일 {0}이(가) 이미 존재하며 {1}이(가) 지정되었습니다.</value>
   </data>
   <data name="ConfigurationFileDoesNotExist" xml:space="preserve">
-    <value>The provided configuration file '{0}' does not exist.</value>
+    <value>제공된 구성 파일 '{0}'이(가) 없습니다.</value>
   </data>
   <data name="NotConfigurationFile" xml:space="preserve">
-    <value>The provided configuration file '{0}' must have a .pssc file extension.</value>
+    <value>제공된 구성 파일 '{0}'에는 .pssc 파일 확장명이 있어야 합니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/ErrorCategoryStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/ErrorCategoryStrings.ko.resx
@@ -121,7 +121,7 @@
     <value>CloseError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>교착 상태 검색: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
     <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
@@ -214,6 +214,6 @@
     <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>인식할 수 없는 오류 범주 {4}: ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/EtwLoggingStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/EtwLoggingStrings.ko.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>명령 {0}은(는) {1}입니다.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>엔진 상태가 {0}에서 {1}(으)로 변경되었습니다.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>정규화된 전체 오류 ID = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>오류 메시지 = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>권장 조치 = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>실행 정책</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>작업 명령 = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>작업 ID = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>작업 인스턴스 ID = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>작업 위치 = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>작업 이름 = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>작업 상태= {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        명령 이름 = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        명령 경로 = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        명령 유형 = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        엔진 버전 = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        호스트 ID = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        호스트 이름 = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        호스트 애플리케이션 = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        호스트 버전 = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        파이프라인 ID = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
     <value>        Runspace ID = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        스크립트 이름 = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        시퀀스 번호 = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        심각도 = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        셸 ID = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        시간 = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        사용자 = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        연결된 사용자 = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>NULL 작업</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>공급자 이름</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>공급자 {0}이(가) 상태를 {1}(으)로 변경했습니다.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>스크립트 실행이 {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>변수 {0}이(가) {1}에서 {2}(으)로 변경되었습니다.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>변수 {0}이(가) {1}(으)로 변경되었습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/ExtendedTypeSystem.ko.resx
+++ b/src/System.Management.Automation/resources/ko/ExtendedTypeSystem.ko.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>구성원 "{0}"이(가) 이미 있습니다.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>구성원 "{0}"은(는) 이미 확장된 형식 데이터 파일에 있습니다.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>구성원 "{0}"이(가) 없습니다.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>"{0}"을(를) 설정하는 동안 예외가 발생함: "{1}"</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>"{0}"을(를) 가져오는 동안 예외가 발생함: "{1}"</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>컬렉션을 열거하는 동안 다음 예외가 발생했습니다. "{0}".</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>PSObject 밖에서는 구성원 "{0}"에 액세스할 수 없습니다.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>형식 구성에서 만든 구성원을 변경할 수 없습니다. "{0}".</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>구성원 이름 "{0}"은(는) 예약되어 있습니다.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>"{0}"은(는) 변경할 수 없습니다.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>"{0}"을(를) "{1}"개의 인수와 함께 호출하는 동안 예외가 발생함: "{2}"</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>"{1}" 형식의 개체 내용을 추출하기 위해 "{0}"을(를) 호출하려고 하는 동안 예외가 throw되었습니다. "{2}"</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>"{0}"에 대한 오버로드를 찾을 수 없으며, 인수 개수는 "{1}"입니다.</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>형식 매개 변수가 "{1}"인 "{0}"에 대해 적절한 제네릭 메서드 오버로드를 찾을 수 없으며, 인수 개수는 "{2}"개입니다.</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>"{0}"에 대한 모호한 오버로드가 여러 개 발견되었으며, 인수 개수는 "{1}"개입니다.</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>"{2}"에 대한 인수 "{0}"(값: "{1}")을(를) 형식 "{3}"(으)로 변환할 수 없습니다. "{4}"</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>속성 "{0}"의 Get 접근자를 사용할 수 없습니다.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>속성 "{0}"의 Set 접근자를 사용할 수 없습니다.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>setter 메서드는 public, void, static이어야 하고 매개 변수는 두 개여야 합니다. 첫 번째 매개 변수는 PSObject 형식이어야 합니다. getter 메서드도 사용할 수 있는 경우 두 번째 매개 변수가 필요하며, 이는 getter 메서드의 반환 형식과 같아야 합니다.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>getter 메서드는 void나 static이 아닌 public이어야 하며, PSObject 형식의 매개 변수가 하나 있어야 합니다.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>CodeProperty는 getter 또는 setter 메서드를 사용해야 합니다.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>메서드 형식 때문에 코드 메서드를 만들 수 없습니다. 메서드는 public, static이어야 하며 PSObject 형식의 매개 변수가 하나 있어야 합니다.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>이름이 "{0}"인 별칭에 주기가 있습니다.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>형식 "{1}"의 "{0}" 값을 형식 "{2}"(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>형식 "{0}"의 값을 형식 "{1}"(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>값 "{0}"을(를) 형식 "{1}"(으)로 변환할 수 없습니다. 오류: "{2}"</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>이 열거형에서는 쉼표를 허용하지 않으므로 값 "{0}"을(를) 형식 "{1}"(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>잘못된 열거형 값이 있으므로 값 "{0}"을(를) 형식 "{1}"(으)로 변환할 수 없습니다. 다음 열거형 값 중 하나를 지정하고 다시 시도하세요. 가능한 열거형 값은 "{2}"입니다.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>잘못된 열거형 값이 있으므로 null을 형식 "{0}"(으)로 변환할 수 없습니다. 다음 열거형 값 중 하나를 지정하고 다시 시도하세요. 가능한 열거형 값은 "{1}"입니다.</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>null을 형식 "{0}"(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>값을 형식 "{0}"(으)로 변환할 수 없습니다.  오류: "{1}"</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>값을 형식 System.String으로 변환할 수 없습니다.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>인수에 참조 형식이 필요합니다.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>"{0}"은(는) IComparable이 아니므로 비교할 수 없습니다.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>"{0}"과(와) "{1}"을(를) 비교할 수 없습니다. 오류: "{2}"</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>개체의 형식이 같지 않거나 개체 "{0}"이(가) "{2}"을(를) 구현하지 않으므로 "{0}"과(와) "{1}"을(를) 비교할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>일치 항목이 최소 두 개 이상 발견되었고({2}, {3}) 이 열거형에서는 일치 항목을 하나만 허용하므로 값 "{0}"을(를) 형식 "{1}"(으)로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>값 "{0}"을(를) 형식 "{1}"(으)로 변환할 수 없습니다. 부울 매개 변수에는 $True, $False, 1, 0 같은 부울 값과 숫자만 사용할 수 있습니다.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>"{0}"은(는) 쓰기 전용 속성이므로 속성 값을 가져올 수 없습니다.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>"{0}"은(는) 읽기 전용 속성입니다.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>XmlNode 속성을 설정하는 값으로는 문자열만 사용할 수 있으므로 "{0}"을(를) 설정할 수 없습니다.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>고유 특성이나 고유 특성이 없는 리프 노드만 설정할 수 있으므로 "{0}"을(를) 설정할 수 없습니다.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>PSProperty 또는 PSMethod 개체는 이 컬렉션에 추가할 수 없습니다.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>확장된 형식 데이터 파일을 로드하는 동안 다음 오류가 발생했습니다. {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>문자열을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>형식 "{1}"의 필드 또는 속성 "{0}"은(는) 필드 또는 속성 "{2}"과(와) 대/소문자만 다릅니다. 형식은 CLS(공용 언어 사양)를 준수해야 합니다.</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>형식 이름 계층 구조를 검색하는 동안 다음 예외가 발생했습니다. "{0}".</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>구성원 "{1}"을(를) 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>구성원을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>속성 "{1}"의 읽기 상태를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>속성 "{1}"의 쓰기 상태를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>속성 "{1}"에 대한 형식을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>속성 "{1}"의 문자열 표현을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>속성 "{1}"의 특성을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>메서드 "{1}"의 정의를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>메서드 "{1}"의 문자열 표현을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>매개 변수가 있는 속성 "{1}"의 형식을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>매개 변수가 있는 속성 "{1}"의 읽기 상태를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>매개 변수가 있는 속성 "{1}"의 쓰기 상태를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>매개 변수가 있는 속성 "{1}"의 정의를 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>매개 변수가 있는 속성 "{1}"의 문자열 표현을 검색하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>형식 "{0}"의 PSMemberInfo 개체에 대해서는 Value 속성을 설정할 수 없습니다.</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>인수 '{0}'은(는) {1}이어(여)야 합니다. {2}을(를) 사용합니다.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>인수 '{0}'은(는) {1}이면 안 됩니다. {2}은(는) 사용하지 마세요.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>"{0}" 속성을 찾을 수 없습니다.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>속성 값을 가져오거나 설정할 수 없습니다. "{0}" 인수는 "{1}" 또는 "{2}" 형식이어야 합니다.</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>개체의 형식이 "{2}" 대신 "{1}"이므로 속성 "{0}"의 값을 설정할 수 없습니다.</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>"{0}"을(를) 호출하는 중 예외가 발생함: "{1}"</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0}은(는) 올바른 클래스 경로가 아닙니다.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0}은(는) 유효한 경로가 아닙니다.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>어댑터에서 속성 "{0}"을(를) 변경할 수 있는지 여부를 확인할 수 없습니다.</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>어댑터에서 속성 "{0}"을(를) 가져올 수 있는지 여부를 확인할 수 없습니다.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>어댑터에서 속성 "{0}"의 값을 가져올 수 없습니다.</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>어댑터에서 속성 "{0}"의 값을 설정할 수 없습니다.</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>어댑터에서 속성 "{0}"의 형식을 가져올 수 없습니다.</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>어댑터에서 "{0}"의 형식 계층 구조를 가져올 수 없습니다.</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>어댑터에서 "{0}"의 속성을 가져올 수 없습니다.</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>어댑터에서 "{1}"에 대한 속성 "{0}"을(를) 가져올 수 없습니다.</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>"{0}"에서 null 값이 반환되었습니다.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>'{0}' 개체에 대한 속성 '{1}'을(를) 찾을 수 없습니다. 설정할 수 있는 속성은 다음과 같습니다. {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>'{0}' 개체에 대한 속성 '{1}'을(를) 찾을 수 없습니다. 설정할 수 있는 속성이 없습니다.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>형식 "{0}"의 개체를 만들 수 없습니다. {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>열려 있는 제네릭 형식 {0}에서는 정적 메서드를 호출하거나 정적 속성에 액세스할 수 없습니다.  형식 매개 변수를 지정하고 다시 시도하세요.  예를 들어 [System.Collections.Generic.HashSet``1]::CreateSetComparer() 대신 [System.Collections.Generic.HashSet[int]]::CreateSetComparer()를 사용하세요.</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>특성 "{1}"을(를) 생성하는 동안 다음 예외가 발생했습니다. "{0}"</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>값 "{0}"은(는) 문자열 배열로 변환할 수 없습니다.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>값을 형식 "{0}"(으)로 변환할 수 없습니다. 이 언어 모드에서는 핵심 형식만 지원됩니다.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef와 유사한 형식 "{0}"(으)로 변환할 수 없습니다. PowerShell에서는 ByRef와 유사한 형식이 지원되지 않습니다.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef와 유사한 형식 "{1}"의 속성 또는 필드 "{0}"을(를) 가져오거나 설정할 수 없습니다. PowerShell에서는 ByRef와 유사한 형식이 지원되지 않습니다.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef와 유사한 반환 형식 "{1}"의 메서드 "{0}"을(를) 호출할 수 없습니다. PowerShell에서는 ByRef와 유사한 형식이 지원되지 않습니다.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef와 유사한 형식 "{0}"의 인스턴스를 만들 수 없습니다. PowerShell에서는 ByRef와 유사한 형식이 지원되지 않습니다.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>확장 유형 시스템 해시 테이블 변환</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 HashTable에서 '{0}'(으)로 형식을 변환할 수 없습니다.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>확장 유형 시스템 해시 테이블 변환</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 '{0}'에서 '{1}'(으)로 형식을 변환할 수 없습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/FileSystemProviderStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/FileSystemProviderStrings.ko.resx
@@ -118,240 +118,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvokeItemAction" xml:space="preserve">
-    <value>Invoke Item</value>
+    <value>항목 호출</value>
   </data>
   <data name="InvokeItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>항목: {0}</value>
   </data>
   <data name="RemoveItemActionFile" xml:space="preserve">
-    <value>Remove File</value>
+    <value>파일 제거</value>
   </data>
   <data name="RemoveItemActionDirectory" xml:space="preserve">
-    <value>Remove Directory</value>
+    <value>디렉터리 제거</value>
   </data>
   <data name="CopyItemActionFile" xml:space="preserve">
-    <value>Copy File</value>
+    <value>파일 복사</value>
   </data>
   <data name="CopyItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>항목: {0} 대상: {1}</value>
   </data>
   <data name="CopyItemActionDirectory" xml:space="preserve">
-    <value>Copy Directory</value>
+    <value>디렉터리 복사</value>
   </data>
   <data name="RenameItemActionFile" xml:space="preserve">
-    <value>Rename File</value>
+    <value>파일 이름 바꾸기</value>
   </data>
   <data name="RenameItemActionDirectory" xml:space="preserve">
-    <value>Rename Directory</value>
+    <value>디렉터리 이름 바꾸기</value>
   </data>
   <data name="RenameItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>항목: {0} 대상: {1}</value>
   </data>
   <data name="MoveItemActionFile" xml:space="preserve">
-    <value>Move File</value>
+    <value>파일 이동</value>
   </data>
   <data name="MoveItemActionDirectory" xml:space="preserve">
-    <value>Move Directory</value>
+    <value>디렉터리 이동</value>
   </data>
   <data name="MoveItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>항목: {0} 대상: {1}</value>
   </data>
   <data name="SetPropertyActionFile" xml:space="preserve">
-    <value>Set Property File</value>
+    <value>속성 파일 설정</value>
   </data>
   <data name="SetPropertyActionDirectory" xml:space="preserve">
-    <value>Set Property Directory</value>
+    <value>속성 Directory 설정</value>
   </data>
   <data name="SetPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1} Value: {2}</value>
+    <value>항목: {0} 속성: {1} 값: {2}</value>
   </data>
   <data name="ClearPropertyActionFile" xml:space="preserve">
-    <value>Clear Property File</value>
+    <value>속성 파일 지우기</value>
   </data>
   <data name="ClearPropertyActionDirectory" xml:space="preserve">
-    <value>Clear Property Directory</value>
+    <value>속성 디렉터리 지우기</value>
   </data>
   <data name="ClearPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1}</value>
+    <value>항목: {0} 속성: {1}</value>
   </data>
   <data name="NewItemActionFile" xml:space="preserve">
-    <value>Create File</value>
+    <value>파일 생성</value>
   </data>
   <data name="NewItemActionDirectory" xml:space="preserve">
-    <value>Create Directory</value>
+    <value>디렉토리 생성</value>
   </data>
   <data name="NewItemActionTemplate" xml:space="preserve">
-    <value>Destination: {0}</value>
+    <value>대상: {0}</value>
   </data>
   <data name="ClearContentActionFile" xml:space="preserve">
-    <value>Clear Content</value>
+    <value>콘텐츠 지우기</value>
   </data>
   <data name="ClearContentesourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>항목: {0}</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>Could not find item {0}.</value>
+    <value>{0} 항목을 찾을 수 없습니다.</value>
   </data>
   <data name="CannotRemoveItem" xml:space="preserve">
-    <value>Cannot remove item {0}: {1}</value>
+    <value>{0} 항목을 제거할 수 없습니다. {1}</value>
   </data>
   <data name="CannotRestoreAttributes" xml:space="preserve">
-    <value>Cannot restore attributes on item {0}: {1}</value>
+    <value>항목 {0}의 속성을 복원할 수 없습니다. {1}</value>
   </data>
   <data name="ItemDoesNotExist" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist.</value>
+    <value>지정한 경로 {0}에 개체가 없습니다.</value>
   </data>
   <data name="DirectoryNotEmpty" xml:space="preserve">
-    <value>Directory {0} cannot be removed because it is not empty.</value>
+    <value>디렉터리 {0}은(는) 비어 있지 않으므로 제거할 수 없습니다.</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>알 수 없는 파일 시스템 형식입니다. "file", "directory" 또는 "symboliclink"만 지정할 수 있습니다.</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
-    <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>
+    <value>지정한 경로가 basePath 밖의 항목을 가리키므로 경로를 처리할 수 없습니다.</value>
   </data>
   <data name="DriveRootError" xml:space="preserve">
-    <value>The specified drive root "{0}" either does not exist, or it is not a folder.</value>
+    <value>지정한 드라이브 루트 "{0}"이(가) 없거나 폴더가 아닙니다.</value>
   </data>
   <data name="DirectoryExist" xml:space="preserve">
-    <value>An item with the specified name {0} already exists.</value>
+    <value>지정된 이름의 {0} 파일이 이미 있습니다.</value>
   </data>
   <data name="DelimiterError" xml:space="preserve">
-    <value>A delimiter cannot be specified when reading the stream one byte at a time.</value>
+    <value>스트림을 한 번에 1바이트씩 읽을 때는 구분 기호를 지정할 수 없습니다.</value>
   </data>
   <data name="CopyError" xml:space="preserve">
-    <value>Cannot overwrite the item {0} with itself.</value>
+    <value>항목 {0}을(를) 자체로 덮어쓸 수 없습니다.</value>
   </data>
   <data name="RenameError" xml:space="preserve">
-    <value>Cannot rename the specified target, because it represents a path or device name.</value>
+    <value>지정한 대상은 경로 또는 디바이스 이름을 나타내므로 이름을 바꿀 수 없습니다.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property {0} does not exist or was not found.</value>
+    <value>속성 {0}이(가) 없거나 찾을 수 없습니다.</value>
   </data>
   <data name="PermissionError" xml:space="preserve">
-    <value>You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.</value>
+    <value>이 작업을 수행할 수 있는 액세스 권한이 없거나, 항목이 숨김, 시스템 또는 읽기 전용입니다.</value>
   </data>
   <data name="AttributesNotSupported" xml:space="preserve">
-    <value>The attribute cannot be set because attributes are not supported. Only the following attributes can be set: Archive, Hidden, Normal, ReadOnly, or System.</value>
+    <value>특성을 지원하지 않으므로 특성을 설정할 수 없습니다. Archive, Hidden, Normal, ReadOnly 또는 System 특성만 설정할 수 있습니다.</value>
   </data>
   <data name="CannotClearProperty" xml:space="preserve">
-    <value>The property cannot be cleared because the property is not supported. Only the Attributes property can be cleared.</value>
+    <value>지원되지 않는 속성이므로 속성을 지울 수 없습니다. Attributes 속성만 지울 수 있습니다.</value>
   </data>
   <data name="TargetCannotContainDeviceName" xml:space="preserve">
-    <value>Cannot process path '{0}' because the target represents a reserved device name.</value>
+    <value>대상이 예약된 디바이스 이름을 나타내므로 경로 '{0}'을(를) 처리할 수 없습니다.</value>
   </data>
   <data name="EncodingNotUsed" xml:space="preserve">
-    <value>Encoding not used when '-AsByteStream' specified.</value>
+    <value>'-AsByteStream'이 지정되면 인코딩은 사용되지 않습니다.</value>
   </data>
   <data name="ByteEncodingError" xml:space="preserve">
-    <value>Cannot proceed with byte encoding. When using byte encoding the content must be of type byte.</value>
+    <value>바이트 인코딩을 계속할 수 없습니다. 바이트 인코딩을 사용할 때 콘텐츠는 바이트 형식이어야 합니다.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>Cannot process the file because the file {0} was not found.</value>
+    <value>파일 {0}을(를) 찾을 수 없어서 파일을 처리할 수 없습니다.</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
-    <value>    Directory: </value>
+    <value>    디렉터리: </value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
-    <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>
+    <value>파일 인코딩을 검색할 수 없습니다. 콘텐츠를 역방향으로 읽을 때는 지정한 인코딩 {0}을(를) 지원하지 않습니다.</value>
   </data>
   <data name="AlternateDataStreamNotFound" xml:space="preserve">
-    <value>Could not open the alternate data stream '{0}' of the file '{1}'.</value>
+    <value>파일 '{0}'의 대체 데이터 스트림 '{1}'을(를) 열 수 없습니다.</value>
   </data>
   <data name="StreamAction" xml:space="preserve">
-    <value>Stream '{0}' of file '{1}'.</value>
+    <value>파일 '{1}'의 스트림 '{0}'입니다.</value>
   </data>
   <data name="RawAndWaitCannotCoexist" xml:space="preserve">
-    <value>The Raw and Wait parameters cannot be specified in the same command.</value>
+    <value>Raw 및 Wait 매개 변수는 같은 명령에서 함께 지정할 수 없습니다.</value>
   </data>
   <data name="InvalidDriveName" xml:space="preserve">
-    <value>To use the Persist switch parameter, the drive name must be supported by the operating system (for example, drive letters A-Z).</value>
+    <value>Persist 스위치 매개 변수를 사용하려면 드라이브 이름이 운영 체제에서 지원되어야 합니다. 예를 들어 A-Z 드라이브 문자를 사용할 수 있습니다.</value>
   </data>
   <data name="PersistNotSupported" xml:space="preserve">
-    <value>When you use the Persist parameter, the root must be a file system location on a remote computer.</value>
+    <value>Persist 매개 변수를 사용할 때 루트는 원격 컴퓨터의 파일 시스템 위치여야 합니다.</value>
   </data>
   <data name="NoFirstLastWaitForRaw" xml:space="preserve">
-    <value>The '{0}' and '{1}' parameters cannot be specified in the same command.</value>
+    <value>'{0}' 매개 변수와 '{1}' 매개 변수는 같은 명령에서 함께 지정할 수 없습니다.</value>
   </data>
   <data name="ItemNotDirectory" xml:space="preserve">
-    <value>A directory is required for the operation. The item '{0}' is not a directory.</value>
+    <value>작업에 사용할 디렉터리가 필요합니다. '{0}' 항목은 디렉터리가 아닙니다.</value>
   </data>
   <data name="NewItemActionJunction" xml:space="preserve">
-    <value>Create Junction</value>
+    <value>접합 만들기</value>
   </data>
   <data name="NewItemActionSymbolicLink" xml:space="preserve">
-    <value>Create Symbolic Link</value>
+    <value>바로 가기 링크 만들기</value>
   </data>
   <data name="ElevationRequired" xml:space="preserve">
-    <value>Administrator privilege required for this operation.</value>
+    <value>이 작업에는 관리자 권한이 필요합니다.</value>
   </data>
   <data name="NewItemActionHardLink" xml:space="preserve">
-    <value>Create Hard Link</value>
+    <value>하드 링크 만들기</value>
   </data>
   <data name="ItemNotFile" xml:space="preserve">
-    <value>A file is required for the operation. The item '{0}' is not a file.</value>
+    <value>작업에 사용할 파일이 필요합니다. '{0}' 항목은 파일이 아닙니다.</value>
   </data>
   <data name="HardLinkNotSupported" xml:space="preserve">
-    <value>Hard links are not supported for the specified path.</value>
+    <value>지정한 경로에서는 하드 링크를 지원하지 않습니다.</value>
   </data>
   <data name="SymbolicLinkNotSupported" xml:space="preserve">
-    <value>Symbolic links are not supported for the specified path.</value>
+    <value>지정한 경로에서는 기호 링크를 지원하지 않습니다.</value>
   </data>
   <data name="CopyItemRemotelyProgressActivity" xml:space="preserve">
     <value>{1}에 {0} 복사</value>
   </data>
   <data name="CopyItemRemoteDestinationIsFile" xml:space="preserve">
-    <value>Destination path {0} is a file that already exists on the target destination.</value>
+    <value>대상 경로 {0}은(는) 대상 위치에 이미 있는 파일입니다.</value>
   </data>
   <data name="CopyItemRemotelyFailed" xml:space="preserve">
-    <value>Failed to copy file {0} to remote target destination.</value>
+    <value>파일 {0}을(를) 원격 대상 위치에 복사하지 못했습니다.</value>
   </data>
   <data name="CopyItemRemotelyStatusDescription" xml:space="preserve">
     <value>{0}에서 {1}(으)로</value>
   </data>
   <data name="CopyItemRemotelyDestinationIsFile" xml:space="preserve">
-    <value>Cannot copy a directory '{0}' to file '{0}'</value>
+    <value>디렉터리 '{0}'을(를) 파일 '{0}'에 복사할 수 없습니다.</value>
   </data>
   <data name="CopyItemRemotelyFailedToGetDirectoryChildItems" xml:space="preserve">
-    <value>Failed to get directory {0} child items.</value>
+    <value>디렉터리 {0}의 자식 항목을 가져오지 못했습니다.</value>
   </data>
   <data name="CopyItemRemotelyFailedToReadFile" xml:space="preserve">
-    <value>Failed to read remote file '{0}'.</value>
+    <value>원격 파일 '{0}'을(를) 읽지 못했습니다.</value>
   </data>
   <data name="CopyItemRemotelyFailedToValidateIfDestinationIsFile" xml:space="preserve">
-    <value>Cannot validate if remote destination {0} is a file.</value>
+    <value>원격 대상 {0}이(가) 파일인지 확인할 수 없습니다.</value>
   </data>
   <data name="CopyItemRemotelyFailedToCreateDirectory" xml:space="preserve">
-    <value>Failed to create directory '{0}' on remote destination.</value>
+    <value>원격 대상에서 '{0}' 디렉터리를 만들지 못했습니다.</value>
   </data>
   <data name="DriveMaxSizeError" xml:space="preserve">
-    <value>Maximum size for drive has been exceeded: {0}.</value>
+    <value>드라이브의 최대 크기를 초과했습니다. {0}.</value>
   </data>
   <data name="SymlinkItemExists" xml:space="preserve">
-    <value>Cannot create link because the path already exists: {0}.</value>
+    <value>경로가 이미 있으므로 링크를 만들 수 없습니다. {0}.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Skip already-visited directory {0}.</value>
+    <value>이미 방문한 Directory {0}을(를) 건너뜁니다.</value>
   </data>
   <data name="TargetCannotBeSubdirectoryOfSource" xml:space="preserve">
-    <value>Destination path cannot be a subdirectory of the source or the source itself: {0}.</value>
+    <value>대상 경로는 원본 또는 원본 자체의 하위 디렉터리일 수 없습니다. {0}.</value>
   </data>
   <data name="NewItemTargetIsSameAsLink" xml:space="preserve">
-    <value>The target and path cannot be the same.</value>
+    <value>대상과 경로는 같을 수 없습니다.</value>
   </data>
   <data name="CopyingLocalFileActivity" xml:space="preserve">
-    <value>Copied {0} of {1} files</value>
+    <value>파일 {0}개 중 {1}개를 복사함</value>
   </data>
   <data name="CopyingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0}개 중 {1}개({2:0.0} MB/s)</value>
   </data>
   <data name="RemovingLocalFileActivity" xml:space="preserve">
-    <value>Removed {0} of {1} files</value>
+    <value>파일 {0}개 중 {1}개를 제거함</value>
   </data>
   <data name="RemovingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0}개 중 {1}개({2:0.0} MB/s)</value>
   </data>
   <data name="JunctionAbsolutePath" xml:space="preserve">
-    <value>Creating a junction requires an absolute path for the target.</value>
+    <value>정션을 만들려면 대상에 절대 경로가 필요합니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/FormatAndOut_out_xxx.ko.resx
+++ b/src/System.Management.Automation/resources/ko/FormatAndOut_out_xxx.ko.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ConsoleLineOutput_PagingPrompt" xml:space="preserve">
-    <value>&lt;SPACE&gt; next page; &lt;CR&gt; next line; Q quit</value>
+    <value>&lt;SPACE&gt; 다음 페이지; &lt;CR&gt; 다음 줄; Q 종료</value>
   </data>
   <data name="OutLineOutput_NullLineOutputParameter" xml:space="preserve">
-    <value>The value of LineOutput should not be null.</value>
+    <value>LineOutput 값은 null이면 안 됩니다.</value>
   </data>
   <data name="OutLineOutput_InvalidLineOutputParameterType" xml:space="preserve">
-    <value>The lineOutput type {0} was not expected; LineOutput expects type {1}.</value>
+    <value>lineOutput 유형 {0}은(는) 예상되지 않았습니다. LineOutput에는 {1} 형식이 필요합니다.</value>
   </data>
   <data name="OutLineOutput_OutOfSequencePacket" xml:space="preserve">
-    <value>The object of type "{0}" is not valid or not in the correct sequence. This is likely caused by a user-specified "{1}" command which is conflicting with the default formatting.</value>
+    <value>"{0}" 형식의 개체가 올바르지 않거나 순서가 맞지 않습니다. 기본 서식과 충돌하는 사용자가 지정한 "{1}" 명령 때문일 수 있습니다.</value>
   </data>
   <data name="OutFile_FileOpenFailure" xml:space="preserve">
-    <value>Cannot open file "{0}".</value>
+    <value>파일 "{0}"을(를) 열 수 없습니다.</value>
   </data>
   <data name="OutFile_Action" xml:space="preserve">
-    <value>Output to File</value>
+    <value>파일에 출력</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/HelpDisplayStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/HelpDisplayStrings.ko.resx
@@ -121,115 +121,115 @@
     <value>이름</value>
   </data>
   <data name="Synopsis" xml:space="preserve">
-    <value>SYNOPSIS</value>
+    <value>개요</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
-    <value>DESCRIPTION</value>
+    <value>설명</value>
   </data>
   <data name="Syntax" xml:space="preserve">
     <value>SYNTAX</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>매개 변수</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>입력</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>출력</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>종료 오류</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>종료되지 않는 오류</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>참고</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>예</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>예제</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>예</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>OUTPUT</value>
+    <value>출력</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>관련 링크</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>간단한 설명</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>제목:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>질문:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>답변</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>용어:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>정의:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>콘텐츠:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>공급자 이름</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
+    <value>    이 cmdlet은 다음 공통 매개 변수를 지원합니다. Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
+    OutBuffer, PipelineVariable 및 OutVariable입니다. 자세한 내용은 다음을 참조하세요.
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>필수인가요?                    </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>위치                    </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>형식: </value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>대상 개체 유형:   </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>기본값                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>파이프라인 입력 허용       </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>와일드카드 문자 허용  </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(범주: </value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>추천 동작: </value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>더 자세한 내용을 보려면 다음을 입력하세요. </value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>기술 정보를 보려면 다음을 입력하세요. </value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>예제를 보려면 다음을 입력하세요. </value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>온라인 도움말을 보려면 다음을 입력하세요. </value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
@@ -241,52 +241,52 @@
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>명명됨</value>
   </data>
   <data name="Drives" xml:space="preserve">
-    <value>DRIVES</value>
+    <value>드라이브</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>기능</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>작업</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>작업: </value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>필터</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>동적 매개 변수</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>지원되는 cmdlet: </value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>별칭</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Get-Help에서 이 cmdlet의 도움말 파일을 이 컴퓨터에서 찾을 수 없습니다. 부분적인 도움말만 표시됩니다.
+    -- 이 cmdlet을 포함하는 모듈의 도움말 파일을 다운로드하여 설치하려면 Update-Help를 사용하세요.
+    -- 이 cmdlet의 도움말 항목을 온라인으로 보려면 "Get-Help {0} -Online"을 입력하거나
+       {1}(으)로 이동</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>없음</value>
   </data>
   <data name="ParameterAliases" xml:space="preserve">
-    <value>Aliases                      </value>
+    <value>별칭                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>동적 여부                     </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>매개 변수 집합 이름           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>UI 문화권 {0}에 대한 HelpInfo XML 파일을 검색할 수 없습니다. 모듈 매니페스트의 HelpInfoUri 속성이 올바른지 확인하거나 네트워크 연결을 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
@@ -298,176 +298,176 @@
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>지정한 문화권은 지원되지 않습니다. {0}. 다음 목록에서 문화권을 지정하세요: {{{1}}}.</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>오류 처리를 미루고 대체 문화권을 시도합니다. 대체 문화권이 모두 지원되지 않으면 다음과 같이 오류가 표시됩니다:
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>ModuleBase 디렉터리를 찾을 수 없습니다. 디렉터리를 확인한 다음 다시 시도하세요.</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>경로 {0}은(는) 올바른 디렉터리가 아닙니다. 디렉터리가 있는지 확인한 다음 다시 시도하세요.</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>도움말 URI에는 10개를 초과하는 리디렉션을 포함할 수 없습니다. 올바른 Help URI를 지정하세요.</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>도움말 업데이트</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>도움말 콘텐츠에 연결하는 중...</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>도움말 콘텐츠 다운로드 중...</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>도움말 콘텐츠를 설치하는 중...</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>도움말 콘텐츠를 찾는 중...</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(모두)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>다음 패턴과 일치하는 PowerShell 모듈을 찾을 수 없습니다. {0}. 패턴을 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>지정된 FullyQualifiedModule {0}과(와) 일치하는 PowerShell 모듈을 찾을 수 없습니다. FullyQualifiedModule 값을 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>도움말 콘텐츠를 찾을 수 없습니다. 서버를 사용할 수 있는지, 그리고 도움말 콘텐츠 위치가 HelpInfo XML에 올바르게 정의되어 있는지 확인하세요.</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>지정한 모듈이 업데이트 가능한 도움말을 지원하지 않으므로 Update-Help 명령이 실패했습니다. Get-Help -Online을 사용하거나 온라인에서 이 모듈의 명령에 대한 도움말을 찾아보세요.</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>다음 매개 변수는 null이거나 비워 둘 수 없습니다. Module.</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>다음 매개 변수는 null이거나 비워 둘 수 없습니다. Path.</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Update-Help가 완료되었습니다.</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>도움말 콘텐츠를 추출하는 중 오류가 발생했습니다.</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>도움말 콘텐츠에 연결할 수 없습니다. 도움말 콘텐츠가 저장된 서버를 사용할 수 없을 수 있습니다. 서버를 사용할 수 있는지 확인하거나 서버가 다시 온라인 상태가 될 때까지 기다린 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>지정한 위치의 도움말 콘텐츠가 올바르지 않습니다. 유효한 도움말 콘텐츠가 포함된 위치를 지정하세요.</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>HelpInfo XML이 올바르지 않습니다. 유효한 HelpInfo XML을 지정하세요.</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>도움말 내용이 다음 위치에 저장되었습니다. {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>{0}에서 도움말 콘텐츠 XSD 파일을 찾을 수 없습니다. 지정된 위치에 XSD 파일이 있는지 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
+    <value>모듈에 대한 도움말을 업데이트하지 못했습니다:
 '{0}'
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>도움말 저장 중</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>도움말 콘텐츠에 올바르지 않은 파일이 포함되어 있습니다. .txt 및 .xml 파일만 지원됩니다.</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>모듈 '{0}'에 대한 도움말을 저장하지 못했습니다. {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>UI 문화권이 {{{1}}}인 모듈 '{0}'에 대한 도움말을 저장하지 못했습니다: {2}.
+영어-US 도움말 콘텐츠를 사용할 수 있으며 Save-Help -UICulture en-US를 사용하여 저장할 수 있습니다.</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>UI 문화권이 {{{1}}}인 모듈 '{0}'에 대한 도움말을 업데이트하지 못했습니다: {2}.
+영어-US 도움말 콘텐츠를 사용할 수 있으며 Update-Help -UICulture en-US를 사용하여 설치할 수 있습니다.</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>현재 문화권은 ({0})이며, 어떤 언어와도 연결되어 있지 않습니다. 시스템 문화권을 변경하거나 Update-Help -UICulture en-US를 사용하여 영어-US 도움말 콘텐츠를 설치하는 것이 좋습니다.</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
     <value>false</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>-Recurse 매개 변수는 원본 경로가 지정된 경우에만 사용할 수 있습니다.</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>경로 {0}에 FileSystem 공급자가 없습니다. 지정한 경로에 FileSystem 공급자가 포함되어 있는지 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>{0}에 대한 도움말을 검색하는 중...</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>다음 패턴과 일치하는 UI 문화권을 찾을 수 없습니다. {0}. 패턴을 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>이 컴퓨터에서 지난 24시간 이내에 Save-Help 명령이 실행되었기 때문에 모듈 {0}에 대한 도움말이 저장되지 않았습니다.
+도움말을 다시 저장하려면 명령에 Force 매개 변수를 추가하세요.</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>이 컴퓨터에서 지난 24시간 이내에 Update-Help 명령이 실행되었기 때문에 모듈 {0}에 대한 도움말이 업데이트되지 않았습니다.
+도움말을 다시 업데이트하려면 명령에 Force 매개 변수를 추가하세요.</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>가장 최신의 도움말 파일이 이미 설치되어 있습니다.</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}. 문화권 {2} 버전 {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>{0}에 업데이트됨</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>모듈 매니페스트의 HelpInfoUri 키 값은 도움말 파일이 저장된 웹 사이트의 컨테이너 또는 루트 URL을 가리켜야 합니다. HelpInfoUri '{0}'은(는) 컨테이너를 가리키지 않습니다.</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>도움말 콘텐츠는 네임스페이스 {0}에 있어야 합니다.</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Get-Help에서 이 cmdlet의 도움말 파일을 이 컴퓨터에서 찾을 수 없습니다. 부분적인 도움말만 표시됩니다.
+    -- 이 cmdlet을 포함하는 모듈의 도움말 파일을 다운로드하여 설치하려면 Update-Help를 사용하세요.</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>최신 도움말 파일이 이미 다운로드되어 있습니다.</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>{0} 저장됨</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>HelpInfoURI {0}이(가) HTTP로 시작하지 않습니다.</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>도움말 콘텐츠의 루트 수준 요소는 "helpItems"여야 합니다.</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>모듈 {0}에 대한 도움말을 저장하는 중</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>모듈 {0}에 대한 도움말을 업데이트하는 중</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>URI를 확인하는 중: "{0}”</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>도움말 URI: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}, 현재 버전: {1}, 사용 가능한 버전: {2}, UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>속성</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>방법</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/InternalCommandStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/InternalCommandStrings.ko.resx
@@ -118,76 +118,76 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AmbiguousMethodName" xml:space="preserve">
-    <value>Input name "{0}" is ambiguous. It can be resolved to multiple matched methods. Possible matches include:{1}.</value>
+    <value>입력 이름 "{0}"이(가) 모호합니다. 이 이름은 여러 일치 항목에 해당할 수 있습니다. 가능한 일치 항목은 다음과 같습니다. {1}</value>
   </data>
   <data name="AmbiguousPropertyOrMethodName" xml:space="preserve">
-    <value>Input name "{0}" is ambiguous. It can be resolved to multiple matched members. Possible matches include:{1}.</value>
+    <value>입력 이름 "{0}"이(가) 모호합니다. 이 이름은 여러 일치 멤버에 해당할 수 있습니다. 가능한 일치 항목은 다음과 같습니다. {1}</value>
   </data>
   <data name="ForEachObjectKeyAction" xml:space="preserve">
-    <value>Retrieve the value for key '{0}'</value>
+    <value>키 '{0}'의 값 검색</value>
   </data>
   <data name="ForEachObjectMethodActionWithArguments" xml:space="preserve">
-    <value>Invoke method '{0}' with arguments: {1}</value>
+    <value>다음 인수를 사용하여 메서드 '{0}'을(를) 호출합니다. {1}</value>
   </data>
   <data name="ForEachObjectMethodActionWithoutArguments" xml:space="preserve">
-    <value>Invoke method '{0}'</value>
+    <value>메서드 '{0}' 호출</value>
   </data>
   <data name="ForEachObjectPropertyAction" xml:space="preserve">
-    <value>Retrieve the value for property '{0}'</value>
+    <value>속성 '{0}'의 값 검색</value>
   </data>
   <data name="ForEachObjectTarget" xml:space="preserve">
-    <value>InputObject: {0}</value>
+    <value>inputObject: {0}</value>
   </data>
   <data name="InputObjectIsNull" xml:space="preserve">
-    <value>Cannot operate on a 'null' input object.</value>
+    <value>'null' 입력 개체에는 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="MethodNotFound" xml:space="preserve">
-    <value>Input name "{0}" cannot be resolved to a method.</value>
+    <value>입력 이름 "{0}"을(를) 메서드로 확인할 수 없습니다.</value>
   </data>
   <data name="NoMethodInvocationInRestrictedLanguageMode" xml:space="preserve">
-    <value>Cannot invoke a method in the restricted language mode.</value>
+    <value>제한된 언어 모드에서는 메서드를 호출할 수 없습니다.</value>
   </data>
   <data name="NoShouldProcessForScriptBlockSet" xml:space="preserve">
-    <value>The -WhatIf and -Confirm parameters are not supported for script blocks.</value>
+    <value>-WhatIf 및 -Confirm 매개 변수는 스크립트 블록에서 지원되지 않습니다.</value>
   </data>
   <data name="OperationNotAllowedInRestrictedLanguageMode" xml:space="preserve">
-    <value>The '{0}' operation is not allowed in the RestrictedLanguage mode.</value>
+    <value>RestrictedLanguage 모드에서는 '{0}' 작업이 허용되지 않습니다.</value>
   </data>
   <data name="OperatorNotSpecified" xml:space="preserve">
-    <value>An operator is required to compare the two specified values. Include a valid operator in the command, and then try the command again. For example, Get-Process | Where-Object -Property Name -eq Idle</value>
+    <value>지정된 두 값을 비교하려면 연산자가 필요합니다. 명령에 올바른 연산자를 포함한 다음 명령을 다시 시도하세요. 예: Get-Process | Where-Object -Property Name -eq Idle</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The input name "{0}" cannot be resolved to a property.</value>
+    <value>입력 이름 "{0}"을(를) 속성으로 확인할 수 없습니다.</value>
   </data>
   <data name="PropertyOrMethodNotFound" xml:space="preserve">
-    <value>The input name "{0}" cannot be resolved to a member.</value>
+    <value>입력 이름 "{0}"을(를) 멤버로 확인할 수 없습니다.</value>
   </data>
   <data name="ValueNotSpecifiedForWhereObject" xml:space="preserve">
-    <value>The specified operator requires both the -Property and -Value parameters. Provide values for both parameters, and then try the command again.</value>
+    <value>지정된 연산자에는 -Property 및 -Value 매개 변수가 모두 필요합니다. 두 매개 변수에 값을 모두 입력한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="PSTaskStreamWriterWrongThread" xml:space="preserve">
-    <value>This method cannot be run on the current thread. It can only be called on the cmdlet thread.</value>
+    <value>이 메서드는 현재 스레드에서 실행할 수 없습니다. cmdlet 스레드에서만 호출할 수 있습니다.</value>
   </data>
   <data name="ParallelUsingVariableCannotBeScriptBlock" xml:space="preserve">
-    <value>A ForEach-Object -Parallel using variable cannot be a script block. Passed-in script block variables are not supported with ForEach-Object -Parallel, and can result in undefined behavior.</value>
+    <value>변수를 사용하는 ForEach-Object -Parallel의 입력 개체는 스크립트 블록일 수 없습니다. 전달된 스크립트 블록 변수는 ForEach-Object -Parallel에서 지원되지 않으며 정의되지 않은 동작을 일으킬 수 있습니다.</value>
   </data>
   <data name="ParallelPipedInputObjectCannotBeScriptBlock" xml:space="preserve">
-    <value>A ForEach-Object -Parallel piped input object cannot be a script block. Passed-in script block variables are not supported with ForEach-Object -Parallel, and can result in undefined behavior.</value>
+    <value>ForEach-Object -Parallel의 파이프된 입력 개체는 스크립트 블록일 수 없습니다. 전달된 스크립트 블록 변수는 ForEach-Object -Parallel에서 지원되지 않으며 정의되지 않은 동작을 일으킬 수 있습니다.</value>
   </data>
   <data name="ParallelCannotUseTimeoutWithJob" xml:space="preserve">
-    <value>The 'TimeoutSeconds' parameter cannot be used with the 'AsJob' parameter.</value>
+    <value>'TimeoutSeconds' 매개 변수는 'AsJob' 매개 변수와 함께 사용할 수 없습니다.</value>
   </data>
   <data name="ParallelCommonParametersNotSupported" xml:space="preserve">
-    <value>The following common parameters are not currently supported in the Parallel parameter set:
+    <value>다음 일반 매개 변수는 현재 Parallel 매개 변수 집합에서 지원되지 않습니다.
 ErrorAction, WarningAction, InformationAction, PipelineVariable</value>
   </data>
   <data name="ParallelPipedInputProcessingError" xml:space="preserve">
-    <value>An unexpected error has occurred while processing ForEach-Object -Parallel input. This may mean that some of the piped input did not get processed. Error: {0}.</value>
+    <value>ForEach-Object -Parallel 입력을 처리하는 동안 예기치 않은 오류가 발생했습니다. 파이프된 입력 중 일부가 처리되지 않았을 수 있습니다. 오류: {0}.</value>
   </data>
   <data name="WDACLogTitle" xml:space="preserve">
     <value>ForEach-Object Cmdlet</value>
   </data>
   <data name="WDACLogMessage" xml:space="preserve">
-    <value>Method invocation on type '{0}' will not be allowed when run in Constrained Language mode.</value>
+    <value>제한된 언어 모드에서 '{0}' 형식에 대한 메서드 호출은 허용되지 않습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/InternalHostUserInterfaceStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/InternalHostUserInterfaceStrings.ko.resx
@@ -118,106 +118,106 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="WriteDebugLineStoppedError" xml:space="preserve">
-    <value>WriteDebug stopped because the value of the DebugPreference variable was 'Stop'.</value>
+    <value>DebugPreference 변수의 값이 'Stop'이므로 WriteDebug를 중지했습니다.</value>
   </data>
   <data name="UnsupportedPreferenceError" xml:space="preserve">
-    <value>The value {0} is not a supported ActionPreference value.</value>
+    <value>값 {0}은(는) 지원되는 ActionPreference 값이 아닙니다.</value>
   </data>
   <data name="PromptEmptyDescriptionsError" xml:space="preserve">
-    <value>The "{0}" parameter must contain at least one value.</value>
+    <value>"{0}" 매개 변수에는 값이 하나 이상 있어야 합니다.</value>
   </data>
   <data name="ShouldContinueYesLabel" xml:space="preserve">
-    <value>&amp;Yes</value>
+    <value>예(&amp;Y)</value>
   </data>
   <data name="ShouldContinueYesHelp" xml:space="preserve">
-    <value>Continue.</value>
+    <value>계속.</value>
   </data>
   <data name="ShouldContinueYesToAllLabel" xml:space="preserve">
-    <value>Yes to &amp;All</value>
+    <value>모두 예(&amp;A)</value>
   </data>
   <data name="ShouldContinueYesToAllHelp" xml:space="preserve">
-    <value>Continue, and do not ask again whether to continue in this session.</value>
+    <value>계속하고 이 세션에서 계속할지 다시 묻지 않습니다.</value>
   </data>
   <data name="ShouldContinueNoLabel" xml:space="preserve">
-    <value>&amp;No</value>
+    <value>아니요(&amp;N)</value>
   </data>
   <data name="ShouldContinueNoHelp" xml:space="preserve">
-    <value>End the operation with an error.</value>
+    <value>오류로 작업을 종료합니다.</value>
   </data>
   <data name="ShouldContinueNoToAllLabel" xml:space="preserve">
-    <value>No to A&amp;ll</value>
+    <value>모두 아니요(&amp;L)</value>
   </data>
   <data name="ShouldContinueNoToAllHelp" xml:space="preserve">
-    <value>End the operation with an error. Do not request to resume operation for this session.</value>
+    <value>오류로 작업을 종료합니다. 이 세션에서는 작업을 다시 시작하도록 요청하지 않습니다.</value>
   </data>
   <data name="ShouldContinueSuspendLabel" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>일시 중단(&amp;S)</value>
   </data>
   <data name="ShouldContinueSuspendHelp" xml:space="preserve">
-    <value>Pause the current operation and enter a command prompt. Type "exit" to resume the paused operation.</value>
+    <value>현재 작업을 일시 중지하고 명령 프롬프트로 이동합니다. 일시 중지된 작업을 다시 시작하려면 "exit"를 입력하세요.</value>
   </data>
   <data name="ShouldContinuePromptMessage" xml:space="preserve">
-    <value>Continue with this operation?</value>
+    <value>이 작업을 계속하시겠습니까?</value>
   </data>
   <data name="DefaultChoice" xml:space="preserve">
-    <value>(default is "{0}")</value>
+    <value>(기본값은 "{0}"입니다.)</value>
   </data>
   <data name="DefaultChoicesForMultipleChoices" xml:space="preserve">
-    <value>(default choices are {0})</value>
+    <value>(기본 선택 항목은 {0}입니다.)</value>
   </data>
   <data name="ChoiceMessage" xml:space="preserve">
-    <value>Choice[{0}]: </value>
+    <value>선택[{0}]: </value>
   </data>
   <data name="EmptyChoicesError" xml:space="preserve">
-    <value>"{0}" should have at least one element.</value>
+    <value>"{0}"에는 요소가 하나 이상 있어야 합니다.</value>
   </data>
   <data name="InvalidDefaultChoiceForMultipleSelection" xml:space="preserve">
-    <value>"{0}" must be a valid index into "{1}". "{2}" is not a valid index.</value>
+    <value>"{0}"은(는) "{1}"의 유효한 인덱스여야 합니다. "{2}"은(는) 유효한 인덱스가 아닙니다.</value>
   </data>
   <data name="InvalidChoiceHotKeyError" xml:space="preserve">
-    <value>Cannot process the hot key because a question mark ("?") cannot be used as a hot key.</value>
+    <value>물음표("?")는 바로 가기 키로 사용할 수 없으므로 바로 가기 키를 처리할 수 없습니다.</value>
   </data>
   <data name="VerboseFormatString" xml:space="preserve">
-    <value>VERBOSE: {0}</value>
+    <value>자세한 정보: {0}</value>
   </data>
   <data name="WarningFormatString" xml:space="preserve">
-    <value>WARNING: {0}</value>
+    <value>경고: {0}</value>
   </data>
   <data name="DebugFormatString" xml:space="preserve">
-    <value>DEBUG: {0}</value>
+    <value>디버그: {0}</value>
   </data>
   <data name="HostNotTranscribing" xml:space="preserve">
-    <value>The host is not currently transcribing.</value>
+    <value>호스트가 현재 전사 중이 아닙니다.</value>
   </data>
   <data name="CommandStartTime" xml:space="preserve">
-    <value>Command start time: {0}</value>
+    <value>명령 시작 시간: {0}</value>
   </data>
   <data name="TranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
-Username: {1}
-RunAs User: {2}
-Configuration Name: {3}
-Machine: {4} ({5})
-Host Application: {6}
-Process ID: {7}
+PowerShell 기록 시작
+시작 시간: {0:yyyyMMddHHmmss}
+사용자 이름: {1}
+실행 사용자: {2}
+구성 이름: {3}
+컴퓨터: {4} ({5})
+호스트 애플리케이션: {6}
+프로세스 ID: {7}
 {8}
 **********************</value>
   </data>
   <data name="MinimalTranscriptPrologue" xml:space="preserve">
     <value>**********************
-PowerShell transcript start
-Start time: {0:yyyyMMddHHmmss}
+PowerShell 기록 시작
+시작 시간: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="TranscriptEpilogue" xml:space="preserve">
     <value>**********************
-PowerShell transcript end
-End time: {0:yyyyMMddHHmmss}
+PowerShell 기록 끝
+종료 시간: {0:yyyyMMddHHmmss}
 **********************</value>
   </data>
   <data name="InvalidTranscriptFilePath" xml:space="preserve">
-    <value>File path {0} resolves to a directory.</value>
+    <value>파일 경로 {0}은(는) 디렉터리로 확인됩니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/Metadata.ko.resx
+++ b/src/System.Management.Automation/resources/ko/Metadata.ko.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>"{0}"에 대해 특성을 초기화할 수 없습니다. "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>인수의 형식 "{0}"이(가) 매개 변수의 최대 및 최소 제한과 같은 형식({1})이 아니므로 인수의 유효성을 검사할 수 없습니다. 인수가 {1} 형식인지 확인한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>인수 "{0}"은(는) 값이 0보다 크지 않으므로 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>인수 "{0}"은(는) 값이 0보다 크거나 같지 않으므로 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>인수 "{0}"은(는) 값이 0보다 작지 않으므로 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>인수 "{0}"는 값이 0보다 작거나 같지 않으므로 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>지정된 최소 범위({0})는 지정된 최대 범위({1})와 형식이 같지 않으므로 사용할 수 없습니다. 매개 변수의 ValidateRange 특성을 업데이트하세요.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>MaxRange 및 MinRange 매개 변수 형식을 사용할 수 없습니다. 두 매개 변수는 모두 IComparable 인터페이스를 구현하는 개체여야 합니다.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>지정된 최대 범위가 지정된 최소 범위보다 작으므로 사용할 수 없습니다. 매개 변수의 ValidateRange 특성을 업데이트하세요.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>{0} 인수가 허용되는 최대 범위인 {1}보다 큽니다. {1}보다 작거나 같은 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>{0} 인수가 허용되는 최소 범위인 {1}보다 작습니다. {1}보다 크거나 같은 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>인수 "{0}"이(가) "{1}" 패턴과 일치하지 않습니다. "{1}"과(와) 일치하는 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>배열이 아닌 매개 변수에는 ValidateCount 특성을 적용할 수 없습니다. 매개 변수에서 특성을 제거하거나 매개 변수를 배열 매개 변수로 만드세요.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>매개 변수에는 정확히 {0}개의 값이 필요합니다. {1}개의 값이 제공되었습니다.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>매개 변수에는 {0}개 이상의 값과 {1}개 이하의 값이 필요합니다. {2}개의 값이 제공되었습니다.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>매개 변수에 지정된 최대 인수 개수가 지정된 최소 인수 개수보다 적습니다. 매개 변수의 ValidateCount 특성을 업데이트하세요.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>인수에 지정된 최대 문자 길이가 지정된 최소 인수 문자 길이보다 짧습니다. 매개 변수의 ValidateLength 특성을 업데이트하세요.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>ValidateLength 특성은 string 또는 string[] 매개 변수에만 적용할 수 있습니다. 매개 변수를 string 또는 string[] 매개 변수로 바꾸세요.</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>인수의 문자 길이({1})가 너무 짧습니다. 길이가 "{0}"보다 크거나 같은 인수를 지정한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>인수의 문자 길이({1})가 너무 깁니다. 길이가 "{0}"보다 짧거나 같은 인수를 지정한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>인수 "{0}"은(는) ValidateSet 특성에 지정된 집합 "{1}"에 속하지 않습니다. 집합에 있는 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>유효한 값 생성기가 null 값을 반환합니다.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>속성 "{1}"에서 "{0}"이(가) 실패했습니다. {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>명령을 가져오거나 실행할 수 없습니다. 이 명령에 대해 허용되는 최대 매개 변수 집합 수를 초과했습니다.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>인수 값이 문자열이 아니므로 인수를 처리할 수 없습니다. ArgumentTransformationAttribute가 지정된 매개 변수 인수의 값은 문자열이어야 합니다.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>값 {1}이(가) {0} 변수에 대한 올바른 값이 아니므로 변수의 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>값이 {0}인 변수 {1}이(가) 더 이상 유효하지 않으므로 특성을 추가할 수 없습니다.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>인수가 null입니다. 인수에 유효한 값을 제공한 다음 명령을 다시 실행하세요.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>인수 값이 null이거나 인수 컬렉션의 요소에 null 값이 있습니다. null 값이 포함되지 않은 컬렉션을 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>인수가 Null이거나 비어 있습니다. null이 아니고 비어 있지 않은 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>인수가 null이거나, 비어 있거나, 인수 컬렉션의 요소에 null 값이 포함되어 있습니다. null 값이 포함되지 않은 컬렉션을 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>인수가 null이거나, 비어 있거나, 공백 문자로만 구성되어 있습니다. 공백이 아닌 문자가 포함된 인수를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>인수 컬렉션의 요소가 null이거나, 비어 있거나, 공백 문자로만 구성되어 있습니다. 해당 값이 포함되지 않은 컬렉션을 제공한 후 명령을 다시 시도하세요.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>이름이 '{0}'인 매개 변수가 명령에 대해 여러 번 정의되었습니다.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>이름이 '{0}'인 별칭이 명령에 이미 여러 번 정의되어 있으므로 매개 변수 별칭을 지정할 수 없습니다.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>'{0}' 매개 변수는 '{1}' 매개 변수의 같은 이름 별칭과 충돌하므로 지정할 수 없습니다.</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>값이 "{1}"인 인수에 대한 "{0}" 유효성 검사 스크립트가 True를 반환하지 않았습니다. 유효성 검사 스크립트가 실패한 이유를 확인한 후 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>"{0}" 인수에 유효한 PowerShell 버전이 포함되어 있지 않습니다. 올바른 버전 번호를 제공한 다음 명령을 다시 시도하세요.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>인수 '{0}'의 유효성을 검사할 수 없습니다. 유효한 변수 이름이 아닙니다.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>작업 변환 형식은 IAstToScriptBlockConverter에서 파생되어야 합니다.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>인수가 잘못되었습니다. 문자열 형식의 경로 인수를 제공하세요.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>경로 인수 드라이브 {0}이(가) 승인된 드라이브 집합 {1}에 속하지 않습니다. 승인된 드라이브가 포함된 경로 인수를 제공하세요.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>경로에 유효하지 않은 문자가 포함되어 있습니다.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>경로 인수에 루트 드라이브가 없습니다.  루트 드라이브가 포함된 전체 경로 인수를 제공하세요.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>'{0}' 매개 변수의 인수 값은 null이거나 빈 문자열일 수 없습니다.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>'{0}'은(는) '{1}' 매개 변수의 올바른 값이 아닙니다. 다음 멤버 중 하나를 지정한 다음 다시 시도하세요: {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>입력을 처리할 수 없습니다. "{0}" 인수는 신뢰할 수 없습니다.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>ValidateTrustedData 특성 검사 실패</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>'{0}' 매개 변수 인수는 신뢰할 수 없으며, 제한 언어 모드에서 ValidateTrustedData 매개 변수 특성 검사에 실패합니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/MiniShellErrors.ko.resx
+++ b/src/System.Management.Automation/resources/ko/MiniShellErrors.ko.resx
@@ -118,9 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="UpdateNotSupportedForConfigurationCategory" xml:space="preserve">
-    <value>The update is not supported for the runspace configuration category {0}. </value>
+    <value>런스페이스 구성 범주 {0}에서는 업데이트를 지원하지 않습니다. </value>
   </data>
   <data name="UpdateAssemblyErrors" xml:space="preserve">
-    <value>The following errors occurred when updating the assembly list for the runspace: {0}.</value>
+    <value>런스페이스의 어셈블리 목록을 업데이트하는 동안 다음 오류가 발생했습니다. {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/NativeCP.ko.resx
+++ b/src/System.Management.Automation/resources/ko/NativeCP.ko.resx
@@ -118,30 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="IncorrectValueForCommandParameter" xml:space="preserve">
-    <value>ScriptBlock should only be specified as a value of the Command parameter.</value>
+    <value>ScriptBlock은 Command 매개 변수의 값으로만 지정할 수 있습니다.</value>
   </data>
   <data name="NoValueForCommandParameter" xml:space="preserve">
-    <value>No value was specified for the Command parameter.</value>
+    <value>Command 매개 변수의 값을 지정하지 않았습니다.</value>
   </data>
   <data name="IncorrectValueForFormatParameter" xml:space="preserve">
-    <value>A value that is not valid ({6}) was specified for the {7} parameter. Valid values are Text and Xml.</value>
+    <value>{7} 매개 변수에 잘못된 값({6})이 지정되었습니다. 유효한 값은 Text 및 Xml입니다.</value>
   </data>
   <data name="NoValueForInputFormatParameter" xml:space="preserve">
-    <value>No value was specified for the InputFormat parameter. Valid values are Text and Xml.</value>
+    <value>InputFormat 매개 변수에 대한 값이 지정되지 않았습니다. 유효한 값은 Text 및 Xml입니다.</value>
   </data>
   <data name="NoValueForOutputFormatParameter" xml:space="preserve">
-    <value>No value was specified for the OutputFormat parameter. Valid values are text and XML.</value>
+    <value>OutputFormat 매개 변수에 대한 값이 지정되지 않았습니다. 유효한 값은 text 및 XML입니다.</value>
   </data>
   <data name="StringValueExpectedForFormatParameter" xml:space="preserve">
-    <value>The {6} parameter requires a string value.</value>
+    <value>{6} 매개 변수에는 문자열 값이 필요합니다.</value>
   </data>
   <data name="NoValuesSpecifiedForArgs" xml:space="preserve">
-    <value>No value was specified for the Args parameter.</value>
+    <value>Args 매개 변수의 값을 지정하지 않았습니다.</value>
   </data>
   <data name="ParameterSpecifiedAlready" xml:space="preserve">
-    <value>The {6} parameter was already specified.</value>
+    <value>{6} 매개 변수는 이미 지정되었습니다.</value>
   </data>
   <data name="CliXmlError" xml:space="preserve">
-    <value>Cannot process the XML from the '{0}' stream of '{1}': {2}</value>
+    <value>'{1}'의 '{0}' 스트림에서 XML을 처리할 수 없습니다. {2}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/PSConfigurationStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/PSConfigurationStrings.ko.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>보안 문제로 인해 PowerShell이 작동을 중지했습니다. 구성 파일을 읽을 수 없습니다. {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/PathUtilsStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/PathUtilsStrings.ko.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>'UTF-7' 인코딩은 더 이상 사용되지 않습니다. UTF-8을 사용하세요.</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>파일 {0}이(가) 이미 존재하며 {1}이(가) 지정되었습니다.</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>현재 공급자({0})는 파일을 열 수 없으므로 파일을 열 수 없습니다.</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>경로가 두 개 이상의 파일로 확인되어 작업을 수행할 수 없습니다. 이 명령은 여러 파일에 사용할 수 없습니다.</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>와일드카드 경로 {0}이(가) 파일로 확인되지 않아 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>알 수 없는 인코딩 {0}입니다. 유효한 값은 {1}입니다.</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>'{0}' 디렉터리가 이미 있습니다.  디렉터리와 디렉터리 안의 파일을 덮어쓰려면 -Force 매개 변수를 사용하세요.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>사용자 모듈 경로가 없으므로 제공된 모듈 이름 '{0}'에 대한 모듈 폴더를 만들 수 없습니다.</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>다음과 같은 이유로 모듈 {0}을(를) 만들 수 없습니다. {1}. -OutputModule 매개 변수에 다른 인수를 사용한 다음 다시 시도하세요.</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>호환되지 않는 버전의 {0} cmdlet을 사용해 모듈을 생성했으므로 모듈을 로드할 수 없습니다. 현재 세션에서 {0} cmdlet을 사용해 모듈을 생성한 다음 모듈을 다시 로드하세요.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/ProgressRecordStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/ProgressRecordStrings.ko.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgMayNotBeNegative" xml:space="preserve">
-    <value>Cannot process the argument because {0} cannot be a negative value.</value>
+    <value>음수 값이 될 수 없으므로 인수를 처리할 수 없습니다. {0}</value>
   </data>
   <data name="ArgMayNotBeNullOrEmpty" xml:space="preserve">
-    <value>Cannot process the argument because the value of {0} cannot be null or empty.</value>
+    <value>{0} 값은 null이거나 비어 있을 수 없으므로 인수를 처리할 수 없습니다.</value>
   </data>
   <data name="PercentMayNotBeMoreThan100" xml:space="preserve">
-    <value>Cannot set percent because {0} cannot be greater than 100.</value>
+    <value>{0}은(는) 100보다 클 수 없으므로 백분율을 설정할 수 없습니다.</value>
   </data>
   <data name="ParentActivityIdCantBeActivityId" xml:space="preserve">
-    <value>ParentActivityId cannot be the same as the ActivityId.</value>
+    <value>ParentActivityId는 ActivityId와 같을 수 없습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/RemotingErrorIdStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/RemotingErrorIdStrings.ko.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>FilePath 매개 변수에는 와일드카드 문자를 사용할 수 없습니다. 와일드카드 문자가 없는 경로를 지정하세요.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>세션 옵션 {0}에는 {1} 값을 지정해야 합니다.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>원격 컴퓨터에 연결할 때 허용할 최대 WS-Man URI 리디렉션 수</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>WriteEvents 매개 변수는 Wait 매개 변수와 함께만 사용할 수 있습니다.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>WinPE(Windows 사전 설치 환경)에서는 PowerShell 원격 처리가 지원되지 않습니다.</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>WinRM 서비스를 다시 시작하기 전에는 {0}이(가) 적용한 변경 내용이 적용되지 않습니다.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0}이(가) 이름을 사용하는 구성이 최근에 등록 취소된 경우 WinRM 서비스를 다시 시작해야 할 수 있습니다. 일부 시스템 데이터 구조가 아직 캐시되어 있을 수 있기 때문입니다. 이 경우 WinRM을 다시 시작해야 할 수 있습니다.
+Microsoft.PowerShell과 Register-PSSessionConfiguration cmdlet으로 만든 세션 구성 같은 PowerShell 세션 구성에 연결된 모든 WinRM 세션의 연결이 끊어집니다.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>원격 세션에서 실행 중이며 강제 옵션을 선택했습니다. 그러면 WinRM 서비스가 다시 시작될 수 있습니다. WinRM 서비스가 다시 시작되면 이 원격 세션은 종료됩니다. 계속하려면 새 세션을 만들어야 합니다</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>-WriteJobInResults 매개 변수는 -Wait 매개 변수와 함께만 사용할 수 있습니다.</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>제공된 입력 스트림이 올바르지 않습니다. 입력 스트림으로는 {0}만 지원됩니다.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>제공된 출력 스트림 집합이 올바르지 않습니다. 출력 스트림으로는 {0}만 지원됩니다.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>제공된 WSMAN_SENDER_DETAILS가 올바르지 않습니다. null WSMAN_SENDER_DETAILS는 처리할 수 없습니다.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>제공한 셸 컨텍스트가 올바르지 않습니다.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>플러그 인 메서드 {0}에 대한 {1}에는 NULL 값이 허용되지 않습니다.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>입력 스트림 및 출력 스트림 집합에는 NULL 값이 허용되지 않습니다. {0}과(와) {1}은(는) 지원되는 입력 및 출력 스트림입니다.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>플러그 인 메서드 {0}에 대한 {1}에는 NULL 값이 허용되지 않습니다.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>플러그 인 메서드 {0}에 대한 {1}에는 NULL 값이 허용되지 않습니다.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>PowerShell 플러그 인 작업을 종료하는 중입니다. 호스팅 서비스 또는 응용 프로그램이 종료되는 경우 이 문제가 발생할 수 있습니다.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>PowerShell 플러그 인이 {0} 옵션을 인식하지 못합니다. 클라이언트가 PowerShell의 빌드 {1}과(와) 프로토콜 버전 {2}과(와) 호환되는지 확인하세요.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>이름이 {0}인 옵션이 클라이언트에 있어야 합니다. 클라이언트가 PowerShell의 빌드 {1}과(와) 프로토콜 버전 {2}과(와) 호환되는지 확인하세요.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;PowerShell 플러그 인이 클라이언트에서 요청한 프로토콜 버전 {2}을(를) 지원하지 않습니다.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>PowerShell 플러그 인에서 WSMan 서비스에 컨텍스트를 보고하는 동안 치명적인 오류가 발생했습니다.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>관리형 서버 세션을 만들 수 없습니다.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>PowerShell 플러그 인에서 종료 알림용 대기 핸들을 등록하는 동안 치명적인 오류가 발생했습니다.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>"{0}" 실행 파일을 찾을 수 없습니다. WOW64 기능이 설치되어 있는지 확인하세요.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>이 컴퓨터에서 Windows PowerShell을 찾을 수 없으므로 Windows PowerShell 프로세스를 만들 수 없습니다.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/ko/RunspaceInit.ko.resx
+++ b/src/System.Management.Automation/resources/ko/RunspaceInit.ko.resx
@@ -118,114 +118,114 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="EnabledExperimentalFeatures" xml:space="preserve">
-    <value>Variable to hold the enabled experimental feature names</value>
+    <value>활성화된 실험적 기능 이름을 저장할 변수</value>
   </data>
   <data name="PSHOMEDescription" xml:space="preserve">
-    <value>Parent folder of the host application of the current runspace</value>
+    <value>현재 runspace의 호스트 애플리케이션의 상위 폴더</value>
   </data>
   <data name="HOMEDescription" xml:space="preserve">
-    <value>Folder containing the current user's profile</value>
+    <value>현재 사용자 프로필이 들어 있는 폴더</value>
   </data>
   <data name="PSHostDescription" xml:space="preserve">
-    <value>A reference to the host of the current runspace</value>
+    <value>현재 runspace 호스트에 대한 참조</value>
   </data>
   <data name="ExecutionContextDescription" xml:space="preserve">
-    <value>The run objects available to cmdlets</value>
+    <value>cmdlet에서 사용할 수 있는 실행 개체</value>
   </data>
   <data name="PSVersionTableDescription" xml:space="preserve">
-    <value>Version information for current PowerShell session</value>
+    <value>현재 PowerShell 세션의 버전 정보</value>
   </data>
   <data name="PIDDescription" xml:space="preserve">
-    <value>Current process ID</value>
+    <value>현재 프로세스 ID</value>
   </data>
   <data name="DollarHookDescription" xml:space="preserve">
-    <value>Status of last command</value>
+    <value>마지막 명령 상태</value>
   </data>
   <data name="PPIDDescription" xml:space="preserve">
-    <value>Parent process ID</value>
+    <value>부모 프로세스 ID</value>
   </data>
   <data name="MshShellIdDescription" xml:space="preserve">
-    <value>The ShellID identifies the current shell.  This is used by #Requires.</value>
+    <value>ShellID는 현재 셸을 식별합니다.  #Requires에서 사용됩니다.</value>
   </data>
   <data name="ConsoleDescription" xml:space="preserve">
-    <value>Name of the current console file</value>
+    <value>현재 콘솔 파일 이름</value>
   </data>
   <data name="OutputEncodingDescription" xml:space="preserve">
-    <value>The text encoding used when piping text to a native executable file</value>
+    <value>텍스트를 네이티브 실행 파일로 파이프할 때 사용하는 텍스트 인코딩</value>
   </data>
   <data name="PSApplicationOutputEncodingDescription" xml:space="preserve">
-    <value>The text encoding used when reading output text from a native executable file</value>
+    <value>네이티브 실행 파일에서 출력 텍스트를 읽을 때 사용하는 텍스트 인코딩</value>
   </data>
   <data name="PSStyleDescription" xml:space="preserve">
-    <value>Configuration controlling how text is rendered.</value>
+    <value>텍스트 렌더링 방식을 제어하는 구성</value>
   </data>
   <data name="PSEmailServerDescription" xml:space="preserve">
-    <value>Variable to contain the name of the email server. This can be used instead of the HostName parameter in the Send-MailMessage cmdlet.</value>
+    <value>전자 메일 서버의 이름을 저장하는 변수입니다. Send-MailMessage cmdlet에서 HostName 매개 변수 대신 사용할 수 있습니다.</value>
   </data>
   <data name="ConfirmPreferenceDescription" xml:space="preserve">
-    <value>Dictates when confirmation should be requested. Confirmation is requested when the ConfirmImpact of the operation is equal to or greater than $ConfirmPreference. If $ConfirmPreference is None, actions will only be confirmed when Confirm is specified.</value>
+    <value>확인을 요청해야 하는 시기를 지정합니다. 작업의 ConfirmImpact가 $ConfirmPreference보다 크거나 같으면 확인을 요청합니다. $ConfirmPreference가 None이면 Confirm을 지정한 경우에만 작업을 확인합니다.</value>
   </data>
   <data name="DebugPreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when a Debug message is delivered</value>
+    <value>디버그 메시지가 전달될 때 수행할 작업 지정</value>
   </data>
   <data name="ErrorActionPreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when an error message is delivered</value>
+    <value>오류 메시지가 전달될 때 수행할 작업 지정</value>
   </data>
   <data name="ProgressPreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when progress records are delivered</value>
+    <value>진행률 레코드가 전달될 때 수행할 작업 지정</value>
   </data>
   <data name="VerbosePreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when a Verbose message is delivered</value>
+    <value>Verbose 정보 메시지가 전달될 때 수행할 작업 지정</value>
   </data>
   <data name="WarningPreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when a Warning message is delivered</value>
+    <value>경고 메시지가 전달될 때 수행할 작업을 지정합니다.</value>
   </data>
   <data name="InformationPreferenceDescription" xml:space="preserve">
-    <value>Dictates the action taken when a command generates an item in the Information stream</value>
+    <value>명령이 정보 스트림에 항목을 생성할 때 수행할 작업 지정</value>
   </data>
   <data name="ErrorViewDescription" xml:space="preserve">
-    <value>Dictates the view mode to use when displaying errors</value>
+    <value>오류를 표시할 때 사용할 보기 모드를 지정합니다.</value>
   </data>
   <data name="NestedPromptLevelDescription" xml:space="preserve">
-    <value>Dictates what type of prompt should be displayed for the current nesting level</value>
+    <value>현재 중첩 수준에 표시할 프롬프트 유형 지정</value>
   </data>
   <data name="PSNativeCommandUseErrorActionPreferenceDescription" xml:space="preserve">
-    <value>If true, $ErrorActionPreference applies to native executables, so that non-zero exit codes will generate cmdlet-style errors governed by error action settings</value>
+    <value>true면 $ErrorActionPreference가 네이티브 실행 파일에도 적용됩니다. 따라서 0이 아닌 종료 코드는 오류 동작 설정에 따라 cmdlet 스타일 오류를 생성합니다.</value>
   </data>
   <data name="WhatIfPreferenceDescription" xml:space="preserve">
-    <value>If true, WhatIf is considered to be enabled for all commands.</value>
+    <value>true이면 WhatIf가 모든 명령에 대해 사용하도록 설정된 것으로 간주됩니다.</value>
   </data>
   <data name="NativeCommandArgumentPassingDescription" xml:space="preserve">
-    <value>Dictates how arguments are passed to native executables.</value>
+    <value>네이티브 실행 파일에 인수를 전달하는 방식을 지정합니다.</value>
   </data>
   <data name="FormatEnumerationLimitDescription" xml:space="preserve">
-    <value>Dictates the limit of enumeration on formatting IEnumerable objects</value>
+    <value>IEnumerable 개체의 서식을 지정할 때 열거 제한 지정</value>
   </data>
   <data name="ReportErrorShowStackTraceDescription" xml:space="preserve">
-    <value>Displays errors with a stack trace</value>
+    <value>스택 추적을 포함하여 오류 표시</value>
   </data>
   <data name="ReportErrorShowInnerExceptionDescription" xml:space="preserve">
-    <value>Displays errors with inner exceptions</value>
+    <value>내부 예외를 포함하여 오류 표시</value>
   </data>
   <data name="ReportErrorShowSourceDescription" xml:space="preserve">
-    <value>Displays errors with their sources</value>
+    <value>출처를 포함하여 오류 표시</value>
   </data>
   <data name="ReportErrorShowExceptionClassDescription" xml:space="preserve">
-    <value>Displays errors with a description of the error class</value>
+    <value>오류 클래스에 대한 설명과 함께 오류를 표시합니다.</value>
   </data>
   <data name="DollarPSCultureDescription" xml:space="preserve">
-    <value>Culture of the current PowerShell session</value>
+    <value>현재 PowerShell 세션의 문화권</value>
   </data>
   <data name="DollarPSUICultureDescription" xml:space="preserve">
-    <value>UI culture of the current PowerShell session</value>
+    <value>현재 PowerShell 세션의 UI 문화권</value>
   </data>
   <data name="PSDefaultParameterValuesDescription" xml:space="preserve">
-    <value>Variable to hold all default &lt;cmdlet:parameter, value&gt; pairs</value>
+    <value>모든 기본 &lt;cmdlet:parameter, value&gt; 쌍을 저장할 변수</value>
   </data>
   <data name="PauseDefinitionString" xml:space="preserve">
-    <value>Press Enter to continue...</value>
+    <value>계속하려면 Enter 키를 누르세요...</value>
   </data>
   <data name="PSEditionDescription" xml:space="preserve">
-    <value>Edition information for the current PowerShell session</value>
+    <value>현재 PowerShell 세션의 에디션 정보</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/RunspaceStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/RunspaceStrings.ko.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>이 작업에는 runspace 상태가 유효하지 않습니다.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>runspace가 BeforeOpen 상태가 아니므로 runspace를 열 수 없습니다. runspace의 현재 상태는 '{0}'입니다.</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>runspace가 Opened 상태가 아니므로 작업을 수행할 수 없습니다. runspace의 현재 상태는 '{0}'입니다.</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Runspace가 열림 상태가 아니므로 파이프라인을 호출할 수 없습니다. runspace의 현재 상태는 '{0}'입니다.</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>이 작업에는 파이프라인 상태가 유효하지 않습니다.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>파이프라인이 이미 호출되었으므로 호출할 수 없습니다.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>매개 변수의 유효한 값은 PipelineResultTypes.Output입니다.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>파이프라인에 명령이 포함되어 있지 않습니다.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>파이프라인이 이미 실행 중이므로 실행할 수 없습니다. 파이프라인은 동시에 실행할 수 없습니다.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>중첩된 파이프라인은 비동기적으로 호출할 수 없습니다. Invoke 메서드를 사용하세요.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>중첩된 파이프라인은 실행 중인 파이프라인 안에서만 실행해야 합니다.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy 메서드 호출이 진행 중인 동안에는 runspace를 닫을 수 없습니다.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy 메서드 호출이 진행 중인 동안에는 파이프라인을 호출할 수 없습니다.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>SessionStateProxy 메서드 호출이 진행 중입니다. 동시에 여러 SessionStateProxy 메서드를 호출할 수 없습니다.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>파이프라인이 이미 실행 중입니다. 동시에 여러 SessionStateProxy 메서드를 호출할 수 없습니다.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>이 속성은 runspace를 연 후에는 변경할 수 없습니다.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>이 runspace를 만드는 데 사용된 InitialSessionState 개체에 지정된 모듈 '{0}'을(를) 처리하는 동안 하나 이상의 오류가 발생했습니다. 전체 오류 목록은 ErrorRecords 속성을 참조하세요. 첫 번째 오류는 다음과 같습니다: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>아파트 상태가 MTA(다중 스레드 아파트)이고, 현재 옵션이 UseNewThread 또는 UseCurrentThread이며, 새 값이 ReuseThread인 경우에만 스레드 옵션을 변경할 수 있습니다.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>{0}은(는) 언어 모드가 {1} 또는 {2}일 때는 false일 수 없습니다.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>로컬 전용 runspace는 연결을 끊을 수 없습니다.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>로컬 runspace에서는 연결 작업이 지원되지 않습니다.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>세션이 사용 중입니다. 사용할 수 있게 되면 바로 세션에 연결됩니다. Enter-PSSession 명령을 취소하려면 Ctrl-C를 누르세요.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>명령을 완료할 수 없습니다. 이 세션 구성에서는 스크립트 호출이 지원되지 않습니다. 세션 구성이 no-language 모드일 때 이 문제가 발생할 수 있습니다.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>로컬 runspace에서는 연결 끊기 및 연결 작업을 사용할 수 없습니다.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>runspace가 Opened 상태가 아니므로 파이프라인을 연결할 수 없습니다.  runspace의 현재 상태는 '{0}'입니다.</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>RemoteRunspace를 만들 수 없습니다. 제공된 RunspacePool 개체가 올바르지 않습니다.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>이 runspace와 연결된 연결 끊긴 명령이 없습니다.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>원격 컴퓨터에서는 연결 끊기 작업이 지원되지 않습니다. 연결 끊기를 지원하려면 원격 컴퓨터에서 Windows PowerShell 3.0 이상을 실행하고 WSMan 전송을 사용해야 합니다.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>세션이 연결 끊김 상태가 아니거나 연결할 수 없으므로 PSSession에 연결할 수 없습니다.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>매개 변수 값은 PipelineResultTypes.None 또는 PipelineResultTypes.Output일 수 없습니다.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>매개 변수의 유효한 값은 PipelineResultTypes.Output 또는 PipelineResultTypes.Null입니다.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>디버그 스트림 리디렉션은 대상 원격 컴퓨터에서 지원되지 않습니다.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>자세한 정보 스트림 리디렉션은 대상 원격 컴퓨터에서 지원되지 않습니다.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>경고 스트림 리디렉션은 대상 원격 컴퓨터에서 지원되지 않습니다.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>정보 스트림 리디렉션은 대상 원격 컴퓨터에서 지원되지 않습니다.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>명령이나 스크립트를 실행 중인 세션에 들어왔습니다.  출력은 작업 "{0}"(으)로 라우팅되므로 콘솔에 출력이 표시되지 않습니다.  실행 중인 명령이 끝날 때까지 기다리거나, 명령을 취소하고 Ctrl-C를 눌러 입력 프롬프트를 가져올 수 있습니다.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>명령 또는 스크립트를 실행 중인 세션에 들어왔으며 출력은 콘솔에 표시됩니다.  실행 중인 명령이 끝날 때까지 기다리거나 Ctrl-C를 눌러 취소한 다음 입력 프롬프트를 받을 수 있습니다.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>실행 중인 명령 또는 스크립트 내부의 디버그 중단점에서 현재 중지된 세션에 들어왔습니다.  PowerShell 명령줄 디버거를 사용하여 디버깅을 계속하세요.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace는 LocalRunspace여야 합니다.</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>정적 PrimaryRunspace 속성은 한 번만 설정할 수 있으며, 이미 설정되어 있습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/SessionStateProviderBaseStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/SessionStateProviderBaseStrings.ko.resx
@@ -118,39 +118,39 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="SetItemAction" xml:space="preserve">
-    <value>Set Item</value>
+    <value>항목 설정</value>
   </data>
   <data name="SetItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Value: {1}</value>
+    <value>항목: {0} 값: {1}</value>
   </data>
   <data name="ClearItemAction" xml:space="preserve">
-    <value>Clear Item</value>
+    <value>항목 지우기</value>
   </data>
   <data name="ClearItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>항목: {0}</value>
   </data>
   <data name="RemoveItemAction" xml:space="preserve">
-    <value>Remove Item</value>
+    <value>항목 제거</value>
   </data>
   <data name="RemoveItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>항목: {0}</value>
   </data>
   <data name="NewItemAction" xml:space="preserve">
-    <value>New Item</value>
+    <value>새 항목</value>
   </data>
   <data name="NewItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Type: {1} Value: {2}</value>
+    <value>항목: {0} 형식: {1} 값: {2}</value>
   </data>
   <data name="CopyItemAction" xml:space="preserve">
-    <value>Copy Item</value>
+    <value>항목 복사</value>
   </data>
   <data name="CopyItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>항목: {0} 대상: {1}</value>
   </data>
   <data name="RenameItemAction" xml:space="preserve">
-    <value>Rename Item</value>
+    <value>항목 이름 바꾸기</value>
   </data>
   <data name="RenameItemResourceTemplate" xml:space="preserve">
-    <value>Item: {0} NewName: {1}</value>
+    <value>항목: {0} NewName: {1}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ko/SessionStateStrings.ko.resx
+++ b/src/System.Management.Automation/resources/ko/SessionStateStrings.ko.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>공급자의 Start 메서드에서 반환된 정보가 전달된 것과 다른 공급자에 대한 정보이므로 반환된 정보를 처리할 수 없습니다.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>공급자의 Start 메서드에서 반환된 정보가 null이므로 반환된 정보를 처리할 수 없습니다.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 SetItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 SetItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ClearItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 InvokeDefaultAction 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 InvokeDefaultAction 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ItemExists 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ItemExists 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 IsValidPath 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 IsItemContainer 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RemoveItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetChildItems 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetChildItems 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetChildNames 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetChildNames 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RenameItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RenameItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 NewItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 NewItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 HasChildItems 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 CopyItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 CopyItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetParentPath 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 NormalizeRelativePath 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 MakePath 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetChildName 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 MoveItem 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 MoveItem 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 SetProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 SetProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ClearProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ClearProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 NewProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 NewProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RemoveProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RemoveProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 CopyProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 CopyProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 MoveProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 MoveProperty 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 RenameProperty 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 RenameProperty에 대한 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 콘텐츠 판독기를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 GetContentReader 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 콘텐츠 작성기를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에 대해 GetContentWriter 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>'{0}'은(는) 디렉터리이므로 콘텐츠를 가져올 수 없습니다. 대신 'Get-ChildItem'을 사용하세요.</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>'{0}'은(는) 디렉터리이므로 콘텐츠를 쓸 수 없습니다.</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>뒤로 이동할 위치 기록이 남아 있지 않습니다.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>앞으로 이동할 위치 기록이 남아 있지 않습니다.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack이 비어 있습니다.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ClearContent 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>'{0}'은(는) 디렉터리이므로 해당 콘텐츠를 지울 수 없습니다. Clear-Content는 파일에서만 지원됩니다.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 ClearContent 작업의 동적 매개 변수를 검색할 수 없습니다. {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 GetSecurityDescriptor 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자에서 SetSecurityDescriptor 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>'{0}' 공급자에서 Start 작업을 수행하지 못했습니다. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>'{0}' 공급자에서 InitializeDefaultDrives 작업을 수행하지 못했습니다.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>루트 '{1}'이(가) 있는 드라이브의 '{0}' 공급자에서 NewDrive 작업을 수행하지 못했습니다. {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>'{0}' 공급자에 대한 NewDrive의 동적 매개 변수를 검색할 수 없습니다. {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>'{0}' 공급자에서 RemoveDrive를 호출하지 못했습니다. {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>공급자 '{1}'에서 허용하지 않으므로 드라이브 '{0}'을(를) 제거할 수 없습니다.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>경로 '{0}'이(가) 기준 '{1}' 밖에 있는 항목을 참조했습니다.</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자 콘텐츠 작성기에서 Seek를 호출하지 못했습니다. {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자 콘텐츠 판독기 또는 작성기에서 Close를 호출하지 못했습니다. {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자 콘텐츠 판독기에서 Read를 호출하지 못했습니다. {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>경로 '{1}'의 '{0}' 공급자 콘텐츠 작성기에서 Write를 호출하지 못했습니다. {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>변수 구문을 사용하여 데이터를 가져오거나 설정할 때는 공급자 '{0}'을(를) 사용할 수 없습니다. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>변수 구문을 사용하여 공급자에서 데이터를 가져오거나 설정할 수 없습니다. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>별칭 {0}이(가) 읽기 전용이거나 상수이고 쓰기가 불가능하므로 별칭을 쓸 수 없습니다.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>함수 {0}은(는) 읽기 전용이거나 상수이므로 쓸 수 없습니다.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>변수가 읽기 전용이거나 상수이므로 변수 {0}을(를) 덮어쓸 수 없습니다.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>변수 '${0}'은(는) 비공개 변수이므로 액세스할 수 없습니다.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>명령 '{0}'은(는) 비공개 명령이므로 명령에 액세스할 수 없습니다.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>비공개 명령이므로 명령에 액세스할 수 없습니다.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>비공개 리소스이므로 세션 상태 리소스에 액세스할 수 없습니다. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>별칭 {0}은(는) 상수이거나 읽기 전용이므로 제거하지 못했습니다.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>함수 {0}은(는) 상수이므로 제거할 수 없습니다.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>변수 {0}은(는) 상수이거나 읽기 전용이므로 제거할 수 없습니다. 변수가 읽기 전용인 경우 Force 옵션을 지정하여 작업을 다시 시도하세요.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>별칭 {0}은(는) 상수이므로 수정할 수 없습니다.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>별칭 {0}은(는) 읽기 전용이므로 수정할 수 없습니다.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>함수 {0}은(는) 상수이므로 수정할 수 없습니다.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>함수 {0}은(는) 읽기 전용이므로 수정할 수 없습니다.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>별칭 {0}은(는) 만든 후 상수로 설정할 수 없습니다. 별칭은 만들 때만 상수로 설정할 수 있습니다.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>기존 함수 {0}은(는) 상수로 만들 수 없습니다. 함수는 만들 때만 상수로 설정할 수 있습니다.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>기존 변수 {0}을(를) 상수로 만들 수 없습니다. 변수는 만들 때만 상수로 설정할 수 있습니다.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>별칭 '{0}'에서 AllScope 옵션을 제거할 수 없습니다.</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>함수 '{0}'에서 AllScope 옵션을 제거할 수 없습니다.</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>변수 '{0}'에서 AllScope 옵션을 제거할 수 없습니다.</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>함수 정의 '{0}'에는 범위 한정자는 있지만 함수 이름이 없습니다.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>공급자 {0}을(를) 제거할 수 없습니다. 공급자 {0}을(를) 제거하려면 먼저 공급자 {0}과(와) 연결된 모든 드라이브를 제거해야 합니다.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>드라이브 이름에 다음과 같은 잘못된 문자가 하나 이상 포함되어 있으므로 드라이브 이름을 처리할 수 없습니다. ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>공급자가 새 드라이브 만들기를 허용하지 않으므로 새 드라이브를 만들지 못했습니다.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>제공된 값 '{0}'이(가) 둘 이상의 위치 스택으로 확인되었습니다.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>위치 스택 '{0}'을(를) 찾을 수 없습니다. 존재하지 않거나 컨테이너가 아닙니다.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>경로 '{0}'이(가) 없으므로 찾을 수 없습니다.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>별칭 '{0}'이(가) 없으므로 별칭을 찾을 수 없습니다.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>경로 '{0}'이(가) 여러 컨테이너로 확인되어 위치를 설정할 수 없습니다. 위치는 한 번에 하나의 컨테이너로만 설정할 수 있습니다.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>변수 경로 '{0}'이(가) 여러 항목으로 확인되었으므로 변수를 처리할 수 없습니다. 변수 값은 한 번에 한 항목씩만 가져오거나 설정할 수 있습니다.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>드라이브를 찾을 수 없습니다. 이름이 '{0}'인 드라이브가 없습니다.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>이름이 '{0}'인 공급자를 찾을 수 없습니다.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>이름이 '{0}'인 공급자를 찾을 수 없습니다. 이름 형식이 올바르지 않습니다. 공급자 이름은 영숫자 문자로만 구성되거나, PowerShell 스냅인 이름 뒤에 단일 '\'와 영숫자 문자가 와야 합니다.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>'{0}'이(가) 둘 이상의 공급자 이름으로 확인되었습니다. 가능한 일치 항목은 다음과 같습니다.{1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>공급자의 인스턴스를 만드는 동안 오류가 발생했습니다. 어셈블리에서 '{0}'의 공급자 형식 이름을 찾을 수 없습니다.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>지정한 공급자 이름 '{0}'에 다음과 같은 잘못된 문자가 하나 이상 포함되어 있으므로 공급자 이름을 사용할 수 없습니다. \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>공급자 '{0}'의 인스턴스를 만드는 동안 오류가 발생했습니다. {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>이름이 '{0}'인 변수를 찾을 수 없습니다.</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>이름이 '{0}'인 추적 원본을 찾을 수 없습니다.</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>이름이 '{0}'인 지정된 드라이브가 이미 있습니다.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>이름이 '{0}'인 변수가 이미 있습니다.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>이름이 '{0}'인 별칭이 이미 있으므로 별칭을 사용할 수 없습니다.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>이름이 '{0}'인 cmdlet 공급자가 이미 있으므로 cmdlet 공급자를 등록할 수 없습니다.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>경로가 파일 시스템 경로를 참조하지 않습니다.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>전역 범위를 제거할 수 없습니다.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>범위 번호 '{0}'이(가) 활성 범위 수를 초과합니다.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>PSDriveInfo를 비교할 수 없습니다. PSDriveInfo 인스턴스는 다른 PSDriveInfo 인스턴스와만 비교할 수 있습니다.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>출력을 스트리밍할 cmdlet이 지정되지 않아 cmdlet 공급자가 결과를 스트리밍할 수 없습니다.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>오류를 스트리밍할 cmdlet이 지정되지 않아 cmdlet 공급자가 결과를 스트리밍할 수 없습니다.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>이 공급자의 홈 위치가 설정되지 않았습니다. 홈 위치를 설정하려면 "(get-psprovider '{0}').Home = 'path'"를 호출하세요.</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>경로 형식이 잘못되었습니다. 공급자 경로에는 공급자 ID 뒤에 "::" 및 공급자별 경로가 차례로 포함되어야 합니다.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>대상 경로를 단일 경로로만 확인할 수 있으므로 항목을 이동할 수 없습니다.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>원본 경로와 대상 경로가 동일한 공급자로 확인되지 않았으므로 항목을 이동할 수 없습니다.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>원본 경로가 하나 이상의 항목을 가리키고 대상 경로가 컨테이너가 아니므로 항목을 이동할 수 없습니다. 대상 경로가 컨테이너인지 확인하고 다시 시도하세요.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>대상이 여러 경로로 확인되었으므로 항목을 이동할 수 없습니다. 하나의 대상으로만 확인되는 대상 경로를 지정하고 다시 시도하세요.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>컨테이너를 기존 리프 항목에 복사할 수 없습니다.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>컨테이너를 다른 컨테이너에 복사할 수 없습니다. -Recurse 또는 -Container 매개 변수가 지정되지 않았습니다.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>원본 경로와 대상 경로가 같은 공급자로 확인되지 않았습니다.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>경로가 여러 항목으로 확인되었으므로 항목 이름을 바꿀 수 없습니다. 한 번에 하나의 항목만 이름을 바꿀 수 있습니다.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>공급자의 오류로 인해 공급자 '{0}'을(를) 사용하여 경로 '{1}'을(를) 확인할 수 없습니다.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>인터페이스를 사용할 수 없습니다. 이 공급자는 IContentCmdletProvider 인터페이스를 구현하지 않습니다.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>인터페이스를 사용할 수 없습니다. 이 공급자는 IPropertyCmdletProvider 인터페이스를 지원하지 않습니다.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>인터페이스를 사용할 수 없습니다. 이 공급자는 IDynamicPropertyCmdletProvider 인터페이스를 구현하지 않습니다.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>이 공급자는 NavigationCmdletProvider 메서드를 지원하지 않습니다.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>공급자 메서드를 처리할 수 없습니다. 이 공급자는 ContainerCmdletProvider 메서드를 지원하지 않습니다.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>메서드를 호출할 수 없습니다. 이 공급자는 ItemCmdletProvider 메서드를 지원하지 않습니다.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>이 공급자는 DriveCmdletProvider 메서드를 지원하지 않습니다.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>공급자가 이 작업을 지원하지 않으므로 공급자 작업이 중지되었습니다.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>공급자가 'Depth' 매개 변수를 지원하지 않으므로 공급자 작업이 중지되었습니다.</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>메서드를 호출할 수 없습니다. 이 공급자는 콘텐츠 Seek 메서드를 지원하지 않습니다.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>ClearContent 작업을 수행할 수 없습니다. 이 공급자는 ClearContent 작업을 지원하지 않습니다.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>공급자가 자격 증명의 사용을 지원하지 않습니다. 자격 증명을 지정하지 않고 작업을 다시 수행하세요.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>FileSystem 공급자는 New-PSDrive cmdlet에서만 자격 증명을 지원합니다. 자격 증명을 지정하지 않고 작업을 다시 수행하세요.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>공급자가 트랜잭션을 지원하지 않습니다. -UseTransaction 매개 변수 없이 작업을 다시 수행하세요.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>메서드를 호출할 수 없습니다. 공급자가 필터의 사용을 지원하지 않습니다.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>드라이브를 만들 수 없습니다. 공급자가 자격 증명의 사용을 지원하지 않습니다.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>경로 '{0}'에 항목이 이미 있습니다.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>항목을 복사할 수 없습니다. 경로 '{0}'에 항목이 없습니다.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>경로 '{0}'에 항목이 없습니다.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>세션 상태에 저장된 별칭의 보기가 포함된 드라이브</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>프로세스에 대한 환경 변수의 보기가 포함된 드라이브</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>세션 상태에 저장된 함수의 보기가 포함된 드라이브</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>세션 상태에 저장된 해당 별칭의 보기가 포함된 드라이브</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>현재 사용자의 임시 디렉터리 경로에 매핑되는 드라이브</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>대상 값을 지정하지 않았으므로 링크 '{0}'을(를) 만들 수 없습니다.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>null 변수에 대한 참조는 항상 null 값을 반환합니다. 할당해도 아무 효과가 없습니다.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>세션에서 유지할 최대 기록 개체 수</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>함수 {0}은(는) 읽기 전용이거나 상수이므로 이름을 바꿀 수 없습니다.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>별칭 {0}은(는) 읽기 전용이거나 상수이므로 이름을 바꿀 수 없습니다.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>변수 {0}은(는) 읽기 전용이거나 상수이므로 이름을 바꿀 수 없습니다.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>로컬 변수 {0}에는 옵션을 설정할 수 없습니다. 옵션을 설정할 수 있는 변수를 만들려면 New-Variable을 사용하세요.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Cmdlet {0}은(는) 읽기 전용이므로 수정할 수 없습니다.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>변수가 최적화되어 제거할 수 없으므로 변수 {0}을(를) 제거할 수 없습니다. 별칭 없이 Remove-Variable cmdlet을 사용하거나, 변수를 제거하는 데 사용하는 명령을 도트 소싱해 보세요.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>변수 {0}이(가) 최적화되어 있으므로 변수를 덮어쓸 수 없습니다. 별칭 없이 New-Variable 또는 Set-Variable cmdlet을 사용하거나, 변수를 설정하는 데 사용하는 명령을 도트 소싱해 보세요.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>매개 변수 {0}과(와) {1}은(는) 함께 사용할 수 없습니다. 매개 변수를 하나만 지정하세요.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>현재 Tail 매개 변수는 FileSystem 공급자에 대해서만 지원됩니다.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>이름이 '{0}'이고 명령 유형이 '{1}'인 명령이 이미 있으므로 별칭을 사용할 수 없습니다.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>소프트웨어를 실행할 수 없습니다. 사용 권한이 거부되었습니다.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>'-{0}' 및 '-{1}'은(는) 상호 배타적이며 동시에 지정할 수 없습니다.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>경로 '{0}'은(는) 유효하지 않습니다. 원격 복사 작업에서는 절대 경로만 지원됩니다.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>원격 경로 '{0}'의 유효성을 검사할 수 없습니다.</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>세션 {0}이(가) {1}(으)로 설정되어 있으므로 작업을 수행할 수 없습니다.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>'{0}' 매개 변수는 null이거나 비워 둘 수 없습니다.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>세션 상태 변수</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 모드에서는 변수 '{0}'의 범위를 AllScope로 변경하거나 만들 수 없습니다.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/CredUI.pl.resx
+++ b/src/System.Management.Automation/resources/pl/CredUI.pl.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>Żądanie poświadczeń programu PowerShell </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>Wprowadź poświadczenia. </value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Wprowadź poświadczenia.</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>Maksymalna długość podpisu to {0} znaków.</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>Maksymalna długość wiadomości to {0} znaków.</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>Maksymalna długość wartości UserName wynosi {0} znaków.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/DebuggerStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/DebuggerStrings.pl.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>Zmienny punkt przerwania na „${0}” ({1} dostęp)</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>Zmienny punkt przerwania w „{0}:${1}” ({2} dostęp)</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>Punkt przerwania wiersza w „{0}:{1}”</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>Punkt przerwania wiersza w „{0}:{1}, {2}”</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>Punkt przerwania polecenia na „{0}”</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>Punkt przerwania polecenia na „{0}:{1}”</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>Punkt przerwania {0} nie zostanie osiągnięty</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Pojedynczy krok (wkrocz do funkcji, skryptów itp.)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Krok do następnej instrukcji (przekrocz funkcje, skrypty itp.)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Wyjdź z bieżącej funkcji, skryptu itp.</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} Kontynuuj operację</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} Zatrzymaj operację i zamknij debuger</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Stos wywołań wyświetlania Get-PSCallStack</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Wyświetl kod źródłowy bieżącego skryptu.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Użyj polecenia „list”, aby rozpocząć od aktualnego wiersza, „list &lt;m&gt;”  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     aby rozpocząć od wiersza &lt;m&gt;, a polecenie „list &lt;m&gt; &lt;n&gt;” służy do wyświetlenia &lt;n&gt; </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     wiersze rozpoczynające się od wiersza &lt;m&gt;</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Powtórz ostatnie polecenie, jeśli było to {0}, {1} lub {2}</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} wyświetla ten komunikat pomocy.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Aby uzyskać instrukcje dotyczące dostosowywania wiersza poleceń debuggera, wpisz „help about_prompt”.</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+Bieżąca sesja nie obsługuje debugowania; operacja będzie kontynuowana.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: wiersz {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>Brak dostępnego kodu źródłowego.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>Wartość początkowa musi być dodatnią liczbą całkowitą nie większą niż {0}</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>Liczba wierszy musi być dodatnią liczbą całkowitą.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
     <value>&lt;No file&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>w {0}, {1}: wiersz {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>Debugger nie może przetwarzać poleceń, dopóki nie znajduje się w stanie „Zatrzymany”.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>Element SetDebugAction nie jest zaimplementowany dla debugera skryptu lokalnego.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>Debuger nie może ustawić akcji wznowienia, ponieważ debuger w sesji zdalnej nie znajduje się w stanie zatrzymania.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>Nie można debugować zadania, ponieważ debuger jest obecnie zajęty.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Przeanalizowano podane zadanie oraz wszystkie zadania podrzędne, ale nie znaleziono żadnych zadań, które można by poddać debugowaniu.  Aby przeprowadzić debugowanie zadania lub zadania podrzędnego, zadanie to musi obsługiwać funkcję debugowania i znajdować się w stanie uruchomienia.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>Nie można włączyć debugera w trybie krokowym, ponieważ debuger jest wyłączony, a tryb debugowania ustawiono na „Brak”.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>Nie można debugować obszaru działania, ponieważ debuger hosta jest obecnie zajęty.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>Nie można debugować obszaru działania. Debugger obszaru działania jest obecnie wyłączony (wartość DebugMode to „None”).</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>Nie można debugować obszaru działania, który nie jest w stanie Otwórz. Stan obszaru działania to {0}.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>Nie można debugować obszaru działania. Obszar działania{0} nie ma skojarzonego debugera.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>Debuger został już zastąpiony.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>Nie można wypchnąć obiektu debugera do samego siebie.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>Polecenie {0} nie jest obsługiwane w przypadku użycia zdalnego w wersji programu PowerShell uruchomionej w zdalnym obszarze działania.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>Proces</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} Kontynuuj działanie i odłącz debuger.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>Polecenie odłączenia debugera nie ma zastosowania.  Polecenie „detach” ma zastosowanie wyłącznie podczas debugowania zadań i przestrzeni uruchomieniowych za pomocą poleceń cmdlet „Debug-Job” lub „Debug-Runspace”.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>Nieprawidłowy identyfikator obszaru uruchamiania: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>Nie udało się uzyskać dostępu do obszaru działania.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Należy określić punkt przerwania lub listę punktów przerwania.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>Lista punktów przerwania zawierała element, który nie był punktem przerwania.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/DiscoveryExceptions.pl.resx
+++ b/src/System.Management.Automation/resources/pl/DiscoveryExceptions.pl.resx
@@ -186,7 +186,7 @@ Instrukcja #requires musi mieć jeden z następujących formatów:
     <value>Nie można uruchomić skryptu „{0}”, ponieważ brakuje następujących przystawek określonych przez instrukcje „#requires” skryptu: {1}.</value>
   </data>
   <data name="RequiresShellIDInvalidForSingleShell" xml:space="preserve">
-    <value>A #requires statement has specified only a shellID. #Requires statements must specify a required PowerShell snap-in when running in PowerShell.</value>
+    <value>Instrukcja #requires określiła tylko identyfikator shellID. Instrukcje #Requires muszą określać wymaganą przystawkę programu PowerShell podczas uruchamiania w programie PowerShell.</value>
   </data>
   <data name="RequiresElevation" xml:space="preserve">
     <value>Nie można uruchomić skryptu „{0}”, ponieważ zawiera on instrukcję „#requires” służącą do uruchamiania jako administrator. Bieżąca sesja programu PowerShell nie jest uruchomiona jako administrator. Uruchom program PowerShell przy użyciu opcji Uruchom jako administrator, a następnie spróbuj ponownie uruchomić skrypt.</value>

--- a/src/System.Management.Automation/resources/pl/ErrorCategoryStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/ErrorCategoryStrings.pl.resx
@@ -121,10 +121,10 @@
     <value>CloseError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>Wykryto zakleszczenie: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
-    <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
+    <value>Błąd urządzenia: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidArgument" xml:space="preserve">
     <value>InvalidArgument: ({1}:{2}) [{0}], {3}</value>
@@ -163,7 +163,7 @@
     <value>OperationTimeout: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ParserError" xml:space="preserve">
-    <value>ParserError: ({1}:{2}) [{0}], {3}</value>
+    <value>Błąd analizatora: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="PermissionDenied" xml:space="preserve">
     <value>PermissionDenied: ({1}:{2}) [{0}], {3}</value>
@@ -181,7 +181,7 @@
     <value>ResourceUnavailable: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="SyntaxError" xml:space="preserve">
-    <value>SyntaxError: ({1}:{2}) [{0}], {3}</value>
+    <value>Błąd składni: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="WriteError" xml:space="preserve">
     <value>WriteError: ({1}:{2}) [{0}], {3}</value>
@@ -214,6 +214,6 @@
     <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>Nierozpoznana kategoria błędu {4}: ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/ExperimentalFeatureStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/ExperimentalFeatureStrings.pl.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>Nie znaleziono funkcji eksperymentalnej o nazwie „{0}”.</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>Włączenie i wyłączenie funkcji eksperymentalnych zaczną obowiązywać dopiero po następnym uruchomieniu programu PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/ExtendedTypeSystem.pl.resx
+++ b/src/System.Management.Automation/resources/pl/ExtendedTypeSystem.pl.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>Element członkowski „{0}” już istnieje.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>Element członkowski „{0}” jest już obecny w pliku danych typów rozszerzonych.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>Element członkowski „{0}” nie istnieje.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>Wyjątek podczas ustawiania „{0}”: „{1}”</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>Wyjątek podczas pobierania „{0}”: „{1}”</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>Podczas próby wyliczenia kolekcji wystąpił następujący wyjątek: „{0}”.</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>Nie można uzyskać dostępu do elementu członkowskiego „{0}” poza obiektem PSObject.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>Nie można zmienić elementu członkowskiego utworzonego na podstawie konfiguracji typu: „{0}”.</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>Nazwa elementu członkowskiego „{0}” jest zastrzeżona.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>„{0}” nie można zmienić.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>Wyjątek podczas wywoływania „{0}” z argumentami „{1}”: „{2}”</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>Zgłoszono wyjątek podczas próby wywołania „{0}” w celu wyodrębnienia zawartości obiektu typu „{1}”: „{2}”</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>Nie można znaleźć przeciążenia dla „{0}” i liczby argumentów: „{1}”.</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>Nie można znaleźć odpowiedniego przeciążenia metody ogólnej dla „{0}” z liczbą parametrów typu „{1}” i liczbą argumentów: „{2}”.</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>Znaleziono wiele niejednoznacznych przeciążeń dla „{0}” i liczbę argumentów: „{1}”.</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>Nie można przekonwertować argumentu „{0}” o wartości „{1}” dla „{2}” na typ „{3}”: „{4}”</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>Metoda pobierająca właściwość „{0}” jest niedostępna.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>Ustawianie metody dostępu dla właściwości „{0}” jest niedostępne.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>Metoda ustawiająca powinna być publiczna, zwracać void, być statyczna i mieć dwa parametry. Pierwszy parametr powinien mieć typ PSObject. Drugi parametr jest wymagany, jeśli dostępna jest też metoda pobierająca, i powinien mieć ten sam typ co typ zwracany przez metodę pobierającą.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>Metoda pobierająca powinna być publiczna, nie zwracać wartości void, być statyczna i przyjmować jeden parametr typu PSObject.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>Właściwość CodeProperty powinna używać metody pobierającej lub ustawiającej.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>Nie można utworzyć metody kodu z powodu formatu metody. Metoda powinna być publiczna, statyczna i mieć jeden parametr typu PSObject.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>Alias o nazwie „{0}” zawiera cykl.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>Nie można przekonwertować wartości „{0}” typu „{1}” na typ „{2}”.</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>Nie można przekonwertować wartości typu „{0}” na typ „{1}”.</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>Nie można przekonwertować wartości „{0}” na typ „{1}”. Błąd: „{2}”</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>Nie można przekonwertować wartości „{0}” na typ „{1}”, ponieważ w tym wyliczeniu nie są dozwolone przecinki.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>Nie można przekonwertować wartości „{0}” na typ „{1}” z powodu nieprawidłowych wartości wyliczenia. Określ jedną z następujących wartości wyliczenia i spróbuj ponownie. Możliwe wartości wyliczenia to „{2}”.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>Nie można przekonwertować wartości null na typ „{0}”, ponieważ wartości wyliczenia są nieprawidłowe. Określ jedną z następujących wartości wyliczenia i spróbuj ponownie. Możliwe wartości wyliczenia to „{1}”.</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>Nie można przekonwertować wartości null na typ „{0}”.</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>Nie można przekonwertować wartości na typ „{0}”.  Błąd: „{1}”</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>Nie można przekonwertować wartości na typ System.String.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>Oczekiwano typu referencyjnego w argumencie.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>Nie można porównać „{0}”, ponieważ nie implementuje interfejsu IComparable.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>Nie można porównać „{0}” z „{1}”. Błąd: „{2}”</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>Nie można porównać „{0}” z „{1}”, ponieważ obiekty nie są tego samego typu lub obiekt „{0}” nie implementuje „{2}”.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>Nie można przekonwertować wartości „{0}” na typ „{1}”, ponieważ znaleziono co najmniej dwa dopasowania ({2}, {3}), a dla tego wyliczenia dozwolone jest tylko jedno dopasowanie.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>Nie można przekonwertować wartości „{0}” na typ „{1}”. Parametry logiczne akceptują tylko wartości logiczne i liczby, takie jak $True, $False, 1 lub 0.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>Nie można pobrać wartości właściwości, ponieważ „{0}” jest właściwością tylko do zapisu.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>„{0}” jest właściwością ReadOnly.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>Nie można ustawić „{0}”, ponieważ jako wartości właściwości XmlNode można używać tylko ciągów.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>Nie można ustawić „{0}”, ponieważ można ustawić tylko unikatowe atrybuty lub unikatowe nieatrybutowe węzły liściowe.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>Nie można dodać obiektu PSProperty ani PSMethod do tej kolekcji.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>Podczas ładowania pliku danych typu rozszerzonego wystąpił następujący błąd: {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania ciągu: „{0}”</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>Pole lub właściwość: „{0}” dla typu: „{1}” różni się od pola lub właściwości: „{2}” tylko wielkością liter. Typ musi być zgodny ze specyfikacją Common Language Specification (CLS).</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania hierarchii nazw typów: „{0}”.</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania elementu członkowskiego „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania elementów członkowskich: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania stanu odczytu dla właściwości „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania stanu zapisu dla właściwości „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania typu właściwości „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>Podczas pobierania reprezentacji ciągu dla właściwości „{1}” wystąpił następujący wyjątek: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania atrybutów właściwości „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania definicji dla metody „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania reprezentacji ciągu dla metody „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania typu właściwości sparametryzowanej „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>Podczas pobierania stanu odczytu dla właściwości sparametryzowanej „{1}” wystąpił następujący wyjątek: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania stanu zapisu dla właściwości sparametryzowanej „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania definicji właściwości sparametryzowanej „{1}”: „{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas pobierania reprezentacji ciągu dla właściwości sparametryzowanej „{1}”: „{0}”</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>Nie można ustawić właściwości Value dla obiektu PSMemberInfo typu „{0}”.</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>Argument: „{0}” powinien być {1}. Użyj {2}.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>Argument : „{0}” nie powinien być {1}. Nie używaj {2}.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>Właściwość "{0}" nie została znaleziona.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>Nie można pobrać lub ustawić wartości właściwości. Argument „{0}” powinien być typu „{1}” lub „{2}”.</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>Nie można ustawić wartości właściwości „{0}”, ponieważ obiekt ma typ „{1}” zamiast „{2}”.</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>Wyjątek podczas wywoływania „{0}” : „{1}”</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0} nie jest prawidłową ścieżką klasy.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} nie jest prawidłową ścieżką.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>Adapter nie może określić, czy można zmienić właściwość „{0}”.</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>Adapter nie może określić, czy właściwość „{0}” umożliwia pobranie wartości.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>Adapter nie może pobrać wartości właściwości „{0}”.</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>Adapter nie może ustawić wartości właściwości „{0}”.</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>Adapter nie może pobrać typu właściwości „{0}”.</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>Adapter nie może pobrać hierarchii typów dla „{0}”.</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>Adapter nie może pobrać właściwości „{0}”.</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>Adapter nie może pobrać właściwości „{0}” dla „{1}”.</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>„{0}” zwróciła wartość null.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>Nie znaleziono właściwości „{0}” dla obiektu „{1}”. Właściwości, które można ustawić, to: {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>Nie znaleziono właściwości „{0}” dla obiektu „{1}”. Brak dostępnej właściwości settable.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>Nie można utworzyć obiektu typu „{0}”. {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>Nie można wywoływać metod statycznych ani uzyskiwać dostępu do właściwości statycznych w otwartym typie generycznym {0}.  Określ parametry typu i spróbuj ponownie.  Na przykład zamiast [System.Collections.Generic.HashSet``1]::CreateSetComparer() użyj [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>Wystąpił następujący wyjątek podczas konstruowania atrybutu „{1}”: „{0}”</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>Nie można przekonwertować wartości „{0}” na tablicę ciągów.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>Nie można przekonwertować wartości na typ „{0}”. W tym trybie języka są obsługiwane tylko typy podstawowe.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nie można przekonwertować na typ „{0}” typu ByRef. Typy podobne do ByRef nie są obsługiwane w programie PowerShell.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nie można pobrać ani ustawić właściwości lub pola „{0}” typu podobnego do ByRef „{1}”. Typy podobne do ByRef nie są obsługiwane w programie PowerShell.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nie można wywołać metody „{0}” zwracającej typ podobny do ByRef „{1}”. Typy podobne do ByRef nie są obsługiwane w programie PowerShell.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Nie można utworzyć wystąpienia typu podobnego do ByRef „{0}”. Typy podobne do ByRef nie są obsługiwane w programie PowerShell.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Konwersja tabeli skrótów systemu typów rozszerzonych</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Konwersja typu z wartości HashTable na „{0}” nie będzie dozwolona w trybie ConstrainedLanguage.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Konwersja tabeli skrótów systemu typów rozszerzonych</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>Konwersja typu z „{0}” na „{1}” nie będzie dozwolona w trybie ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/HelpDisplayStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/HelpDisplayStrings.pl.resx
@@ -124,350 +124,350 @@
     <value>SYNOPSIS</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
-    <value>DESCRIPTION</value>
+    <value>OPIS</value>
   </data>
   <data name="Syntax" xml:space="preserve">
-    <value>SYNTAX</value>
+    <value>SKŁADNIA</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>PARAMETRY</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>DANE WEJŚCIOWE</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>DANE WYJŚCIOWE</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>BŁĘDY POWODUJĄCE PRZERWANIE DZIAŁANIA</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>BŁĘDY NIEPOWODUJĄCE PRZERWANIA DZIAŁANIA</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>UWAGI</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>PRZYKŁADY</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>Przykład</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>PRZYKŁAD</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>OUTPUT</value>
+    <value>DANE WYJŚCIOWE</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>POWIĄZANE LINKI</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>KRÓTKI OPIS</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>Tytuł:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>Pytanie:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>Odpowiedź</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>Okres:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>Definicja:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>Zawartość:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>NAZWA DOSTAWCY</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
+    <value>    To polecenie cmdlet obsługuje typowe parametry: Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
+    OutBuffer, PipelineVariable, and OutVariable. Aby uzyskać więcej informacji, zobacz
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>Wymagany?                    </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>Lokalizacja?                    </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>Typ: </value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>Typ obiektu docelowego:   </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>Wartość domyślna                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>Zaakceptować dane wejściowe potoku?       </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>Akceptować symbole wieloznaczne?  </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(Kategoria: </value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>Sugerowana akcja: </value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>Aby uzyskać więcej informacji, wpisz: </value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>Aby uzyskać informacje techniczne, wpisz: </value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>Aby wyświetlić przykłady, wpisz: </value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>Aby uzyskać pomoc online, wpisz: </value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
   </data>
   <data name="RemarksSection" xml:space="preserve">
-    <value>REMARKS</value>
+    <value>UWAGI</value>
   </data>
   <data name="TrueShort" xml:space="preserve">
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>Nazwane</value>
   </data>
   <data name="Drives" xml:space="preserve">
-    <value>DRIVES</value>
+    <value>DYSKI</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>MOŻLIWOŚCI</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>ZADANIA</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>ZADANIE: </value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>FILTRY</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>PARAMETRY DYNAMICZNE</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>Obsługiwane polecenia cmdlet: </value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>ALIASY</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Funkcja Get-Help nie może znaleźć plików pomocy dotyczących tego polecenia cmdlet na tym komputerze. Wyświetla tylko częściową pomoc.
+    -- Aby pobrać i zainstalować pliki Pomocy dla modułu zawierającego to polecenie cmdlet, użyj polecenia Update-Help.
+    -- Aby wyświetlić temat Pomocy dla tego polecenia cmdlet w trybie online, wpisz: „Get-Help {0} -Online” lub
+       przejdź do {1}.</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>Brak</value>
   </data>
   <data name="ParameterAliases" xml:space="preserve">
-    <value>Aliases                      </value>
+    <value>Aliasy                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>Dynamiczny?                     </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>Nazwa zestawu parametrów           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>Nie można pobrać pliku XML HelpInfo dla kultury interfejsu użytkownika {0}. Upewnij się, że właściwość HelpInfoUri w manifeście modułu jest prawidłowa lub sprawdź połączenie sieciowe, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
   </data>
   <data name="PipelineByValue" xml:space="preserve">
-    <value>ByValue</value>
+    <value>Wartość ByValue</value>
   </data>
   <data name="PipelineFromRemainingArguments" xml:space="preserve">
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>Określona kultura jest nieobsługiwana: {0}. Określ kulturę z następującej listy: {{{1}}}.</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>Odłożenie błędu i wypróbowanie kultur rezerwowych spowoduje wyświetlenie błędu, jeśli żadna z kultur rezerwowych nie jest obsługiwana:
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>Nie można odnaleźć katalogu ModuleBase. Sprawdź katalog i spróbuj ponownie.</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>Ścieżka {0} nie jest prawidłowym katalogiem. Upewnij się, że katalog istnieje, i spróbuj ponownie.</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>Identyfikator URI Pomocy nie może zawierać więcej niż 10 przekierowań. Określ prawidłowy identyfikator URI Pomocy.</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>Aktualizowanie Pomocy</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>Trwa łączenie z zawartością Pomocy...</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>Trwa pobieranie zawartości Pomocy...</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>Trwa instalowanie zawartości Pomocy...</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>Trwa lokalizowanie zawartości Pomocy...</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(Wszystko)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Nie znaleziono modułów programu PowerShell zgodnych z następującym wzorcem: {0}. Sprawdź wzorzec, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>Nie znaleziono modułów programu PowerShell zgodnych z określonym modułem FullyQualifiedModule {0}. Sprawdź wartość FullyQualifiedModule, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>Nie można odnaleźć zawartości pomocy. Upewnij się, że serwer jest dostępny, a lokalizacja treści pomocy jest prawidłowo zdefiniowana w pliku XML HelpInfo.</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>Polecenie „Update-Help” zakończyło się niepowodzeniem, ponieważ wskazany moduł nie obsługuje pomocy z możliwością aktualizacji. Aby uzyskać pomoc dotyczącą poleceń zawartych w tym module, użyj polecenia Get-Help -Online lub poszukaj informacji w Internecie.</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>Następujący parametr nie może mieć wartości null ani być pusty: Moduł.</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>Następujący parametr nie może mieć wartości null ani być pusty: Path.</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Operacja Update-Help została ukończona pomyślnie.</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>Błąd podczas wyodrębniania zawartości Pomocy.</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>Nie można nawiązać połączenia z zawartością Pomocy. Serwer, na którym jest przechowywana zawartość Pomocy, może być niedostępny. Sprawdź, czy serwer jest dostępny, lub zaczekaj, aż serwer wróci do trybu online, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>Treść Pomocy w podanej lokalizacji jest nieprawidłowa. Określ lokalizację zawierającą prawidłową zawartość Pomocy.</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>Kod XML HelpInfo jest nieprawidłowy. Określ prawidłowy kod XML HelpInfo.</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>Zawartość pomocy została pomyślnie zapisana w następującej lokalizacji: {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>Nie można odnaleźć pliku XSD zawartości Pomocy w {0}. Sprawdź, czy plik XSD istnieje w określonej lokalizacji, a następnie ponów próbę wykonania polecenia.</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
-'{0}'
+    <value>Nie udało się zaktualizować Pomocy dla następujących modułów:
+„{0}”
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>Zapisywanie Pomocy</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>Zawartość Pomocy zawiera nieprawidłowe pliki. Obsługiwane są wyłącznie pliki z rozszerzeniami .txt i .xml.</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>Nie można zapisać Pomocy dla modułów „{0}” : {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>Nie udało się zapisać pomocy dla modułu(-ów) „{0}” z ustawieniami kulturowymi interfejsu użytkownika {{{1}}} : {2}.
+Dostępna jest treść pomocy w języku angielskim (wersja amerykańska), którą można zapisać za pomocą polecenia: Save-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>Nie można zaktualizować Pomocy dla modułów „{0}”z kulturami interfejsu użytkownika {{{1}}}: {2}.
+Dostępna jest dokumentacja pomocy w języku angielskim (wersja amerykańska), którą można zainstalować za pomocą polecenia: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>Obecna kultura systemu to ({0}), która nie jest powiązana z żadnym językiem. Rozważ zmianę kultury systemu lub zainstaluj treści pomocy w języku angielskim (USA), korzystając z polecenia: Update-Help -UICulture en-US.</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
     <value>false</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>Parametr -Recurse jest dostępny tylko wtedy, gdy określono ścieżkę źródłową.</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>Ścieżka {0} nie zawiera dostawcy FileSystem. Sprawdź, czy określona ścieżka zawiera dostawcę FileSystem, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>Wyszukiwanie Pomocy dla {0} ...</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Nie znaleziono żadnej kultury interfejsu użytkownika, która odpowiadałaby poniższemu wzorcowi: {0}. Sprawdź wzorzec, a następnie spróbuj ponownie wykonać polecenie.</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>Pomoc nie została zapisana dla modułu {0}, ponieważ polecenie Save-Help zostało uruchomione na tym komputerze w ciągu ostatnich 24 godzin.
+Aby ponownie zapisać pomoc, dodaj parametr Force do polecenia.</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>Pomoc dla modułu {0} nie została zaktualizowana, ponieważ polecenie Update-Help zostało uruchomione na tym komputerze w ciągu ostatnich 24 godzin.
+Aby ponownie zaktualizować pomoc, dodaj parametr Force do polecenia.</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>Najnowsze pliki Pomocy są już zainstalowane.</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}. Kultura {2} Wersja {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>Zaktualizowano {0}</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>Wartość klucza „HelpInfoUri” w manifeście modułu musi odnosić się do adresu URL kontenera lub adresu głównego witryny internetowej, na której przechowywane są pliki pomocy. Adres HelpInfoUri „{0}” nie prowadzi do żadnego kontenera.</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>Zawartość Pomocy musi znajdować się w przestrzeni nazw {0}.</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Funkcja Get-Help nie może znaleźć plików pomocy dotyczących tego polecenia cmdlet na tym komputerze. Wyświetla tylko częściową pomoc.
+    -- Aby pobrać i zainstalować pliki pomocy dla modułu zawierającego ten cmdlet, należy użyć polecenia Update-Help.</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>Najnowsze pliki Pomocy są już pobrane.</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>Zapisano kategorię {0}</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>Identyfikator HelpInfoURI {0} nie rozpoczyna się od protokołu HTTP.</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>Elementem najwyższego poziomu treści pomocy musi mieć wartość „helpItems”.</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>Zapisywanie Pomocy dla modułu {0}</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>Aktualizowanie Pomocy dla modułu {0}</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>Rozpoznawanie identyfikatora URI: „{0}”</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>Identyfikator URI Pomocy: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}, bieżąca wersja: {1}, dostępna wersja: {2}, UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>WŁAŚCIWOŚCI</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>METODY</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/Modules.pl.resx
+++ b/src/System.Management.Automation/resources/pl/Modules.pl.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Określony moduł „{0}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Określony moduł „{0}” z numerem wersji „{1}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Określony element MaximumVersion „{0}” jest niepoprawny. Jeśli używasz znaku „*”, element MaximumVersion obsługuje tylko jeden taki znak i musi on znajdować się na końcu wartości MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Określony moduł „{0}” z parametrem MaximumVersion „{1}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Określony moduł „{0}” z parametrami MinimumVersion „{1}” i MaximumVersion „{2}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>Wartość MinimumVersion „{0}” nie może być większa niż wartość MaximumVersion „{1}”.</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>Nie załadowano zestawu „{0}”, ponieważ nie znaleziono zestawu o tej nazwie. Sprawdź nazwę zestawu, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Moduł do przetwarzania „{0}”, wymieniony w polu „{1}” manifestu modułu „{2}”, nie został przetworzony, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego modułu.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Nie zwrócono niestandardowego obiektu dla modułu „{0}”, ponieważ parametru -AsCustomObject można używać tylko z modułami skryptowymi.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Nie można przetworzyć manifestu modułu „{0}”, ponieważ nie jest to prawidłowy plik manifestu modułu programu PowerShell. Usuń niedozwolone elementy: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Przetwarzanie pliku manifestu modułu „{0}” nie spowodowało utworzenia prawidłowego obiektu manifestu. Zaktualizuj plik tak, aby zawierał prawidłowy manifest modułu programu PowerShell. Prawidłowy manifest można utworzyć za pomocą polecenia cmdlet New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Nie można zaimportować modułu „{0}”, ponieważ jego manifest zawiera jeden lub więcej nieprawidłowych elementów. Prawidłowe elementy manifestu to ({1}). Usuń nieprawidłowe elementy ({2}), a następnie spróbuj ponownie zaimportować moduł.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>Tablica skrótów opisująca moduł zawiera jeden lub więcej elementów, które są nieprawidłowe. Prawidłowe elementy to ({0}). Usuń nieprawidłowe elementy ({1}), a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Nie można załadować modułu „{0}”, ponieważ przekroczono limit zagnieżdżania modułów. Moduły można zagnieżdżać tylko do poziomu {1}. Sprawdź kolejność ładowania modułów i zmień ją, aby nie przekraczać limitu zagnieżdżania, a potem spróbuj ponownie uruchomić skrypt.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Elementu „ModuleVersion” nie ma w manifeście modułu. Ten element musi istnieć i mieć przypisany numer wersji w formacie „n.n.n.n”. Dodaj brakujący element do pliku „{0}”.</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Element „{0}” nie jest prawidłowy w pliku manifestu modułu „{2}”: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>Wersja „{0}” modułu „{1}” nie spełnia wymaganego minimum „{2}”. Sprawdź, czy numer wersji jest obsługiwany, a następnie spróbuj ponownie załadować moduł.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>Wersja programu PowerShell na tym komputerze to „{0}”. Do uruchomienia modułu „{1}” wymagana jest co najmniej wersja programu PowerShell „{2}”. Sprawdź, czy masz zainstalowaną minimalną wymaganą wersję programu PowerShell, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Nie można użyć elementu manifestu modułu „NestedModules”, jeśli element „ModuleToProcess” jest modułem binarnym. Edytuj plik manifestu modułu w „{0}”, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Element „{0}” w manifeście modułu jest nieprawidłowy: {1}. Sprawdź, czy dla tego pola w pliku „{2}” określono prawidłową wartość.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Ścieżka manifestu modułu „{0}” jest nieprawidłowa. Wartość argumentu ścieżki musi wskazywać pojedynczy plik z rozszerzeniem „.psd1”. Zmień wartość argumentu ścieżki tak, aby wskazywała prawidłowy plik psd1, a następnie spróbuj ponownie.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>Klucz ModuleVersion w manifeście modułu „{0}” określa wersję modułu „{1}”, która nie zgadza się z nazwą folderu wersji w lokalizacji „{2}”. Zmień wartość klucza ModuleVersion, aby pasowała do nazwy folderu wersji.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Określony wpis NestedModule „{0}” w manifeście modułu „{1}” jest nieprawidłowy. Spróbuj ponownie po zaktualizowaniu tego wpisu prawidłowymi wartościami.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Określony wpis RequiredAssemblies „{0}” w manifeście modułu „{1}” jest nieprawidłowy. Spróbuj ponownie po zaktualizowaniu tego wpisu prawidłowymi wartościami.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Określony wpis FileList „{0}” w manifeście modułu „{1}” jest nieprawidłowy. Spróbuj ponownie po zaktualizowaniu tego wpisu prawidłowymi wartościami.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Określony wpis RequiredModules „{0}” w manifeście modułu „{1}” jest nieprawidłowy. Spróbuj ponownie po zaktualizowaniu tego wpisu prawidłowymi wartościami.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Określony wpis ModuleList „{0}” w manifeście modułu „{1}” jest nieprawidłowy. Spróbuj ponownie po zaktualizowaniu tego wpisu prawidłowymi wartościami.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Manifest modułu „{0}” zawiera klucz CompatiblePSEditions, który jest obsługiwany tylko w programie PowerShell w wersji „5.1” lub nowszej. Zaktualizuj wartość klucza PowerShellVersion do „5.1” lub nowszej, a następnie spróbuj ponownie.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>Określona wartość „{0}” dla elementu CompatiblePSEditions zawiera zduplikowane nazwy edycji programu PowerShell. Spróbuj ponownie po usunięciu zduplikowanych nazw edycji programu PowerShell.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>Wersja określona w kluczu ModuleVersion jest taka sama jak nazwa folderu wersji.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Pomijanie folderu wersji {0} w module {1}, ponieważ nie zawiera prawidłowego pliku manifestu modułu.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Element „ModuleName” nie istnieje w tabeli skrótów opisującej ten moduł.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Elementy „ModuleVersion”, „MaximumVersion” i „RequiredVersion” nie istnieją w tabeli skrótów opisującej ten moduł. Jeden z tych trzech elementów musi istnieć i mieć przypisany numer wersji w formacie „n.n.n.n”.</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Wymagany moduł „{1}” nie został załadowany. Załaduj moduł albo usuń go z elementu „RequiredModules” w pliku „{0}”.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Wymagany moduł „{1}” o identyfikatorze GUID „{2}” nie jest załadowany. Załaduj moduł albo usuń go z elementu „RequiredModules” w pliku „{0}”.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Wymagany moduł „{1}” o numerze wersji „{2}” nie jest załadowany. Załaduj moduł albo usuń go z elementu „RequiredModules” w pliku „{0}”.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Wymagany moduł „{1}” o parametrze MaximumVersion „{2}” nie jest załadowany. Załaduj moduł albo usuń go z elementu „RequiredModules” w pliku „{0}”.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Wymagany moduł „{1}” z wartościami MinimumVersion „{2}” i MaximumVersion „{3}” nie jest załadowany. Załaduj moduł albo usuń go z elementu „RequiredModules” w pliku „{0}”.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Nie można znaleźć modułu „{0}” z wersją ModuleVersion „{1}”.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Nie można znaleźć modułu „{0}” z wymaganą wersją RequiredVersion „{1}”.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Nie można znaleźć modułu „{0}” z wersją MaximumVersion „{1}”.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Nie można odnaleźć modułu „{0}” z wartością ModuleVersion „{1}” i MaximumVersion „{2}”.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Nie można znaleźć modułu {0}.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Nie usunięto żadnych modułów. Sprawdź, czy specyfikacja modułów do usunięcia jest poprawna i czy te moduły istnieją w obszarze działania.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Nie można usunąć elementu „{0}”, który został zaimportowany z modułu „{1}”. Przyczyna: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Nie można usunąć modułu „{0}”, ponieważ jest tylko do odczytu. Dodaj parametr „Force” do polecenia, aby usunąć moduły tylko do odczytu.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Nie można usunąć modułu „{0}”, ponieważ jest oznaczony wartością „constant”. Modułu nie można usunąć, jeśli jest oznaczony wartością „constant”.</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Nie można usunąć modułu „{0}”, ponieważ jest on wymagany przez „{1}”. Dodaj parametr „Force” do polecenia, aby usunąć moduł.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Polecenie cmdlet Export-ModuleMember można wywołać tylko z poziomu modułu.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>Rozszerzenie „{0}” nie jest prawidłowym rozszerzeniem modułu. Obsługiwane rozszerzenia modułów to „.dll”, „.ps1”, „.psm1”, „.psd1” i „.cdxml”. Popraw rozszerzenie, a następnie spróbuj ponownie dodać plik „{1}”.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Tej operacji nie można wykonać na module binarnym. Można ją wykonać tylko na module skryptowym.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Plik „{0}” jest niedozwolony, ponieważ nie ma rozszerzenia „.ps1”.</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Nieznane</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Wszelkie prawa zastrzeżone.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Usuwanie zaimportowanej funkcji „{0}”.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Usuwanie zaimportowanego aliasa „{0}”.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Usuwanie zaimportowanej zmiennej „{0}”.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Ładowanie modułu ze ścieżki „{0}”.</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Ładowanie elementu „{0}” ze ścieżki „{1}”.</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Importowanie metodą dot-sourcing pliku skryptu '{0}'.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Importowanie funkcji „{0}”.</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Importowanie polecenia cmdlet „{0}”.</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Importowanie aliasu „{0}”.</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Importowanie zmiennej „{0}”.</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Eksportowanie polecenia cmdlet „{0}”.</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Eksportowanie funkcji „{0}”.</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Eksportowanie aliasu „{0}”.</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Eksportowanie zmiennej „{0}”.</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Nazwy niektórych zaimportowanych poleceń z modułu „{0}” zawierają niezatwierdzone czasowniki, przez co mogą być trudniejsze do odnalezienia. Aby znaleźć polecenia z niezatwierdzonymi czasownikami, uruchom ponownie polecenie Import-Module z parametrem Verbose. Aby wyświetlić listę zatwierdzonych czasowników, wpisz polecenie Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Polecenie „{0}” w module „{1}” zostało zaimportowane, ale ponieważ jego nazwa nie zawiera zatwierdzonego czasownika, może być trudne do znalezienia. Aby wyświetlić listę zatwierdzonych czasowników, wpisz polecenie Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Polecenie „{0}” w module „{2}” zostało zaimportowane, ale ponieważ jego nazwa nie zawiera zatwierdzonego czasownika, może być trudne do znalezienia. Sugerowane alternatywne czasowniki to „{1}”.</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Niektóre zaimportowane nazwy poleceń zawierają co najmniej jeden z następujących znaków ograniczonych: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : „” &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Nazwa polecenia „{0}” z modułu „{1}” zawiera co najmniej jeden z następujących znaków ograniczonych: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : „” &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Tworzenie pliku manifestu modułu „{0}”.</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (ścieżka: „{1}”)</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>Bieżąca architektura procesora to: {0}. Moduł „{1}” wymaga następującej architektury: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Nazwa bieżącego hosta programu PowerShell to: „{0}”. Moduł „{1}” wymaga następującego hosta programu PowerShell: „{2}”.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>Bieżący host programu PowerShell to: „{0}” (wersja {1}). Do uruchomienia modułu „{2}” wymagana jest minimalna wersja hosta programu PowerShell „{3}”.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Manifest modułu dla modułu „{0}”</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Wygenerowane przez: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Wygenerowano: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Plik modułu skryptowego lub binarnego skojarzony z tym manifestem.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Moduły do zaimportowania jako moduły zagnieżdżone modułu określonego w lokalizacji RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>Identyfikator używany do jednoznacznego identyfikowania tego modułu</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Autor tego modułu</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Firma lub dostawca tego modułu</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Oświadczenie o prawach autorskich do tego modułu</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Numer wersji tego modułu.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Opis funkcjonalności udostępnianej przez ten moduł</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Minimalna wersja aparatu programu PowerShell wymagana przez ten moduł</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Minimalna wersja środowiska uruchomieniowego języka wspólnego (CLR) wymagana przez ten moduł. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Moduły, które muszą zostać zaimportowane do środowiska globalnego przed zaimportowaniem tego modułu</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Pliki skryptów (.ps1) uruchamiane w środowisku wywołującego przed zaimportowaniem tego modułu.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Wpisz pliki (.ps1xml), które mają zostać załadowane podczas importowania tego modułu</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Pliki formatowania (.ps1xml) do załadowania podczas importowania tego modułu</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Zestawy, które muszą zostać załadowane przed zaimportowaniem tego modułu</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Lista wszystkich plików dołączonych do tego modułu</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Dane prywatne do przekazania do modułu określonego w elemencie RootModule/ModuleToProcess. Może też zawierać tabelę skrótów PSData z dodatkowymi metadanymi modułu używanymi przez program PowerShell.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Tagi zastosowane do tego modułu. Pomagają one w odnajdywaniu modułów w galeriach online.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>Adres URL głównej witryny internetowej tego projektu.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>Adres URL licencji dla tego modułu.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>Adres URL ikony reprezentującej ten moduł.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Informacje o wersji tego modułu</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Ciąg wersji wstępnej tego modułu</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Flaga wskazująca, czy moduł wymaga jawnej akceptacji użytkownika podczas instalowania, aktualizowania lub zapisywania</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Zewnętrzne moduły zależne tego modułu</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Koniec tablicy skrótów {0}</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>Wartość parametru PrivateData musi być tabelą skrótów, aby można było utworzyć manifest modułu z następującymi wartościami parametrów: tagi, ProjectUri, LicenseUri, IconUri lub ReleaseNotes. Usuń wartości parametrów tagów, ProjectUri, LicenseUri, IconUri lub ReleaseNotes albo umieść zawartość parametru PrivateData w tabeli skrótów.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>Parametr PrivateData powinien być zdefiniowany jako tabela skrótów, ale w tym manifeście modułu jest zdefiniowany jako obiekt. Rozważ umieszczenie zawartości parametru PrivateData w tabeli skrótów. Dzięki temu będzie można później dodać do manifestu modułu właściwości tagów, ProjectUri, LicenseUri, IconUri i ReleaseNotes.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Określona wartość „{0}” jest nieprawidłowa. Spróbuj ponownie, podając prawidłową wartość.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Funkcje do wyeksportowania z tego modułu: aby uzyskać najlepszą wydajność, nie używaj symboli wieloznacznych i nie usuwaj wpisu, a jeśli nie ma funkcji do wyeksportowania, użyj pustej tablicy.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Aliasy do wyeksportowania z tego modułu: aby uzyskać najlepszą wydajność, nie używaj symboli wieloznacznych i nie usuwaj wpisu, a jeśli nie ma aliasów do wyeksportowania, użyj pustej tablicy.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Polecenia cmdlet do wyeksportowania z tego modułu: aby uzyskać najlepszą wydajność, nie używaj symboli wieloznacznych i nie usuwaj wpisu, a jeśli nie ma poleceń cmdlet do wyeksportowania, użyj pustej tablicy.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Zmienne do wyeksportowania z tego modułu</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Zasoby konfiguracji DSC do wyeksportowania z tego modułu</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Obsługiwane elementy PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Architektura procesora (brak, X86, Amd64) wymagana przez ten moduł</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Lista wszystkich modułów dołączonych do tego modułu</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Minimalna wersja platformy Microsoft .NET Framework wymagana przez ten moduł. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Nazwa hosta programu PowerShell wymagana przez ten moduł</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Minimalna wersja hosta programu PowerShell wymagana przez ten moduł</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>Identyfikator URI HelpInfo tego modułu</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Ponieważ moduł {0} udostępnia element PSDrive w bieżącej sesji programu PowerShell, nie usunięto żadnych modułów. Zmień bieżącego dostawcę elementu PSDrive, a następnie spróbuj ponownie usunąć moduły.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Polecenie cmdlet „{0}” nie zostało zaimportowane, ponieważ w bieżącym zakresie istnieje element o tej samej nazwie.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Alias „{0}” nie został zaimportowany, ponieważ w bieżącym zakresie istnieje element o tej samej nazwie.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Funkcja „{0}” nie została zaimportowana, ponieważ w bieżącym zakresie istnieje element o tej samej nazwie.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Zmienna „{0}” nie została zaimportowana, ponieważ w bieżącym zakresie istnieje element o tej samej nazwie.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>Symbole wieloznaczne są niedozwolone w elementach „ModuleToProcess”, „RootModule” ani „NestedModules” w manifeście modułu „{0}”.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Moduł „{0}” jest modułem podstawowym programu PowerShell. Dodaj parametr „Force” do polecenia, aby usunąć moduły podstawowe.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Manifest modułu nie może zawierać jednocześnie elementów „ModuleToProcess” i „RootModule”. Zmień plik manifestu modułu w „{0}”, aby usunąć jeden z tych elementów, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Element manifestu modułu „ModuleToProcess” jest przestarzały. Zamiast tego użyj elementu „RootModule”.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Domyślny prefiks poleceń eksportowanych z tego modułu. Zmień domyślny prefiks przy użyciu polecenia Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Nie można jednocześnie określić parametrów „Global” i „Scope”. Usuń jeden z tych parametrów, a następnie spróbuj ponownie uruchomić polecenie.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Wymagany moduł „{0}” nie został załadowany. Moduł „{0}” ma element requiredModule „{1}” w manifeście modułu „{2}”, który wskazuje zależność cykliczną.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Wymagany moduł „{0}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Niektórych poleceń z modułu {0} nie można zaimportować za pośrednictwem polecenia CimSession. Aby uzyskać wszystkie polecenia, sprawdź, czy na serwerze zdalnym włączono zdalne zarządzanie programem PowerShell, a następnie spróbuj dodać parametr PSSession do polecenia cmdlet Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Moduł {0} jest ładowany w programie Windows PowerShell przy użyciu sesji zdalnej {1}; pamiętaj, że wszystkie dane wejściowe i wyjściowe poleceń z tego modułu będą obiektami po deserializacji. Jeśli chcesz załadować ten moduł do programu PowerShell, użyj składni „Import-Module -SkipEditionCheck”.</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Wykryto program Windows PowerShell w wersji {0}. Do ładowania modułów przy użyciu funkcji zgodności z programem Windows PowerShell wymagana jest wersja programu Windows PowerShell 5.1. Aby włączyć tę funkcję, zainstaluj funkcję Windows Management Framework (WMF) 5.1 z https://aka.ms/WMF5Download.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Ładowanie modułu „{0}” przy użyciu funkcji zgodności z programem Windows PowerShell jest blokowane przez ustawienie „WindowsPowerShellCompatibilityModuleDenyList” w pliku konfiguracji programu PowerShell.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Modułu {0} nie można zaimportować za pośrednictwem polecenia CimSession. Spróbuj użyć parametru PSSession polecenia cmdlet Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>Wartość architektury procesora {0} nie jest obsługiwana. Uruchom ponownie polecenie New-ModuleManifest, określając jedną z następujących obsługiwanych wartości wyliczenia dla architektury procesora: brak, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>Uruchamianie polecenia cmdlet Get-Module na komputerze zdalnym może wyświetlać tylko dostępne moduły. Dodaj parametr ListAvailable do polecenia, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Moduł „{0}” nie został zaimportowany, ponieważ przystawka „{0}” została już zaimportowana.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>Symbole wieloznaczne są niedozwolone w elemencie „RequiredAssemblies” w manifeście modułu „{0}”.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>Wartość klucza {0} w elemencie {1} ma wartość {2}, a moduł ma zagnieżdżone moduły. Gdy plik CDXML jest modułem głównym, polecenie Import-Module kończy się niepowodzeniem, ponieważ polecenia w modułach zagnieżdżonych nie mogą zostać wyeksportowane. Przenieś plik CDXML do klucza NestedModules i spróbuj ponownie uruchomić polecenie.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Niepowodzenie polecenia zdalnego: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Nie można wygenerować serwerów proxy dla modułu zdalnego „{0}”. {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Nie można przetworzyć modułu zdalnego {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Nie można odebrać danych modułu ze zdalnej sesji CimSession. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Wymagany moduł „{0}” o identyfikatorze GUID „{1}” i wersji „{2}” nie został załadowany, ponieważ w żadnym katalogu modułów nie znaleziono prawidłowego pliku modułu.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Na serwerze CIM nie znaleziono dostawcy CIM na potrzeby odnajdywania modułów. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Nie można zweryfikować wersji platformy Microsoft .NET Framework {0}, ponieważ nie ma jej na liście dozwolonych wersji.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Analizowanie elementu {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Przygotowywanie modułów do pierwszego użycia.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Trwa wyszukiwanie dostępnych modułów...</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Wyszukiwanie udziału UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Uruchamianie polecenia cmdlet Get-Module na komputerze zdalnym jest możliwe tylko w przypadku nazw modułów, które nie zawierają ścieżki. Parametr „Name” ma element „{0}”, który jest rozpoznawany jako ścieżka. Zaktualizuj parametr „Name” tak, aby nie zawierał elementów ścieżki, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Uruchamianie polecenia cmdlet Get-Module bez parametru ListAvailable nie jest obsługiwane w przypadku nazw modułów zawierających ścieżkę. Parametr „Name” ma element „{0}”, który jest rozpoznawany jako ścieżka. Zaktualizuj parametr „Name” tak, aby nie zawierał elementów ścieżki, a następnie spróbuj ponownie.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Określony moduł „{0}” nie został znaleziony. Zaktualizuj parametr „Name”, aby wskazywał prawidłową ścieżkę, i spróbuj ponownie. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Wypełnianie właściwości RepositorySourceLocation dla modułu {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Moduł do przetwarzania „{0}”, wymieniony w polu „{1}” manifestu modułu „{2}”, nie został przetworzony. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>To wymaganie wstępne dotyczy tylko edycji programu PowerShell na komputery stacjonarne.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Moduł „{0}” nie obsługuje bieżącej edycji programu PowerShell „{1}”. Obsługiwane edycje to „{2}”. Użyj polecenia „Import-Module -SkipEditionCheck”, aby pominąć sprawdzanie zgodności tego modułu.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Moduł „{0}” obsługuje edycję programu PowerShell „{1}” i nie może zostać załadowany niejawnie przy użyciu funkcji zgodności z systemem Windows, ponieważ jest ona wyłączona w pliku ustawień. Użyj polecenia „Import-Module -UseWindowsPowerShell”, aby załadować ten moduł w programie Windows PowerShell, lub polecenia „Import-Module -SkipEditionCheck”, aby spróbować załadować go w bieżącym programie PowerShell.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Dla funkcji eksperymentalnej zadeklarowanej w manifeście modułu należy określić wartość ciągu, która nie jest pusta.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Znaleziono co najmniej jedną nieprawidłową nazwę funkcji eksperymentalnej: {0}. Nazwa funkcji eksperymentalnej modułu powinna mieć postać „ModuleName.FeatureName”.</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Nie można użyć parametru przełącznika -SkipEditionCheck bez parametru przełącznika -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>Importowanie plików *.ps1 jako modułów jest niedozwolone w trybie ConstrainedLanguage.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Wystąpił błąd podczas ładowania modułu skryptu {0}, ponieważ ma on inny tryb językowy niż manifest modułu. Tryb językowy manifestu to {1}, a tryb językowy modułu to {2}. Upewnij się, że wszystkie pliki modułu są podpisane lub w inny sposób znajdują się na liście dozwolonych aplikacji.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Ten moduł używa operatora dot-source podczas eksportowania funkcji przy użyciu symboli wieloznacznych, a jest to niedozwolone, gdy system wymusza weryfikację aplikacji.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Nie można wyeksportować elementów modułu z modułu, który ma inny tryb języka niż uruchomiona sesja.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Nie można utworzyć nowego modułu, gdy sesja jest w trybie ConstrainedLanguage.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Nie można znaleźć wbudowanego modułu „{0}”, który jest zgodny z edycją „Core”. Upewnij się, że wbudowane moduły programu PowerShell są dostępne. Zazwyczaj są dostarczane z pakietem programu PowerShell w ścieżce modułu $PSHOME i są wymagane do prawidłowego działania programu PowerShell.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Polecenie cmdlet Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>Eksportowanie elementów modułu w trybie języka z ograniczeniami zakończy się niepowodzeniem, ponieważ moduł „{0}” ma tryb języka „{1}”, który różni się od bieżącej sesji „{2}”.</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Niejawny eksport funkcji modułu</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>Niejawny eksport funkcji dla modułu „{0}” zostanie odrzucony, ponieważ moduł jest zaufany (działa w trybie Full Language), ale sesja nie jest zaufana (działa w trybie Constrained Language). Najlepszym rozwiązaniem jest zawsze eksportowanie funkcji modułu osobno, używając pełnej nazwy.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Importowanie pliku skryptu jako modułu</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>Importowanie pliku skryptu „{0}” jako modułu będzie niedozwolone w trybie ConstrainedLanguage.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Moduł zawiera operator dot-source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>Importowanie modułu „{0}” zakończy się niepowodzeniem w trybie języka z ograniczeniami, ponieważ eksportuje funkcje przy użyciu symboli wieloznacznych, a jednocześnie używa operatora dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>„Funkcje eksportowane przez moduł</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Moduł „{0}” eksportuje funkcje przy użyciu symboli wieloznacznych w nazwie. Wszystkie nazwy funkcji zagnieżdżonych modułów zostaną usunięte podczas działania w trybie języka z ograniczeniami.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>„Polecenie cmdlet New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Nowy moduł z niezaufanej sesji języka z ograniczeniami będzie blokowany przed udostępnianiem bloku skryptu FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>„Niezgodne tryby języka modułu</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Trwa ładowanie modułu zależnego, który ma inny tryb języka niż moduł nadrzędny. W trybie Constrained Language nie będzie to dozwolone.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/PSConfigurationStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/PSConfigurationStrings.pl.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>Program PowerShell przestał działać z powodu problemu z zabezpieczeniami: nie można odczytać pliku konfiguracji: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/PathUtilsStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/PathUtilsStrings.pl.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>Kodowanie „UTF-7” jest przestarzałe. Użyj UTF-8.</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>Plik {0} już istnieje i określono {1}.</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Nie można otworzyć pliku, ponieważ bieżący dostawca ({0}) nie może otworzyć pliku.</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Nie można wykonać operacji, ponieważ ścieżka wskazuje na więcej niż jeden plik. To polecenie nie może działać na wielu plikach.</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Nie można wykonać operacji, ponieważ ścieżka z symbolami wieloznacznymi {0} nie wskazuje na plik.</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>Nieznane kodowanie {0}; prawidłowe wartości to {1}.</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>Katalog „{0}” już istnieje.  Użyj parametru -Force, jeśli chcesz zastąpić katalog i znajdujące się w nim pliki.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>Ścieżka modułu użytkownika nie istnieje, więc nie można utworzyć folderu modułu dla podanej nazwy modułu „{0}”.</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>Nie można utworzyć modułu {0} z następującego powodu: {1}. Użyj innego argumentu dla parametru -OutputModule i spróbuj ponownie.</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>Nie można załadować modułu, ponieważ został wygenerowany przy użyciu niezgodnej wersji polecenia cmdlet {0}. Wygeneruj moduł za pomocą polecenia cmdlet {0} z bieżącej sesji i spróbuj załadować go ponownie.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/RemotingErrorIdStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/RemotingErrorIdStrings.pl.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>Symbole wieloznaczne nie są obsługiwane dla parametru FilePath. Określ ścieżkę bez symboli wieloznacznych.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>Należy określić wartość {0} dla opcji sesji {1}.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>Maksymalna liczba przekierowań identyfikatora URI WS-Man dozwolonych podczas łączenia się z komputerem zdalnym</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>Nie można użyć parametru WriteEvents bez parametru Wait.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>Komunikacja zdalna programu PowerShell nie jest obsługiwana w środowisku preinstalacji systemu Windows (WinPE).</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>Zmiany wprowadzone przez {0} nie zaczną obowiązywać, dopóki usługa WinRM nie zostanie ponownie uruchomiona.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0} Może być konieczne ponowne uruchomienie usługi WinRM, jeśli konfiguracja używająca tej nazwy została niedawno wyrejestrowana, ponieważ niektóre struktury danych systemowych mogą być nadal buforowane. W takim przypadku może być wymagane ponowne uruchomienie usługi WinRM.
+Wszystkie sesje WinRM połączone z konfiguracjami sesji programu PowerShell, takimi jak Microsoft.PowerShell, oraz konfiguracjami sesji utworzonymi za pomocą polecenia cmdlet Register-PSSessionConfiguration, zostaną rozłączone.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>Korzystasz z sesji zdalnej i wybrano opcję Wymuś, co oznacza, że usługa WinRM może zostać ponownie uruchomiona. Jeśli usługa WinRM zostanie ponownie uruchomiona, ta sesja zdalna zostanie zakończona i aby kontynuować, trzeba będzie utworzyć nową sesję</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>Parametru -WriteJobInResults nie można użyć bez parametru -Wait</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>Podany strumień wejściowy jest nieprawidłowy. Jako strumień wejściowy jest obsługiwany tylko {0}.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>Podany zestaw strumieni wyjściowych jest nieprawidłowy. Jako strumień wyjściowy obsługiwana jest tylko {0}.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>Podany WSMAN_SENDER_DETAILS jest nieprawidłowy. Nie można przetworzyć WSMAN_SENDER_DETAILS o wartości null.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>Podany kontekst powłoki jest nieprawidłowy.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Wartość NULL nie jest dozwolona dla {0} w metodzie wtyczki {1}.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>Wartość NULL nie jest dozwolona dla zestawów strumieni wejściowych i wyjściowych. {0} i {1} są obsługiwanymi strumieniami wejściowymi i wyjściowymi.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Wartość NULL nie jest dozwolona dla {0} w metodzie wtyczki {1}.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>Wartość NULL nie jest dozwolona dla {0} w metodzie wtyczki {1}.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>Trwa zamykanie operacji wtyczki programu PowerShell. Może się tak zdarzyć, jeśli usługa hostująca lub aplikacja jest zamykana.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Wtyczka programu PowerShell nie rozumie opcji {0}. Upewnij się, że klient jest zgodny z kompilacją {1} i wersją protokołu {2} programu PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>Oczekiwana jest opcja o nazwie {0} od klienta. Upewnij się, że klient jest zgodny z kompilacją {1} i wersją protokołu {2} programu PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Wtyczka programu PowerShell nie obsługuje wersji protokołu {2} żądanej przez klienta.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>Wtyczka programu PowerShell napotkała błąd krytyczny podczas raportowania kontekstu do usługi WSMan.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>Nie można utworzyć zarządzanej sesji serwera.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>Wtyczka programu PowerShell napotkała błąd krytyczny podczas rejestrowania dojścia oczekiwania dla powiadomienia o zamknięciu.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>Nie znaleziono pliku wykonywalnego „{0}”. Sprawdź, czy funkcja WOW64 jest zainstalowana.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>Nie można utworzyć procesu programu Windows PowerShell, ponieważ na tym komputerze nie można znaleźć programu Windows PowerShell.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/pl/Serialization.pl.resx
+++ b/src/System.Management.Automation/resources/pl/Serialization.pl.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AttributeExpected" xml:space="preserve">
-    <value>{0} attribute was expected.</value>
+    <value>Oczekiwano atrybutu {0}.</value>
   </data>
   <data name="InvalidElementTag" xml:space="preserve">
-    <value>{0} XML tag is not recognized.</value>
+    <value>{0} tag XML nie został rozpoznany.</value>
   </data>
   <data name="InvalidReferenceId" xml:space="preserve">
-    <value>No object found for referenceId {0}</value>
+    <value>Nie znaleziono obiektu dla referenceId {0}</value>
   </data>
   <data name="InvalidDictionaryKeyName" xml:space="preserve">
-    <value>Name attribute for dictionary key is incorrectly specified.</value>
+    <value>Atrybut Name dla klucza słownika jest nieprawidłowo określony.</value>
   </data>
   <data name="InvalidDictionaryValueName" xml:space="preserve">
-    <value>Name attribute for dictionary value is incorrectly specified.</value>
+    <value>Atrybut nazwy dla wartości słownika jest niepoprawnie określony.</value>
   </data>
   <data name="InvalidVersion" xml:space="preserve">
-    <value>Version of PSObject is not valid.</value>
+    <value>Wersja obiektu PSObject jest nieprawidłowa.</value>
   </data>
   <data name="UnexpectedVersion" xml:space="preserve">
-    <value>Version of incoming PSObject is {0}. Expected value is 1.</value>
+    <value>Wersja przychodzącego obiektu PSObject to {0}. Oczekiwana wartość to 1.</value>
   </data>
   <data name="InvalidTypeHierarchyReferenceId" xml:space="preserve">
-    <value>Cannot process names because no TypeNames were found for referenceId {0}.</value>
+    <value>Nie można przetworzyć nazw, ponieważ nie znaleziono elementów TypeNames dla elementu referenceId {0}.</value>
   </data>
   <data name="DepthOfOneRequired" xml:space="preserve">
-    <value>Value of depth parameter must be greater than or equal to 1.</value>
+    <value>Wartość parametru głębokości musi być większa lub równa 1.</value>
   </data>
   <data name="InvalidNodeType" xml:space="preserve">
-    <value>Current Node type is {0}. Expected type is {1}.</value>
+    <value>Bieżący typ węzła to {0}. Oczekiwanym typ to {1}.</value>
   </data>
   <data name="DictionaryKeyNotSpecified" xml:space="preserve">
-    <value>Key for dictionary entry is not specified.</value>
+    <value>Nie określono klucza dla wpisu słownika.</value>
   </data>
   <data name="DictionaryValueNotSpecified" xml:space="preserve">
-    <value>Value for dictionary entry is not specified.</value>
+    <value>Nie określono wartości wpisu słownika.</value>
   </data>
   <data name="ReadCalledAfterDone" xml:space="preserve">
-    <value>There are no more objects to deserialize.</value>
+    <value>Nie ma już więcej obiektów do deserializacji.</value>
   </data>
   <data name="NullAsDictionaryKey" xml:space="preserve">
-    <value>Null is specified as dictionary key.</value>
+    <value>Wartość null jest określona jako klucz słownika.</value>
   </data>
   <data name="InvalidPrimitiveType" xml:space="preserve">
-    <value>The contents of the {0} primitive type are not valid.</value>
+    <value>Zawartość typu pierwotnego {0} jest nieprawidłowa.</value>
   </data>
   <data name="DeserializationTooDeep" xml:space="preserve">
-    <value>Serialized XML is nested too deeply.</value>
+    <value>Serializowany kod XML jest zagnieżdżony zbyt głęboko.</value>
   </data>
   <data name="Stopping" xml:space="preserve">
-    <value>Serializer was closed.</value>
+    <value>Serializator został zamknięty.</value>
   </data>
   <data name="DeserializationMemoryQuota" xml:space="preserve">
-    <value>The data in the command exceeded the maximum size that is allowed by the session configuration. The allowed maximum is {0} MB. Change the input, use a different session configuration, or change the "{1}" and "{2}" properties of the session configuration on the remote computer.</value>
+    <value>Dane w poleceniu przekroczyły maksymalny rozmiar dozwolony przez konfigurację sesji. Maksymalny dozwolony rozmiar to {0} MB. Zmień dane wejściowe, użyj innej konfiguracji sesji lub zmień właściwości „{1}” i „{2}” konfiguracji sesji na komputerze zdalnym.</value>
   </data>
   <data name="DeserializeSecureStringFailed" xml:space="preserve">
-    <value>Deserialization of encrypted secure string failed</value>
+    <value>Deserializacja zaszyfrowanego bezpiecznego ciągu nie powiodła się</value>
   </data>
   <data name="PrimitiveHashtableInvalidKey" xml:space="preserve">
-    <value>The key type {0} is not valid. The PSPrimitiveDictionary class accepts only keys of the type System.String.</value>
+    <value>Typ klucza {0} jest nieprawidłowy. Klasa PSPrimitiveDictionary akceptuje tylko klucze typu System.String.</value>
   </data>
   <data name="PrimitiveHashtableInvalidValue" xml:space="preserve">
-    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over PowerShell remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
+    <value>Typ wartości {0} jest nieprawidłowy. Klasa PSPrimitiveDictionary akceptuje tylko wartości typów, które są w pełni serializowalne przez zdalne komunikowanie PowerShell. Zobacz temat Pomoc about_Remoting, aby uzyskać listę typów w pełni serializowalnych.</value>
   </data>
   <data name="InvalidKey" xml:space="preserve">
-    <value>Could not decrypt data. The data was not encrypted with this key.</value>
+    <value>Nie można odszyfrować danych. Dane nie zostały zaszyfrowane przy użyciu tego klucza.</value>
   </data>
   <data name="InvalidEncryptedString" xml:space="preserve">
-    <value>The parameter value "{0}" is not a valid encrypted string.</value>
+    <value>Wartość parametru „{0}” nie jest prawidłowym zaszyfrowanym ciągiem.</value>
   </data>
   <data name="InvalidKeyLength" xml:space="preserve">
-    <value>The specified {0} is not valid. Valid {0} length settings are either 128 bits, 192 bits, or 256 bits.</value>
+    <value>Określony {0} jest nieprawidłowy. Prawidłowe ustawienia długości {0} to 128 bitów, 192 bity lub 256 bitów.</value>
   </data>
   <data name="DeserializeSecureStringNotSupported" xml:space="preserve">
-    <value>Deserialization of SecureString is currently only supported on Windows.</value>
+    <value>Deserializacja obiektu SecureString jest obecnie obsługiwana tylko w systemie Windows.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/SessionStateStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/SessionStateStrings.pl.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>Nie można przetworzyć zwróconych informacji, ponieważ informacje zwrócone przez metodę Start dostawcy dotyczyły innego dostawcy niż ten, który przekazano.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>Nie można przetworzyć zwróconych informacji, ponieważ informacje zwrócone przez metodę Start dostawcy miały wartość null.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji SetItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji SetItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji ClearItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji InvokeDefaultAction dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji InvokeDefaultAction od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji ItemExists dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji ItemExists od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji IsValidPath dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji IsItemContainer dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji RemoveItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetChildItems dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetChildItems od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetChildNames dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetChildNames od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji RenameItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji RenameItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji NewItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji NewItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji HasChildItems dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji CopyItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji CopyItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetParentPath dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji NormalizeRelativePath dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji MakePath dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetChildName dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji MoveItem dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji MoveItem od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji SetProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji SetProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji ClearProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji ClearProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji NewProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji NewProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji RemoveProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji RemoveProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji CopyProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji CopyProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji MoveProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji MoveProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji RenameProperty dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji RenameProperty od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Nie można pobrać czytnika zawartości dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetContentReader od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Nie można pobrać autora zawartości dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji GetContentWriter od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>Nie można pobrać zawartości, ponieważ to katalog: „{0}”. Użyj zamiast tego polecenia „Get-ChildItem”.</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>Nie można zapisać zawartości, ponieważ to katalog: „{0}”.</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>Brak historii lokalizacji, która umożliwiałaby wsteczną nawigację.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>Brak historii lokalizacji umożliwiającej dalszą nawigację.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>Element BoundedStack jest pusty.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji ClearContent dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>Nie można wyczyścić zawartości elementu „{0}”, ponieważ jest to katalog. Polecenie Clear-Content jest obsługiwane tylko dla plików.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla operacji ClearContent od dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji GetSecurityDescriptor dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Nie można wykonać operacji SetSecurityDescriptor dla dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>Nie można wykonać operacji Start dla dostawcy „{0}”. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>Nie można wykonać operacji InitializeDefaultDrives u dostawcy „{0}”.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>Nie można wykonać operacji NewDrive dla dysku z poziomem głównym „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>Nie można pobrać parametrów dynamicznych dla dostawcy „{0}” dla operacji NewDrive. {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>Wywołanie RemoveDrive u dostawcy „{0}” zakończyło się niepowodzeniem. {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>Nie można usunąć dysku „{0}”, ponieważ uniemożliwił to dostawca „{1}”.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>Ścieżka „{0}” odwoływała się do elementu znajdującego się poza podstawą „{1}”.</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Nie można wywołać metody Seek w module zapisu zawartości dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>Nie można wywołać metody Close w module odczytu lub zapisu zawartości dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>Nie można wywołać metody Read w module odczytu zawartości dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Nie można wywołać metody Write w module zapisu zawartości dostawcy „{0}” dla ścieżki „{1}”. {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>Dostawcy „{0}” nie można użyć do pobierania ani ustawiania danych przy użyciu składni zmiennej. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>Składnia zmiennej nie może być używana do pobierania lub ustawiania danych w dostawcy. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>Alias nie jest zapisywalny, ponieważ alias {0} jest tylko do odczytu lub stały i nie można go zmieniać.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>Nie można zapisać do funkcji {0}, ponieważ jest ona tylko do odczytu lub stała.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>Nie można zastąpić zmiennej {0}, ponieważ jest tylko do odczytu lub stała.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>Nie można uzyskać dostępu do zmiennej „${0}”, ponieważ jest to zmienna prywatna.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>Nie można uzyskać dostępu do polecenia „{0}”, ponieważ jest ono prywatne.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>Nie można uzyskać dostępu do polecenia, ponieważ jest ono prywatne.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>Nie można uzyskać dostępu do zasobu stanu sesji, ponieważ jest to zasób prywatny. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>Alias nie został usunięty, ponieważ alias {0} jest stały lub tylko do odczytu.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>Nie można usunąć funkcji {0}, ponieważ jest stała.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>Nie można usunąć zmiennej {0}, ponieważ jest stała lub tylko do odczytu. Jeśli zmienna jest tylko do odczytu, spróbuj ponownie, używając opcji Force.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>Alias {0} nie może zostać zmodyfikowany ponieważ jest stały.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>Alias {0} nie może zostać zmodyfikowany ponieważ jest tylko do odczytu.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>Nie można zmodyfikować funkcji {0}, ponieważ jest stała.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>Nie można zmodyfikować funkcji {0}, ponieważ jest tylko do odczytu.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>Nie można ustawić aliasu {0} jako stałego po jego utworzeniu. Alias można ustawić jako stały tylko w momencie tworzenia.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>Istniejącej funkcji {0} nie można ustawić jako stałej. Funkcje można oznaczyć jako stałe tylko w chwili tworzenia.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>Istniejącej zmiennej {0} nie można ustawić jako stałej. Zmienne można oznaczyć jako stałe tylko w chwili tworzenia.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>Nie można usunąć opcji AllScope z aliasu „{0}”.</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>Nie można usunąć opcji AllScope z funkcji „{0}”.</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>Nie można usunąć opcji AllScope ze zmiennej „{0}”.</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>Definicja funkcji „{0}” zawierała kwalifikator zakresu, ale nie zawierała nazwy funkcji.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>Nie można usunąć dostawcy {0}. Przed usunięciem dostawcy {0} trzeba usunąć wszystkie dyski skojarzone z dostawcą {0}.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>Nie można przetworzyć nazwy dysku, ponieważ zawiera co najmniej jeden z tych nieprawidłowych znaków: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>Nie można utworzyć nowego dysku, ponieważ dostawca nie zezwala na tworzenie nowego dysku.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>Podana wartość „{0}” została rozpoznana jako więcej niż jeden stos lokalizacji.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>Nie można znaleźć stosu lokalizacji „{0}”. Element nie istnieje albo nie jest kontenerem.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
-    <value>Cannot find path '{0}' because it does not exist.</value>
+    <value>Nie można odnaleźć ścieżki „{0}”, ponieważ nie istnieje.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>Nie można znaleźć aliasu, ponieważ alias „{0}” nie istnieje.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>Nie można ustawić lokalizacji, ponieważ ścieżka „{0}” wskazuje na wiele kontenerów. Lokalizację można ustawić tylko dla jednego kontenera na raz.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>Nie można przetworzyć zmiennej, ponieważ ścieżka zmiennej „{0}” wskazuje wiele elementów. Wartość zmiennej można pobierać lub ustawiać tylko dla jednego elementu na raz.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>Nie można odnaleźć dysku. Dysk o nazwie „{0}” nie istnieje.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>Nie można znaleźć dostawcy o nazwie „{0}”.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Nie można znaleźć dostawcy o nazwie „{0}”. Nazwa ma nieprawidłowy format. Nazwa dostawcy może zawierać tylko znaki alfanumeryczne albo nazwę przystawki programu PowerShell, po której występuje pojedynczy znak „\”, a potem znaki alfanumeryczne.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>Element „{0}” rozpoznano jako więcej niż jedną nazwę dostawcy. Możliwe dopasowania to: {1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Wystąpił błąd podczas próby utworzenia wystąpienia dostawcy. Nie można odnaleźć nazwy typu dostawcy „{0}” w zestawie.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>Nie można użyć określonej nazwy dostawcy „{0}”, ponieważ zawiera co najmniej jeden z tych nieprawidłowych znaków: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>Wystąpił błąd podczas próby utworzenia wystąpienia dostawcy „{0}”. {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>Nie można znaleźć zmiennej o nazwie „{0}”.</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>Nie można odnaleźć źródła śledzenia o nazwie „{0}”.</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>Dysk o nazwie „{0}” już istnieje.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>Zmienna o nazwie „{0}” już istnieje.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>Nie można utworzyć aliasu, ponieważ alias o nazwie „{0}” już istnieje.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>Nie można zarejestrować dostawcy poleceń cmdlet, ponieważ dostawca o nazwie „{0}” już istnieje.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>Ścieżka nie jest ścieżką systemu plików.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>Nie można usunąć zakresu globalnego.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>Numer zakresu „{0}” przekracza liczbę aktywnych zakresów.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>Nie można porównać obiektu PSDriveInfo. Wystąpienie PSDriveInfo można porównać tylko z innym wystąpieniem PSDriveInfo.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Dostawca poleceń cmdlet nie może przesłać wyników strumieniowo, ponieważ nie określono polecenia cmdlet, przez które można przesłać wynik strumieniowo.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Dostawca poleceń cmdlet nie może przesłać wyników strumieniowo, ponieważ nie określono polecenia cmdlet, przez które można przesłać błąd strumieniowo.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>Lokalizacja główna tego dostawcy nie jest ustawiona. Aby ustawić lokalizację główną, wywołaj „(get-psprovider '{0}').Home = 'path'”.</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>Ścieżka ma niepoprawny format. Ścieżki dostawców muszą zawierać identyfikator dostawcy, po którym występuje „::”, a następnie ścieżka właściwa dla dostawcy.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>Nie można przenieść elementu, ponieważ ścieżka docelowa może wskazywać tylko jedną ścieżkę.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>Nie można przenieść elementu, ponieważ ścieżki źródłowa i docelowa nie zostały rozpoznane jako należące do tego samego dostawcy.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>Nie można przenieść elementu, ponieważ ścieżka źródłowa wskazuje jeden lub więcej elementów, a ścieżka docelowa nie jest kontenerem. Sprawdź, czy ścieżka docelowa jest kontenerem, i spróbuj ponownie.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>Nie można przenieść elementu, ponieważ miejsce docelowe zostało rozpoznane jako wiele ścieżek. Podaj ścieżkę docelową, która prowadzi do jednego miejsca docelowego, i spróbuj ponownie.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>Nie można skopiować kontenera do istniejącego elementu końcowego.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>Nie można skopiować kontenera do innego kontenera. Nie określono parametru -Recurse ani -Container.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>Ścieżka źródłowa i docelowa nie wskazują na tego samego dostawcę.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>Nie można zmienić nazwy elementu, ponieważ ścieżka została rozpoznana jako wiele elementów. Jednocześnie można zmienić nazwę tylko jednego elementu.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>Nie można użyć dostawcy „{0}” do rozwiązania ścieżki „{1}” z powodu błędu w dostawcy.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>Nie można użyć interfejsu. Ten dostawca nie wdraża interfejsu IContentCmdletProvider.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>Nie można użyć interfejsu. Ten dostawca nie obsługuje interfejsu IPropertyCmdletProvider.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>Nie można użyć interfejsu. Ten dostawca nie wdraża interfejsu IDynamicPropertyCmdletProvider.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>Metody NavigationCmdletProvider nie są obsługiwane przez tego dostawcę.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Metody dostawcy nie zostały przetworzone. Metody ContainerCmdletProvider nie są obsługiwane przez tego dostawcę.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>Nie można wywołać metod. Metody ItemCmdletProvider nie są obsługiwane przez tego dostawcę.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>Metody DriveCmdletProvider nie są obsługiwane przez tego dostawcę.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>Operacja dostawcy została zatrzymana, ponieważ ten dostawca nie obsługuje tej operacji.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>Operacja dostawcy została zatrzymana, ponieważ ten dostawca nie obsługuje parametru „Depth”.</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>Nie można wywołać metody. Metoda wyszukiwania zawartości nie jest obsługiwana przez tego dostawcę.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>Nie można wykonać operacji ClearContent. Ten dostawca nie obsługuje operacji ClearContent.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>Dostawca nie obsługuje używania poświadczeń. Spróbuj ponownie bez podawania poświadczeń.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>Dostawca systemu plików obsługuje poświadczenia tylko w poleceniu cmdlet New-PSDrive. Spróbuj ponownie bez podawania poświadczeń.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>Dostawca nie obsługuje transakcji. Wykonaj operację ponownie bez parametru -UseTransaction.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>Nie można wywołać metody. Dostawca nie obsługuje używania filtrów.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>Nie można utworzyć dysku. Dostawca nie obsługuje używania poświadczeń.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>Element w ścieżce „{0}” już istnieje.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>Nie można skopiować elementu. Element na ścieżce „{0}” nie istnieje.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>Element na ścieżce „{0}” nie istnieje.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Dysk zawierający widok aliasów przechowywanych w stanie sesji</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>Dysk zawierający widok zmiennych środowiskowych procesu</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Dysk zawierający widok funkcji przechowywanych w stanie sesji</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Dysk zawierający widok zmiennych przechowywanych w stanie sesji</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Dysk mapowany do ścieżki katalogu tymczasowego bieżącego użytkownika</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>Nie można utworzyć łącza „{0}”, ponieważ nie określono wartości docelowej.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Odwołania do zmiennej null zawsze zwracają wartość null. Przypisania nie mają żadnego efektu.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Maksymalna liczba obiektów historii przechowywanych w sesji</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>Nie można zmienić nazwy funkcji, ponieważ funkcja {0} jest tylko do odczytu lub stała.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>Nie można zmienić nazwy aliasu, ponieważ alias {0} jest tylko do odczytu lub stały.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>Nie można zmienić nazwy zmiennej, ponieważ zmienna {0} jest tylko do odczytu lub stała.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>Nie można ustawić opcji dla zmiennej lokalnej {0}. Użyj polecenia New-Variable, aby utworzyć zmienną, dla której można ustawiać opcje.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Polecenie cmdlet {0} nie może zostać zmodyfikowane ponieważ jest tylko do odczytu.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>Nie można usunąć zmiennej {0}, ponieważ została zoptymalizowana i nie można jej usunąć. Spróbuj użyć polecenia cmdlet Remove-Variable (bez aliasów) albo polecenia dot-source, którego używasz do usunięcia zmiennych.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>Nie można zastąpić zmiennej {0}, ponieważ została zoptymalizowana. Spróbuj użyć polecenia cmdlet -New-Variable lub Set-Variable (bez aliasów) albo polecenia dot-source, którego używasz do ustawienia zmiennych.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>Parametrów {0} i {1} nie można używać razem. Określ tylko jeden parametr.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Parametr Tail jest obecnie obsługiwany tylko przez dostawcę FileSystem.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>Nie można utworzyć aliasu, ponieważ polecenie o nazwie „{0}” i typie polecenia „{1}” już istnieje.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>Nie można uruchomić oprogramowania. Odmowa uprawnień.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>Elementy „-{0}” i „-{1}” wykluczają się wzajemnie i nie można ich podać jednocześnie.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>Ścieżka „{0}” jest nieprawidłowa. W operacjach kopiowania zdalnego są obsługiwane tylko ścieżki bezwzględne.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>Nie można zweryfikować ścieżki zdalnej „{0}”.</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>Nie można wykonać operacji, ponieważ sesja {0} jest ustawiona na wartość {1}.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>Parametr „{0}” nie może mieć wartości null ani być pusty.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Zmienne stanu sesji</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>Zmiana zakresu zmiennej „{0}” na wartość AllScope lub utworzenie takiej zmiennej będzie blokowane w trybie ConstrainedLanguage.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/pl/TabCompletionStrings.pl.resx
+++ b/src/System.Management.Automation/resources/pl/TabCompletionStrings.pl.resx
@@ -118,274 +118,274 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>Nie można poprawnie zdeserializować wyniku uzupełniania tabulatorem, ponieważ zdalny obszar roboczy nie zawiera wystąpienia TypeTable.</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>Nie można uzyskać dostępu do właściwości pustego wystąpienia typu CompletionResult.</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>Bitowe NIE</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>Logiczne, że nie. Neguje wyrażenie, które po nim występuje.</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest równy prawemu operandowi.</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest równy prawemu operandowi.</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>Równe — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest równy prawemu operandowi.</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Nie równa się — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które nie są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie jest równy prawemu operandowi.</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Nie równa się — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które nie są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie jest równy prawemu operandowi.</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>Nie równa się — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które nie są równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie jest równy prawemu operandowi.</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Większe niż lub równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe lub równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest większy lub równy prawemu operandowi.</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Większe niż lub równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe lub równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest większy lub równy prawemu operandowi.</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>Większe niż lub równe — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe lub równe prawemu operandowi; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest większy lub równy prawemu operandowi.</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Większe niż — bez uwzględniania wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest większy od prawego operandu.</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Większe niż — bez uwzględniania wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest większy od prawego operandu.</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>Większe niż — z uwzględnieniem wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są większe od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest większy od prawego operandu.</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Mniejsze niż — bez uwzględniania wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są mniejsze od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy od prawego operandu.</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Mniejsze niż — bez uwzględniania wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są mniejsze od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy od prawego operandu.</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>Mniejsze niż — z uwzględnieniem wielkości liter. Jeśli lewy operand jest kolekcją, zwraca wartości ze zbioru, które są mniejsze od prawego operandu. W przeciwnym wypadku zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy od prawego operandu.</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Mniejsze niż lub równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które są mniejsze lub równe prawemu operandowi. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy lub równy prawemu operandowi.</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Mniejsze niż lub równe — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które są mniejsze lub równe prawemu operandowi. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy lub równy prawemu operandowi.</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>Mniejsze niż lub równe — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które są mniejsze lub równe prawemu operandowi. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand jest mniejszy lub równy prawemu operandowi.</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania symboli wieloznacznych — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca wartości z kolekcji, które pasują do prawego operandu; w przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand pasuje do prawego operandu.</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — bez uwzględniania wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>Operator dopasowywania wyrażeń regularnych — z uwzględnieniem wielkości liter. Gdy lewy operand jest kolekcją, zwraca z niej wartości, które nie pasują do prawego operandu. W przeciwnym razie zwraca wartość PRAWDA, jeśli lewy operand nie pasuje do prawego operandu.</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operator zamiany — bez uwzględniania wielkości liter. Zmienia lewy operand. Przykład: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operator zamiany — bez uwzględniania wielkości liter. Zmienia lewy operand. Przykład: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>Operator zamiany — z uwzględnieniem wielkości liter. Zmienia lewy operand. Przykład: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (prawy operand) dokładnie pasuje do co najmniej jednej z wartości w lewym operandzie.</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (prawy operand) dokładnie pasuje do co najmniej jednej z wartości w lewym operandzie.</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>Operator zawierania — z uwzględnieniem wielkości liter. Zwraca wartość PRAWDA tylko wtedy, gdy wartość testowa (prawy operand) dokładnie pasuje do co najmniej jednej z wartości w lewym operandzie.</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (prawy operand) nie pasuje dokładnie do żadnej wartości w lewym operandzie.</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (prawy operand) nie pasuje dokładnie do żadnej wartości w lewym operandzie.</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>Operator zawierania — z uwzględnieniem wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (prawy operand) nie pasuje dokładnie do żadnej wartości w lewym operandzie.</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) dokładnie pasuje do co najmniej jednej z wartości w prawym operandzie.</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) dokładnie pasuje do co najmniej jednej z wartości w prawym operandzie.</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>Operator zawierania — z uwzględnieniem wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) dokładnie pasuje do co najmniej jednej z wartości w prawym operandzie.</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operator zawierania — z uwzględnieniem wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) nie pasuje dokładnie do żadnej wartości w prawym operandzie.</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operator zawierania — bez uwzględniania wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) nie pasuje dokładnie do żadnej wartości w prawym operandzie.</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>Operator zawierania — z uwzględnieniem wielkości liter. Zwraca wartość PRAWDA, gdy wartość testowa (lewy operand) nie pasuje dokładnie do żadnej wartości w prawym operandzie.</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Podział — z uwzględnieniem wielkości liter. Dzieli jeden lub więcej ciągów na podciągi.
+-Podziel &lt;Ciąg&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;Ciąg&gt; -Podziel &lt;Ogranicznik&gt;[,&lt;Maks. liczba podciągów&gt;[,"&lt;Opcje&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;Ciąg&gt; -Podziel {&lt;ScriptBlock&gt;} [,&lt;Maks. liczba podciągów&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Podział — z uwzględnieniem wielkości liter. Dzieli jeden lub więcej ciągów na podciągi.
+-Podziel &lt;Ciąg&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;Ciąg&gt; -Podziel &lt;Ogranicznik&gt;[,&lt;Maks. liczba podciągów&gt;[,"&lt;Opcje&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;Ciąg&gt; -Podziel {&lt;ScriptBlock&gt;} [,&lt;Maks. liczba podciągów&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
--Split &lt;String&gt;
+    <value>Podział— z uwzględnieniem wielkości liter. Dzieli jeden lub więcej ciągów na podciągi.
+-Podziel &lt;Ciąg&gt;
 
-&lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
+&lt;Ciąg&gt; -Podziel &lt;Ogranicznik&gt;[,&lt;Maks. liczba podciągów&gt;[,"&lt;Opcje&gt;"]]
 
-&lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
+&lt;Ciąg&gt; -Podziel {&lt;ScriptBlock&gt;} [,&lt;Maks. liczba podciągów&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>Zwraca wartość PRAWDA, gdy lewy operand nie jest wystąpieniem określonego typu platformy .NET Framework (prawy operand).</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>Zwraca wartość PRAWDA, gdy lewy operand jest wystąpieniem określonego typu platformy .NET Framework (prawy operand).</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>Konwertuje lewy operand na określony typ platformy .NET Framework (prawy operand).</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>Formatuje ciągi przy użyciu metody formatowania obiektów ciągów.</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>Logiczne oraz. Zwraca wartość PRAWDA, gdy oba wyrażenia mają wartość PRAWDA.</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>Bitowe polecenie ORAZ</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>Logiczne lub. Zwraca wartość PRAWDA, gdy jedno lub oba wyrażenia mają wartość PRAWDA.</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>Bitowe LUB (włącznie)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>Logiczne wyłączne lub. Zwraca wartość PRAWDA, gdy jedno z wyrażeń ma wartość PRAWDA, a drugie wartość FAŁSZ.</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>Bitowe LUB (wyłączne)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
--Join &lt;String[]&gt;
-&lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
+    <value>Dołącz — łączy wiele ciągów w jeden ciąg.
+-Dołącz &lt;Ciąg[]&gt;
+&lt;Ciąg[]&gt; -Dołącz &lt;Ogranicznik&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>Operator bitowy przesunięcia w lewo. Wstawia zero w skrajnie prawej pozycji bitowej.</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>Operator bitowy przesunięcia w prawo. Wstawia zero w skrajnie lewej pozycji bitowej. W przypadku wartości ze znakiem zachowywany jest bit znaku.</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
-    <value>[string]
-Specifies the name of the property being created.</value>
+    <value>[ciąg]
+Określa nazwę tworzonej właściwości.</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
-    <value>[string]
-Specifies the name of the property being created.</value>
+    <value>[ciąg]
+Określa nazwę tworzonej właściwości.</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
-    <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+    <value>[blok skryptu]
+Blok skryptu używany do obliczania wartości nowej właściwości.</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
-    <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+    <value>[ciąg]
+Określa sposób wyświetlania wartości w kolumnie.
+Prawidłowe wartości to „left”, „center” i „right”.</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
-    <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+    <value>[ciąg]
+Określa ciąg formatujący, który definiuje sposób formatowania wartości wyjściowej.</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+Określa maksymalną szerokość kolumny w tabeli, gdy wyświetlana jest wartość.
+Wartość musi być większa od 0.</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+Klucz głębokości określa głębokość rozwijania dla każdej właściwości.</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
-    <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+    <value>[wartość logiczna]
+Określa kolejność sortowania dla jednej lub kilku właściwości.</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
-    <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+    <value>[wartość logiczna]
+Określa kolejność sortowania dla jednej lub kilku właściwości.</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+    <value>[Ciąg[]]
+Określa nazwy dzienników, z których mają być pobierane zdarzenia.
+Obsługuje symbole wieloznaczne.</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+    <value>[Ciąg[]]
+Określa dostawców dzienników zdarzeń, z których mają być pobierane zdarzenia.
+Obsługuje symbole wieloznaczne.</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
-    <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+    <value>[Ciąg[]]
+Określa ścieżki plików dziennika, z których mają być pobierane zdarzenia.
+Prawidłowe formaty plików to: .etl, .evt i .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
-    <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+    <value>[długie[]]
+Wybiera zdarzenia z określonymi maskami bitowymi słów kluczowych.
+Poniżej znajdują się standardowe słowa kluczowe:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,213 +398,213 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+Wybiera zdarzenia o określonych identyfikatorach.</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
-2: Error
-3: Warning
-4: Informational
-5: Verbose</value>
+Wybiera zdarzenia z określonymi poziomami dziennika.
+Prawidłowe poziomy dziennika to:
+1: krytyczny
+2: błąd
+3: ostrzeżenie
+4: w celach informacyjnych
+5: pełne informacje</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
-    <value>[datetime]
-Selects events created after the specified date and time.</value>
+    <value>[data/godzina]
+Wybiera zdarzenia utworzone po określonej dacie i godzinie.</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
-    <value>[datetime]
-Selects events created before the specified date and time.</value>
+    <value>[data/godzina]
+Wybiera zdarzenia utworzone przed określoną datą i godziną.</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
-    <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+    <value>[ciąg]
+Wybiera zdarzenia wygenerowane przez określonego użytkownika.
+Może to być ciąg znaków reprezentujący identyfikator SID albo domenę i nazwę użytkownika w formacie DOMENA\NAZWA_UŻYTKOWNIKA lub USERNAME@DOMAIN</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
-    <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+    <value>[ciąg[]]
+Wybiera zdarzenia z dowolną z wartości określonych w sekcji EventData.</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
-    <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+    <value>[tablica skrótów]
+Wyklucza zdarzenia zgodne z wartościami określonymi w tabeli skrótów.</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[ciąg] lub [tabela skrótów]
+Określa tablicę modułów programu PowerShell wymaganych przez skrypt.
+Każdy element może być ciągiem znaków z nazwą modułu albo tabelą skrótów z następującymi kluczami:
+Nazwa: Nazwa modułu
+GUID: identyfikator GUID modułu
+Jedno z następujących:
+ModuleVersion: określa minimalną akceptowalną wersję modułu.
+RequiredVersion: określa dokładną, wymaganą wersję modułu.
+MaximumVersion: określa maksymalną akceptowalną wersję modułu.</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
-    <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+    <value>[ciąg]
+Określa wersję programu PowerShell wymaganą przez skrypt.
+Prawidłowe wartości to „Core” i „Desktop”</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
-    <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+    <value>[przełącznik]
+Określa, że program PowerShell musi być uruchomiony jako administrator w systemie Windows.
+To musi być ostatni parametr w wierszu instrukcji #requires.</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
-    <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+    <value>[wersja]
+Określa minimalną wersję programu PowerShell wymaganą przez skrypt.</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>Określa, że skrypt wymaga do uruchomienia programu PowerShell 7+.</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>Określa, że ​​do uruchomienia skryptu wymagany jest program Windows PowerShell 5.1.</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
-    <value>[string]
-Required. Specifies the module name.</value>
+    <value>[ciąg]
+Wymagane. Określa nazwę modułu.</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
-    <value>[string]
-Optional. Specifies the GUID of the module.</value>
+    <value>[ciąg]
+Opcjonalne. Określa identyfikator GUID modułu.</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
-    <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+    <value>[ciąg]
+Określa minimalną akceptowalną wersję modułu.</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
-    <value>[string]
-Specifies an exact, required version of the module.</value>
+    <value>[ciąg]
+Określa dokładną, wymaganą wersję modułu.</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
-    <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+    <value>[ciąg]
+Określa maksymalną akceptowalną wersję modułu.</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Krótki opis funkcji lub skryptu.
+Tego słowa kluczowego można użyć tylko raz w każdym temacie.</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>Szczegółowy opis funkcji lub skryptu.
+Tego słowa kluczowego można użyć tylko raz w każdym temacie.</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
-    <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+    <value>.PARAMETER  &lt;Nazwa parametru&gt;
+Opis parametru.
+Dodaj słowo kluczowe .PARAMETER dla każdego parametru w składni funkcji lub skryptu.</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>Przykładowe polecenie używające funkcji lub skryptu, po którym opcjonalnie następują przykładowe dane wyjściowe i opis.
+Powtórz to słowo kluczowe dla każdego przykładu.</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>Typy obiektów platformy .NET, które można przekazać potokiem do funkcji lub skryptu.
+Można również uwzględnić opis obiektów wejściowych.</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>Typ platformy .NET obiektów zwracanych przez polecenie cmdlet.
+Możesz też dodać opis zwracanych obiektów.</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>Dodatkowe informacje o funkcji lub skrypcie.</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>Nazwa powiązanego tematu.
+Powtórz słowo kluczowe funkcji .LINK dla każdego powiązanego tematu.
+Zawartość słowa kluczowego funkcji .Link może też zawierać identyfikator URI do internetowej wersji tego samego tematu pomocy.</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>Nazwa technologii lub funkcji używanej przez funkcję lub skrypt bądź z którą jest powiązana.</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>Nazwa roli użytkownika dla tematu pomocy.</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>Słowa kluczowe opisujące zamierzone użycie funkcji.</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+Przekierowuje do tematu pomocy dla określonego polecenia.</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
-    <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+    <value>.FORWARDHELPCATEGORY &lt;Kategoria&gt;
+Określa kategorię pomocy elementu w elemencie .ForwardHelpTargetName</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+Określa sesję zawierającą temat pomocy.
+Wprowadź zmienną zawierającą obiekt PSSession.</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+Słowo kluczowe .ExternalHelp jest wymagane, gdy funkcja lub skrypt są udokumentowane w plikach XML.</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>Określa ścieżkę do zestawu platformy .NET do załadowania.
 
-using assembly &lt;.NET-assembly-path&gt;</value>
+używając zestawu &lt;.NET-assembly-path&gt;</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>Określa moduł programu PowerShell, z którego mają być ładowane klasy.
 
-using module &lt;ModuleName or Path&gt;
+używając modułu &lt;ModuleName lub Path&gt;
 
-using module &lt;ModuleSpecification hashtable&gt;</value>
+używając modułu &lt;ModuleSpecification hashtable&gt;</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>Określa przestrzeń nazw platformy .NET, z której mają być rozpoznawane typy, albo alias przestrzeni nazw.
 
-using namespace &lt;.NET-namespace&gt;
+używając przestrzeni nazw &lt;.NET-namespace&gt;
 
-using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
+używając przestrzeni nazw &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>Określa alias typu platformy .NET.
 
-using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
+używając typu &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>Zwykły ciąg znaków.</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>Ciąg znaków zawierający nierozwinięte odwołania do zmiennych środowiskowych, które są rozwijane podczas pobierania wartości.</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>Dane binarne w dowolnej formie.</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>32-bitowa liczba binarna.</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>Tablica ciągów.</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>64-bitowa liczba binarna.</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>Nieobsługiwany typ danych rejestru.</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
-    <value>',' - Comma</value>
+    <value>„-” — przecinek</value>
   </data>
   <data name="SeparatorCommaSpaceToolTip" xml:space="preserve">
-    <value>', ' - Comma-Space</value>
+    <value>„, ” - przecinek i spacja</value>
   </data>
   <data name="SeparatorSemiColonToolTip" xml:space="preserve">
-    <value>';' - Semi-Colon</value>
+    <value>„-” — średnik</value>
   </data>
   <data name="SeparatorSemiColonSpaceToolTip" xml:space="preserve">
-    <value>'; ' - Semi-Colon-Space</value>
+    <value>„-” — średnik i spacja</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
-    <value>{0} - Newline</value>
+    <value>{0} — nowy wiersz</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
-    <value>'-' - Dash</value>
+    <value>„-” — kreska</value>
   </data>
   <data name="SeparatorSpaceToolTip" xml:space="preserve">
-    <value>' ' - Space</value>
+    <value>„-” — spacja</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/Authenticode.ru.resx
+++ b/src/System.Management.Automation/resources/ru/Authenticode.ru.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>Невозможно загрузить файл {0}, так как вы решили не запускать это программное обеспечение сейчас.</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>Невозможно загрузить файл {0}, так как вы решили никогда не запускать программное обеспечение от этого издателя.</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>Файл {0} опубликован {1}. Этот издатель явно не является доверенным в вашей системе. Скрипт не будет запущен в системе. Для получения дополнительных сведений выполните команду "get-help about_signing".</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>Невозможно загрузить файл {0}, так как выполнение скриптов отключено в этой системе. Дополнительные сведения см. в статье about_Execution_Policies на странице https://go.microsoft.com/fwlink/?LinkID=135170.</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>Невозможно загрузить файл {0}. {1}.</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>Невозможно загрузить файл {0}, так как его выполнение заблокировано политиками ограниченного использования программ, например созданными с помощью групповой политики.</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>Невозможно загрузить файл {0}, так как не удалось прочитать его содержимое.</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>Не удается подписать код. Указанный сертификат не подходит для подписания кода.</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>Не удается подписать код. URL-адрес сервера TimeStamp должен быть указан полностью в формате http://&lt;server url&gt; или https://&lt;server url&gt;.</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>Не удается подписать код. Хэш-алгоритм не поддерживается.</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>Вы действительно хотите запускать программы от этого недоверенного издателя?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>Файл {0} опубликован {1} и не является доверенным в вашей системе. Запускайте скрипты только от доверенных издателей.</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>Программное обеспечение {0} опубликовано неизвестным издателем. Не рекомендуется запускать это программное обеспечение.</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>Предупреждение системы безопасности</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>Запускайте только скрипты, которым вы доверяете. Хотя скрипты из Интернета могут быть полезны, этот скрипт может нанести вред вашему компьютеру. Если вы доверяете этому скрипту, используйте командлет Unblock-File, чтобы разрешить его выполнение без этого предупреждающего сообщения. Вы хотите запустить {0}?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>Н&amp;икогда не запускать</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>Не запускать скрипт от этого издателя сейчас и не предлагать запускать этот скрипт в будущем. Дальнейшие попытки запустить этот скрипт будут завершаться без сообщения об ошибке.</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>&amp;Не выполнять</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Не запускать скрипт от этого издателя сейчас и предлагать запускать этот скрипт в будущем.</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>В&amp;ыполнить однократно</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Запустить скрипт от этого издателя сейчас и предлагать запускать этот скрипт в будущем.</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>&amp;Всегда выполнять</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>Запустить скрипт от этого издателя сейчас и не предлагать запускать этот скрипт в будущем.</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Приостановить</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>Приостановить текущий конвейер и вернуться в командную строку. По завершении введите exit, чтобы возобновить работу.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/CoreClrStubResources.ru.resx
+++ b/src/System.Management.Automation/resources/ru/CoreClrStubResources.ru.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentIllegalEnvVarName" xml:space="preserve">
-    <value>Environment variable name cannot contain equal character.</value>
+    <value>Имя переменной среды не может содержать знак равенства.</value>
   </data>
   <data name="ArgumentLongEnvVarValue" xml:space="preserve">
-    <value>Environment variable name or value is too long.</value>
+    <value>Слишком длинное имя или значение переменной среды.</value>
   </data>
   <data name="ArgumentStringFirstCharIsZero" xml:space="preserve">
-    <value>The first char in the string is the null character.</value>
+    <value>Первый символ в строке — символ null.</value>
   </data>
   <data name="ArgumentStringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
+    <value>Строка не может быть нулевой длины.</value>
   </data>
   <data name="CannotGetComputerName" xml:space="preserve">
-    <value>Computer name could not be obtained.</value>
+    <value>Не удалось получить имя компьютера.</value>
   </data>
   <data name="CannotGetDomainName" xml:space="preserve">
-    <value>Current user's domain name could not be obtained.</value>
+    <value>Не удалось получить доменное имя текущего пользователя.</value>
   </data>
   <data name="UnknownErrorNumber" xml:space="preserve">
-    <value>Unknown error "{0}".</value>
+    <value>Неизвестная ошибка: "{0}".</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/DebuggerStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/DebuggerStrings.ru.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>Точка останова по переменной в "${0}" (доступ {1})</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>Точка останова по переменной в "{0}:${1}" (доступ {2})</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>Точка останова по строке на "{0}:{1}"</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>Точка останова по строке на "{0}:{1}, {2}"</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>Точка останова по команде в "{0}"</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>Точка останова по команде в "{0}:{1}"</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>Точка останова {0} не будет достигнута</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Выполнить один шаг (с заходом в функции, скрипты и т. д.)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Перейти к следующему оператору (шаг с обходом функций, скриптов и т. д.)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Выйти из текущей функции, скрипта и т. д.</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} Продолжить выполнение</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} Остановить выполнение и выйти из отладчика</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Get-PSCallStack Отобразить стек вызовов</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Перечислить исходный код текущего скрипта.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Используйте "list", чтобы начать с текущей строки, "list &lt;m&gt;"  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     чтобы начать со строки &lt;m&gt;, и "list &lt;m&gt; &lt;n&gt;", чтобы вывести &lt;n&gt; </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     строки, начиная со строки &lt;m&gt;</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Повторить последнюю команду, если она была {0}, {1} или {2}</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} выводит это справочное сообщение.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Для получения инструкций по настройке запроса отладчика введите "help about_prompt".</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+Текущий сеанс не поддерживает отладку; операция будет продолжена.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: строка {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>Исходный код недоступен.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>Начальная строка должна быть положительным целым числом не больше {0}</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>Число строк должно быть положительным целым числом.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
-    <value>&lt;No file&gt;</value>
+    <value>&lt;Без файла&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>в {0}, {1}: строка {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>Отладчик не может обрабатывать команды, если не находится в состоянии Stopped.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>SetDebugAction не реализовано для отладчика локальных скриптов.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>Отладчик не может задать действие продолжения, так как отладчик в удаленном сеансе не находится в состоянии Stopped.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>Задание невозможно отладить, так как отладчик сейчас занят.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Указанное задание и все дочерние задания были проверены, но задания, которые можно отладить, не найдены.  Чтобы отладить задание или дочернее задание, оно должно поддерживать отладку и находиться в состоянии выполнения.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>Отладчик нельзя включить для пошагового режима, так как он отключен, а для режима отладки задано значение None.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>Невозможно отладить пространство выполнения, так как узловой отладчик сейчас занят.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>Невозможно отладить пространство выполнения. Отладчик пространства выполнения сейчас отключен (DebugMode имеет значение "None").</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>Невозможно выполнить отладку пространства выполнения, которое не находится в открытом состоянии. Данное состояние пространства выполнения: {0}.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>Невозможно отладить пространство выполнения. У пространства выполнения {0} нет связанного отладчика.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>Отладчик уже переопределен.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>Невозможно поместить объект отладчика сам в себя.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>Команда {0} не поддерживается для удаленного использования в версии PowerShell, запущенной в удаленном пространстве выполнения.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>Процесс</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} Продолжить выполнение и отключить отладчик.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>Команда отключения отладчика неприменима.  Команда отключения применяется только при отладке заданий и пространств выполнения с помощью командлетов Debug-Job или Debug-Runspace.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>Недопустимый идентификатор пространства выполнения: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>Не удалось получить пространство выполнения.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Необходимо указать точку останова или список точек останова.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>BreakpointList содержит элемент, который не является точкой останова.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/ErrorCategoryStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/ErrorCategoryStrings.ru.resx
@@ -121,7 +121,7 @@
     <value>CloseError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeadlockDetected" xml:space="preserve">
-    <value>Deadlock detected: ({1}:{2}) [{0}], {3}</value>
+    <value>Обнаружена взаимоблокировка: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="DeviceError" xml:space="preserve">
     <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
@@ -196,7 +196,7 @@
     <value>ProtocolError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="ConnectionError" xml:space="preserve">
-    <value>ConnectionError: ({1}:{2}) [{0}], {3}</value>
+    <value>Ошибка подключения: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="AuthenticationError" xml:space="preserve">
     <value>AuthenticationError: ({1}:{2}) [{0}], {3}</value>
@@ -214,6 +214,6 @@
     <value>NotSpecified: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidErrorCategory" xml:space="preserve">
-    <value>Unrecognized error category {4}: ({1}:{2}) [{0}], {3}</value>
+    <value>Нераспознанная категория ошибки {4}: ({1}:{2}) [{0}], {3}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/ErrorPackage.ru.resx
+++ b/src/System.Management.Automation/resources/ru/ErrorPackage.ru.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Ellipsize" xml:space="preserve">
-    <value>{0}…{1}</value>
+    <value>{0}: {1}</value>
   </data>
   <data name="ErrorDetailsEmptyTemplate" xml:space="preserve">
-    <value>Error text is empty for error "{0}" : "{1}"</value>
+    <value>Пустой текст ошибки для ошибки "{0}": "{1}"</value>
   </data>
   <data name="RedirectedException" xml:space="preserve">
-    <value>Object "{0}" is reported as an error.</value>
+    <value>Объект "{0}" отмечен как ошибка.</value>
   </data>
   <data name="UnsupportedPreferenceError" xml:space="preserve">
-    <value>The value {0} is not supported for an ActionPreference variable. The provided value should be used only as a value for a preference parameter, and has been replaced by the default value. For more information, see the Help topic, "about_Preference_Variables."</value>
+    <value>Значение {0} не поддерживается для переменной ActionPreference. Указанное значение следует использовать только как значение параметра настройки, и его заменено значением по умолчанию. Дополнительные сведения см. в разделе справки, "about_Preference_Variables".</value>
   </data>
   <data name="ActionPreferenceReservedForFutureUseError" xml:space="preserve">
-    <value>The {0} ActionPreference value is reserved for future use and is not supported at this time. For more information about preference variables, see the Help topic, "about_Preference_Variables."</value>
+    <value>Значение {0} ActionPreference зарезервировано для использования в будущем и в настоящее время не поддерживается. Подробнее о привилегированных переменных см. в разделе справки "about_Preference_Variables".</value>
   </data>
   <data name="ReservedActionPreferenceReplacedError" xml:space="preserve">
-    <value>The {0} ActionPreference value is reserved for future use and is not supported at this time. It has been replaced in your {1} variable by the default value of {2}. For more information about preference variables, see the Help topic, "about_Preference_Variables."</value>
+    <value>Значение {0} ActionPreference зарезервировано для использования в будущем и в настоящее время не поддерживается. В переменной {1} оно было заменено значением по умолчанию {2}. Подробнее о привилегированных переменных см. в разделе справки "about_Preference_Variables".</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/EtwLoggingStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/EtwLoggingStrings.ru.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>Команда {0} {1}.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>Состояние подсистемы изменено с {0} на {1}.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>Полный идентификатор ошибки = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>Сообщение об ошибке = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>Рекомендуемое действие = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>Политика выполнения</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>Команда задания = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>Идентификатор задания = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>Идентификатор экземпляра задания = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>Расположение задания = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>Имя задания = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>Состояние задания = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        Имя команды = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        Путь команды = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        Тип команды = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        Версия подсистемы = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        ИД узла = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        Имя узла = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        Ведущее приложение = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        Версия узла = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        ИД конвейера = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        ИД пространства выполнения = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        Имя скрипта = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        Порядковый номер = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        Уровень серьезности = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        Идентификатор оболочки = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        Время = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        Пользователь = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        Подключенный пользователь = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>Задание NULL</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>Имя поставщика</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>Поставщик {0} изменил состояние на {1}.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>Выполнение скрипта: {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>Переменная {0} изменилась с {1} на {2}.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>Переменная {0} изменена на {1}.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/ExperimentalFeatureStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/ExperimentalFeatureStrings.ru.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>Не было обнаружено ни одной экспериментальной характеристики, соответствующей названию "{0}".</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>Включение и отключение экспериментальных функций вступают в силу только при следующем запуске PowerShell.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/ExtendedTypeSystem.ru.resx
+++ b/src/System.Management.Automation/resources/ru/ExtendedTypeSystem.ru.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>Элемент "{0}" уже присутствует.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>Элемент "{0}" уже присутствует в файле данных расширенного типа.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>Элемент "{0}" отсутствует.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>Исключение при настройке "{0}": "{1}"</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>Исключение при получении "{0}": "{1}"</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>При попытке перечисления коллекции возникло следующее исключение: "{0}".</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>Нельзя получить доступ к элементу "{0}" вне PSObject.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>Невозможно изменить элемент, созданный из конфигурации типа: "{0}".</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>Имя элемента "{0}" зарезервировано.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>"{0}" невозможно изменить.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>Исключение при вызове "{0}" с аргументами "{1}": "{2}"</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>Возникло исключение при попытке вызвать "{0}" для извлечения содержимого объекта типа "{1}": "{2}"</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>Не удается найти перегрузку для "{0}" с количеством аргументов: "{1}".</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>Не удалось найти подходящую перегрузку универсального метода для "{0}" с параметрами типа "{1}" и количеством аргументов: "{2}".</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>Обнаружено несколько неоднозначных перегрузок для "{0}" с количеством аргументов: "{1}".</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>Не удается преобразовать аргумент "{0}" со значением "{1}" для "{2}" в тип "{3}": "{4}"</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>Метод доступа get для свойства "{0}" недоступен.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>Метод доступа set для свойства "{0}" недоступен.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>Метод задания должен быть общедоступным, недействительным, статическим и содержать два параметра. Первый параметр должен относиться к типу PSObject. Второй параметр обязателен, если также доступен метод получения, и он должен относиться к тому же типу, что и возвращаемое значение метода получения.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>Метод получения должен быть общедоступным, не аннулированным, статическим и содержать один параметр типа PSObject.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>У свойства CodeProperty должен быть метод получения или метод задания.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>Не удается создать метод кода из-за формата метода. Метод должен быть общедоступным, статическим и содержать один параметр типа PSObject.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>Псевдоним с именем "{0}" содержит цикл.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>Невозможно преобразовать значение "{0}" типа "{1}" в тип "{2}".</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>Невозможно преобразовать значение типа "{0}" в тип "{1}".</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>Невозможно преобразовать значение "{0}" в тип "{1}". Ошибка. "{2}"</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>Не удается преобразовать значение "{0}" в тип "{1}", так как в этом перечислении не допускаются запятые.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>Не удается преобразовать значение "{0}" в тип "{1}", так как значения перечисления недопустимы. Укажите одно из следующих значений перечисления и повторите попытку. Возможные значения перечисления: "{2}".</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>Не удается преобразовать значение null в тип "{0}", так как значения перечисления недопустимы. Укажите одно из следующих значений перечисления и повторите попытку. Возможные значения перечисления: "{1}".</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>Не удается преобразовать значение null в тип "{0}".</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>Невозможно преобразовать значение в тип "{0}".  Ошибка. "{1}"</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>Не удалось преобразовать значение в тип System.String.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>Ожидается ссылочный тип в аргументе.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>Не удается сравнить "{0}", так как он не реализует IComparable.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>Не удалось сравнить "{0}" с "{1}". Ошибка. "{2}"</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>Не удается сравнить "{0}" с "{1}", так как объекты относятся к разным типам или объект "{0}" не реализует "{2}".</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>Не удается преобразовать значение "{0}" в тип "{1}", так как найдено как минимум два совпадения ({2}, {3}), а для этого перечисления допускается только одно совпадение.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>Невозможно преобразовать значение "{0}" в тип "{1}". Логические параметры принимают только логические значения и числа, например $True, $False, 1 или 0.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>Не удается получить значение свойства, так как свойство "{0}" доступно только для записи.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>Свойство "{0}" доступно только для чтения.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>Не удается задать "{0}", так как в качестве значений свойств XmlNode можно использовать только строки.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>Невозможно задать "{0}", так как задавать можно только уникальные атрибуты или уникальные конечные узлы без атрибутов.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>Нельзя добавить в эту коллекцию объект PSProperty или PSMethod.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>При загрузке файла данных расширенного типа произошла следующая ошибка: {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>При получении строки возникло следующее исключение: "{0}"</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>Поле или свойство "{0}" для типа "{1}" отличается от поля или свойства "{2}" только регистром. Тип должен соответствовать спецификации CLS.</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>При получении иерархии имен типов возникло следующее исключение: "{0}".</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>При получении элемента "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>При получении элементов возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>При получении состояния доступности для чтения свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>При получении состояния доступности для записи свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>При получении типа свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>При получении строкового представления свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>При получении атрибутов свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>При получении определений метода "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>При получении строкового представления метода "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>При получении типа для параметризованного свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>При получении состояния доступности для чтения параметризованного свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>При получении состояния доступности для записи параметризованного свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>При получении определений параметризованного свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>При получении строкового представления для параметризованного свойства "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>Невозможно задать свойство Value для объекта PSMemberInfo типа "{0}".</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>Аргумент "{0}" должен быть {1}. Используйте {2}.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>Аргумент "{0}" не должен быть {1}. Не используйте {2}.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>Свойство "{0}" не найдено.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>Не удается получить или задать значение свойства. Аргумент "{0}" должен относиться к типу "{1}" или "{2}".</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>Не удается задать значение для свойства "{0}", так как объект относится к типу "{1}", а не "{2}".</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>Исключение при вызове "{0}": "{1}"</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0} не является допустимым путем к классу.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>"{0}" не является допустимым путем.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>Адаптер не может определить, можно ли изменить свойство "{0}".</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>Адаптер не может определить, доступно ли свойство "{0}" для чтения.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>Адаптер не может получить значение свойства "{0}".</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>Адаптер не может задать значение свойства "{0}".</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>Адаптер не может получить тип свойства "{0}".</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>Адаптер не может получить иерархию типов "{0}".</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>Адаптер не может получить свойства "{0}".</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>Адаптер не может получить свойство "{0}" для "{1}".</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>"{0}" возвратил значение null.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>Свойство "{0}" не найдено в объекте "{1}". Можно задать следующие свойства: {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>Свойство "{0}" не найдено в объекте "{1}". Доступное для задания свойство отсутствует.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>Не удается создать объект типа "{0}". {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>Нельзя вызывать статические методы или получать доступ к статическим свойствам общедоступного универсального типа {0}.  Укажите параметры типа и повторите попытку.  Например, вместо [System.Collections.Generic.HashSet``1]::CreateSetComparer() используйте [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>При создании атрибута "{1}" возникло следующее исключение: "{0}"</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>Значение "{0}" нельзя преобразовать в массив строк.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>Невозможно преобразовать значение в тип "{0}". В этом языковом режиме поддерживаются только основные типы.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Не удается преобразовать в тип "{0}", подобный ByRef. Типы, подобные ByRef, не поддерживаются в PowerShell.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Не удается получить или задать свойство или поле "{0}" типа "{1}", подобного ByRef. Типы, подобные ByRef, не поддерживаются в PowerShell.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Не удается вызвать метод "{0}" с типом возвращаемого значения "{1}", который подобен ByRef. Типы, подобные ByRef, не поддерживаются в PowerShell.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>Не удается создать экземпляр типа "{0}", подобного ByRef. Типы, подобные ByRef, не поддерживаются в PowerShell.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Преобразование хэш-таблицы расширенного типа</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>В режиме ConstrainedLanguage преобразование типа из HashTable в "{0}" не допускается.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Преобразование хэш-таблицы расширенного типа</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>В режиме ConstrainedLanguage преобразование типа из "{0}" в "{1}" не допускается.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/FileSystemProviderStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/FileSystemProviderStrings.ru.resx
@@ -118,240 +118,240 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvokeItemAction" xml:space="preserve">
-    <value>Invoke Item</value>
+    <value>Вызвать элемент</value>
   </data>
   <data name="InvokeItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Элемент: {0}</value>
   </data>
   <data name="RemoveItemActionFile" xml:space="preserve">
-    <value>Remove File</value>
+    <value>Удалить файл</value>
   </data>
   <data name="RemoveItemActionDirectory" xml:space="preserve">
-    <value>Remove Directory</value>
+    <value>Удалить каталог</value>
   </data>
   <data name="CopyItemActionFile" xml:space="preserve">
-    <value>Copy File</value>
+    <value>Копировать файл</value>
   </data>
   <data name="CopyItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Элемент: {0} Назначение: {1}</value>
   </data>
   <data name="CopyItemActionDirectory" xml:space="preserve">
-    <value>Copy Directory</value>
+    <value>Копировать каталог</value>
   </data>
   <data name="RenameItemActionFile" xml:space="preserve">
-    <value>Rename File</value>
+    <value>Переименовать файл</value>
   </data>
   <data name="RenameItemActionDirectory" xml:space="preserve">
-    <value>Rename Directory</value>
+    <value>Переименовать каталог</value>
   </data>
   <data name="RenameItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Элемент: {0} Назначение: {1}</value>
   </data>
   <data name="MoveItemActionFile" xml:space="preserve">
-    <value>Move File</value>
+    <value>Переместить файл</value>
   </data>
   <data name="MoveItemActionDirectory" xml:space="preserve">
-    <value>Move Directory</value>
+    <value>Переместить каталог</value>
   </data>
   <data name="MoveItemResourceFileTemplate" xml:space="preserve">
-    <value>Item: {0} Destination: {1}</value>
+    <value>Элемент: {0} Назначение: {1}</value>
   </data>
   <data name="SetPropertyActionFile" xml:space="preserve">
-    <value>Set Property File</value>
+    <value>Задать файл свойств</value>
   </data>
   <data name="SetPropertyActionDirectory" xml:space="preserve">
-    <value>Set Property Directory</value>
+    <value>Задать каталог свойств</value>
   </data>
   <data name="SetPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1} Value: {2}</value>
+    <value>Элемент: {0} Свойство: {1} Значение: {2}</value>
   </data>
   <data name="ClearPropertyActionFile" xml:space="preserve">
-    <value>Clear Property File</value>
+    <value>Очистить файл свойств</value>
   </data>
   <data name="ClearPropertyActionDirectory" xml:space="preserve">
-    <value>Clear Property Directory</value>
+    <value>Очистить каталог свойств</value>
   </data>
   <data name="ClearPropertyResourceTemplate" xml:space="preserve">
-    <value>Item: {0} Property: {1}</value>
+    <value>Элемент: {0} Свойство: {1}</value>
   </data>
   <data name="NewItemActionFile" xml:space="preserve">
-    <value>Create File</value>
+    <value>Создать файл</value>
   </data>
   <data name="NewItemActionDirectory" xml:space="preserve">
-    <value>Create Directory</value>
+    <value>Создать каталог</value>
   </data>
   <data name="NewItemActionTemplate" xml:space="preserve">
-    <value>Destination: {0}</value>
+    <value>Назначение: {0}</value>
   </data>
   <data name="ClearContentActionFile" xml:space="preserve">
-    <value>Clear Content</value>
+    <value>Очистить содержимое</value>
   </data>
   <data name="ClearContentesourceTemplate" xml:space="preserve">
-    <value>Item: {0}</value>
+    <value>Элемент: {0}</value>
   </data>
   <data name="ItemNotFound" xml:space="preserve">
-    <value>Could not find item {0}.</value>
+    <value>Не удалось найти элемент {0}.</value>
   </data>
   <data name="CannotRemoveItem" xml:space="preserve">
-    <value>Cannot remove item {0}: {1}</value>
+    <value>Не удается удалить элемент {0}: {1}</value>
   </data>
   <data name="CannotRestoreAttributes" xml:space="preserve">
-    <value>Cannot restore attributes on item {0}: {1}</value>
+    <value>Не удается восстановить атрибуты элемента {0}: {1}</value>
   </data>
   <data name="ItemDoesNotExist" xml:space="preserve">
-    <value>An object at the specified path {0} does not exist.</value>
+    <value>Объект по указанному пути {0} не существует.</value>
   </data>
   <data name="DirectoryNotEmpty" xml:space="preserve">
-    <value>Directory {0} cannot be removed because it is not empty.</value>
+    <value>Невозможно удалить {0}, так как этот объект не пуст.</value>
   </data>
   <data name="UnknownType" xml:space="preserve">
-    <value>The type is not a known type for the file system. Only "file","directory" or "symboliclink" can be specified.</value>
+    <value>Тип не является известным типом файловой системы. Можно указать только "file", "directory" или "symboliclink".</value>
   </data>
   <data name="PathOutSideBasePath" xml:space="preserve">
-    <value>Cannot process the path because the specified path refers to an item that is outside the basePath.</value>
+    <value>Невозможно обработать путь, так как указанный путь ссылается на элемент за пределами basePath.</value>
   </data>
   <data name="DriveRootError" xml:space="preserve">
-    <value>The specified drive root "{0}" either does not exist, or it is not a folder.</value>
+    <value>Указанный корень диска "{0}" не существует или не является папкой.</value>
   </data>
   <data name="DirectoryExist" xml:space="preserve">
-    <value>An item with the specified name {0} already exists.</value>
+    <value>Файл с указанным именем {0} уже существует.</value>
   </data>
   <data name="DelimiterError" xml:space="preserve">
-    <value>A delimiter cannot be specified when reading the stream one byte at a time.</value>
+    <value>Невозможно указать разделитель при чтении потока по одному байту за раз.</value>
   </data>
   <data name="CopyError" xml:space="preserve">
-    <value>Cannot overwrite the item {0} with itself.</value>
+    <value>Невозможно перезаписать элемент {0} самим собой.</value>
   </data>
   <data name="RenameError" xml:space="preserve">
-    <value>Cannot rename the specified target, because it represents a path or device name.</value>
+    <value>Невозможно переименовать указанный целевой объект, поскольку он представляет путь или имя устройства.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property {0} does not exist or was not found.</value>
+    <value>Свойство {0} не существует или не найдено.</value>
   </data>
   <data name="PermissionError" xml:space="preserve">
-    <value>You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.</value>
+    <value>У вас недостаточно прав доступа для выполнения этой операции, либо элемент является скрытым, системным или доступным только для чтения.</value>
   </data>
   <data name="AttributesNotSupported" xml:space="preserve">
-    <value>The attribute cannot be set because attributes are not supported. Only the following attributes can be set: Archive, Hidden, Normal, ReadOnly, or System.</value>
+    <value>Невозможно задать атрибут, так как атрибуты не поддерживаются. Можно задать только следующие атрибуты:: Archive, Hidden, Normal, ReadOnly или System.</value>
   </data>
   <data name="CannotClearProperty" xml:space="preserve">
-    <value>The property cannot be cleared because the property is not supported. Only the Attributes property can be cleared.</value>
+    <value>Свойство не может быть очищено, так как оно не поддерживается. Можно очистить только свойство Attributes.</value>
   </data>
   <data name="TargetCannotContainDeviceName" xml:space="preserve">
-    <value>Cannot process path '{0}' because the target represents a reserved device name.</value>
+    <value>Невозможно обработать путь "{0}", так как целевой объект представляет зарезервированное имя устройства.</value>
   </data>
   <data name="EncodingNotUsed" xml:space="preserve">
-    <value>Encoding not used when '-AsByteStream' specified.</value>
+    <value>Кодирование не используется, если указан параметр "-AsByteStream".</value>
   </data>
   <data name="ByteEncodingError" xml:space="preserve">
-    <value>Cannot proceed with byte encoding. When using byte encoding the content must be of type byte.</value>
+    <value>Невозможно продолжить байтовое кодирование. При использовании байтового кодирования содержимое должно иметь тип byte.</value>
   </data>
   <data name="FileNotFound" xml:space="preserve">
-    <value>Cannot process the file because the file {0} was not found.</value>
+    <value>Невозможно обработать файл, так как файл {0} не найден.</value>
   </data>
   <data name="DirectoryDisplayGrouping" xml:space="preserve">
-    <value>    Directory: </value>
+    <value>    Каталог: </value>
   </data>
   <data name="ReadBackward_Encoding_NotSupport" xml:space="preserve">
-    <value>Cannot detect the encoding of the file. The specified encoding {0} is not supported when the content is read in reverse.</value>
+    <value>Не удается определить кодировку файла. Указанная кодировка {0} не поддерживается при чтении содержимого в обратном направлении.</value>
   </data>
   <data name="AlternateDataStreamNotFound" xml:space="preserve">
-    <value>Could not open the alternate data stream '{0}' of the file '{1}'.</value>
+    <value>Не удалось открыть альтернативный поток данных "{0}" файла "{1}".</value>
   </data>
   <data name="StreamAction" xml:space="preserve">
-    <value>Stream '{0}' of file '{1}'.</value>
+    <value>Поток "{0}" файла "{1}".</value>
   </data>
   <data name="RawAndWaitCannotCoexist" xml:space="preserve">
-    <value>The Raw and Wait parameters cannot be specified in the same command.</value>
+    <value>Параметры Raw и Wait не могут быть указаны в одной команде.</value>
   </data>
   <data name="InvalidDriveName" xml:space="preserve">
-    <value>To use the Persist switch parameter, the drive name must be supported by the operating system (for example, drive letters A-Z).</value>
+    <value>Для использования параметра Persist имя диска должно поддерживаться операционной системой (например, буквы дисков A–Z).</value>
   </data>
   <data name="PersistNotSupported" xml:space="preserve">
-    <value>When you use the Persist parameter, the root must be a file system location on a remote computer.</value>
+    <value>При использовании параметра Persist корень должен быть расположением в файловой системе на удаленном компьютере.</value>
   </data>
   <data name="NoFirstLastWaitForRaw" xml:space="preserve">
-    <value>The '{0}' and '{1}' parameters cannot be specified in the same command.</value>
+    <value>Параметры "{0}" и "{1}" нельзя указывать в одной команде.</value>
   </data>
   <data name="ItemNotDirectory" xml:space="preserve">
-    <value>A directory is required for the operation. The item '{0}' is not a directory.</value>
+    <value>Для операции требуется каталог. Элемент "{0}" не является каталогом.</value>
   </data>
   <data name="NewItemActionJunction" xml:space="preserve">
-    <value>Create Junction</value>
+    <value>Создать соединение</value>
   </data>
   <data name="NewItemActionSymbolicLink" xml:space="preserve">
-    <value>Create Symbolic Link</value>
+    <value>Создать символьную ссылку</value>
   </data>
   <data name="ElevationRequired" xml:space="preserve">
-    <value>Administrator privilege required for this operation.</value>
+    <value>Для этой операции требуются права администратора.</value>
   </data>
   <data name="NewItemActionHardLink" xml:space="preserve">
-    <value>Create Hard Link</value>
+    <value>Создать жесткую связь</value>
   </data>
   <data name="ItemNotFile" xml:space="preserve">
-    <value>A file is required for the operation. The item '{0}' is not a file.</value>
+    <value>Для операции требуется файл. Элемент "{0}" не является файлом.</value>
   </data>
   <data name="HardLinkNotSupported" xml:space="preserve">
-    <value>Hard links are not supported for the specified path.</value>
+    <value>Жесткие связи для указанного пути не поддерживаются.</value>
   </data>
   <data name="SymbolicLinkNotSupported" xml:space="preserve">
-    <value>Symbolic links are not supported for the specified path.</value>
+    <value>Символьные ссылки для указанного пути не поддерживаются.</value>
   </data>
   <data name="CopyItemRemotelyProgressActivity" xml:space="preserve">
     <value>Копирование {0} в {1}</value>
   </data>
   <data name="CopyItemRemoteDestinationIsFile" xml:space="preserve">
-    <value>Destination path {0} is a file that already exists on the target destination.</value>
+    <value>Путь назначения {0} — это файл, который уже существует в конечном расположении.</value>
   </data>
   <data name="CopyItemRemotelyFailed" xml:space="preserve">
-    <value>Failed to copy file {0} to remote target destination.</value>
+    <value>Не удалось скопировать файл {0} в удаленное целевое расположение.</value>
   </data>
   <data name="CopyItemRemotelyStatusDescription" xml:space="preserve">
     <value>Из {0} в {1}</value>
   </data>
   <data name="CopyItemRemotelyDestinationIsFile" xml:space="preserve">
-    <value>Cannot copy a directory '{0}' to file '{0}'</value>
+    <value>Не удается скопировать каталог "{0}" в файл "{0}"</value>
   </data>
   <data name="CopyItemRemotelyFailedToGetDirectoryChildItems" xml:space="preserve">
-    <value>Failed to get directory {0} child items.</value>
+    <value>Не удалось получить дочерние элементы каталога {0}.</value>
   </data>
   <data name="CopyItemRemotelyFailedToReadFile" xml:space="preserve">
-    <value>Failed to read remote file '{0}'.</value>
+    <value>Не удалось прочитать удаленный файл "{0}".</value>
   </data>
   <data name="CopyItemRemotelyFailedToValidateIfDestinationIsFile" xml:space="preserve">
-    <value>Cannot validate if remote destination {0} is a file.</value>
+    <value>Не удается проверить, является ли файлом удаленное назначение {0}.</value>
   </data>
   <data name="CopyItemRemotelyFailedToCreateDirectory" xml:space="preserve">
-    <value>Failed to create directory '{0}' on remote destination.</value>
+    <value>Не удалось создать каталог "{0}" в удаленном расположении.</value>
   </data>
   <data name="DriveMaxSizeError" xml:space="preserve">
-    <value>Maximum size for drive has been exceeded: {0}.</value>
+    <value>Превышен максимальный размер диска: {0}.</value>
   </data>
   <data name="SymlinkItemExists" xml:space="preserve">
-    <value>Cannot create link because the path already exists: {0}.</value>
+    <value>Не удается создать ссылку, так как путь уже существует: {0}.</value>
   </data>
   <data name="AlreadyListedDirectory" xml:space="preserve">
-    <value>Skip already-visited directory {0}.</value>
+    <value>Пропустить уже посещенный каталог {0}.</value>
   </data>
   <data name="TargetCannotBeSubdirectoryOfSource" xml:space="preserve">
-    <value>Destination path cannot be a subdirectory of the source or the source itself: {0}.</value>
+    <value>Путь назначения не может быть подкаталогом источника или самим источником: {0}.</value>
   </data>
   <data name="NewItemTargetIsSameAsLink" xml:space="preserve">
-    <value>The target and path cannot be the same.</value>
+    <value>Конечный объект и путь не могут совпадать.</value>
   </data>
   <data name="CopyingLocalFileActivity" xml:space="preserve">
-    <value>Copied {0} of {1} files</value>
+    <value>Скопировано {0} из {1} файлов</value>
   </data>
   <data name="CopyingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} из {1} ({2:0.0} МБ/с)</value>
   </data>
   <data name="RemovingLocalFileActivity" xml:space="preserve">
-    <value>Removed {0} of {1} files</value>
+    <value>Удалено {0} из {1} файлов</value>
   </data>
   <data name="RemovingLocalBytesStatus" xml:space="preserve">
-    <value>{0} of {1} ({2:0.0} MB/s)</value>
+    <value>{0} из {1} ({2:0.0} МБ/с)</value>
   </data>
   <data name="JunctionAbsolutePath" xml:space="preserve">
-    <value>Creating a junction requires an absolute path for the target.</value>
+    <value>Для создания соединения требуется абсолютный путь к целевому объекту.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/GetErrorText.ru.resx
+++ b/src/System.Management.Automation/resources/ru/GetErrorText.ru.resx
@@ -118,30 +118,30 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ResourceBaseNameFailure" xml:space="preserve">
-    <value>Cannot load a resource with base name "{0}".</value>
+    <value>Не удается загрузить ресурс с базовым именем "{0}".</value>
   </data>
   <data name="ResourceIdFailure" xml:space="preserve">
-    <value>Cannot load a resource string with ID "{0}".</value>
+    <value>Не удается загрузить строку ресурса с идентификатором "{0}".</value>
   </data>
   <data name="ActionPreferenceStop" xml:space="preserve">
-    <value>Running commands is prevented by Stop policy settings.</value>
+    <value>Параметры политики Stop запрещают выполнение команд.</value>
   </data>
   <data name="AssemblyNotRegistered" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}" because an assembly was not registered.</value>
+    <value>Невозможно получить сообщение "{0}" "{1}" "{2}", так как сборка не зарегистрирована.</value>
   </data>
   <data name="BadTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string format is not valid in template string "{3}".</value>
+    <value>Не удается получить сообщение "{0}" "{1}" "{2}". Формат строки шаблона недопустим в строке шаблона "{3}".</value>
   </data>
   <data name="BlankTemplate" xml:space="preserve">
-    <value>Cannot retrieve the message "{0}" "{1}" "{2}". A template string exists, but its value is empty or blank.</value>
+    <value>Не удается получить сообщение "{0}" "{1}" "{2}". Строка шаблона существует, но ее значение пусто или состоит только из пробелов.</value>
   </data>
   <data name="PipelineStoppedException" xml:space="preserve">
-    <value>The pipeline has been stopped.</value>
+    <value>Конвейер остановлен.</value>
   </data>
   <data name="ScriptCallDepthException" xml:space="preserve">
-    <value>The script failed due to call depth overflow.</value>
+    <value>Сбой скрипта из-за переполнения глубины вызовов.</value>
   </data>
   <data name="PipelineDepthException" xml:space="preserve">
-    <value>The pipeline failed due to call depth overflow.</value>
+    <value>Сбой конвейера из-за переполнения глубины вызовов.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/HelpDisplayStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/HelpDisplayStrings.ru.resx
@@ -121,172 +121,172 @@
     <value>Имя</value>
   </data>
   <data name="Synopsis" xml:space="preserve">
-    <value>SYNOPSIS</value>
+    <value>Краткий обзор</value>
   </data>
   <data name="DetailedDescription" xml:space="preserve">
-    <value>DESCRIPTION</value>
+    <value>ОПИСАНИЕ</value>
   </data>
   <data name="Syntax" xml:space="preserve">
-    <value>SYNTAX</value>
+    <value>СИНТАКСИС</value>
   </data>
   <data name="Parameters" xml:space="preserve">
-    <value>PARAMETERS</value>
+    <value>ПАРАМЕТРЫ</value>
   </data>
   <data name="InputType" xml:space="preserve">
-    <value>INPUTS</value>
+    <value>ВХОДНЫЕ ДАННЫЕ</value>
   </data>
   <data name="ReturnType" xml:space="preserve">
-    <value>OUTPUTS</value>
+    <value>ВЫХОДНЫЕ ДАННЫЕ</value>
   </data>
   <data name="TerminatingErrors" xml:space="preserve">
-    <value>TERMINATING ERRORS</value>
+    <value>ПРЕРЫВАЮЩИЕ ОШИБКИ</value>
   </data>
   <data name="NonHyphenTerminatingErrors" xml:space="preserve">
-    <value>NON-TERMINATING ERRORS</value>
+    <value>НЕПРЕРЫВАЮЩИЕ ОШИБКИ</value>
   </data>
   <data name="Notes" xml:space="preserve">
-    <value>NOTES</value>
+    <value>ПРИМЕЧАНИЯ</value>
   </data>
   <data name="Examples" xml:space="preserve">
-    <value>EXAMPLES</value>
+    <value>ПРИМЕРЫ</value>
   </data>
   <data name="Example" xml:space="preserve">
     <value>Пример</value>
   </data>
   <data name="ExampleUpperCase" xml:space="preserve">
-    <value>EXAMPLE</value>
+    <value>ПРИМЕР</value>
   </data>
   <data name="Output" xml:space="preserve">
-    <value>OUTPUT</value>
+    <value>ВЫХОДНЫЕ ДАННЫЕ</value>
   </data>
   <data name="RelatedLinks" xml:space="preserve">
-    <value>RELATED LINKS</value>
+    <value>СВЯЗАННЫЕ ССЫЛКИ</value>
   </data>
   <data name="ShortDescription" xml:space="preserve">
-    <value>SHORT DESCRIPTION</value>
+    <value>КРАТКОЕ ОПИСАНИЕ</value>
   </data>
   <data name="TitleColon" xml:space="preserve">
-    <value>Title:</value>
+    <value>Название:</value>
   </data>
   <data name="QuestionColon" xml:space="preserve">
-    <value>Question:</value>
+    <value>Вопрос:</value>
   </data>
   <data name="Answer" xml:space="preserve">
     <value>Ответ</value>
   </data>
   <data name="TermColon" xml:space="preserve">
-    <value>Term:</value>
+    <value>Срок:</value>
   </data>
   <data name="DefinitionColon" xml:space="preserve">
-    <value>Definition:</value>
+    <value>Определение:</value>
   </data>
   <data name="ContentColon" xml:space="preserve">
-    <value>Content:</value>
+    <value>Содержимое:</value>
   </data>
   <data name="ProviderName" xml:space="preserve">
-    <value>PROVIDER NAME</value>
+    <value>ИМЯ ПОСТАВЩИКА</value>
   </data>
   <data name="BaseCmdletInformation" xml:space="preserve">
-    <value>    This cmdlet supports the common parameters: Verbose, Debug,
+    <value>    Этот командлет поддерживает общие параметры: Verbose, Debug,
     ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-    OutBuffer, PipelineVariable, and OutVariable. For more information, see
+    OutBuffer, PipelineVariable и OutVariable. Дополнительные сведения см. в разделе
     about_CommonParameters (https://go.microsoft.com/fwlink/?LinkID=113216). </value>
   </data>
   <data name="ParameterRequired" xml:space="preserve">
-    <value>Required?                    </value>
+    <value>Обязательно?                    </value>
   </data>
   <data name="ParameterPosition" xml:space="preserve">
-    <value>Position?                    </value>
+    <value>Позиция?                    </value>
   </data>
   <data name="TypeColon" xml:space="preserve">
-    <value>Type: </value>
+    <value>Тип: </value>
   </data>
   <data name="TargetObjectTypeColon" xml:space="preserve">
-    <value>Target Object Type:   </value>
+    <value>Тип целевого объекта:   </value>
   </data>
   <data name="ParameterDefaultValue" xml:space="preserve">
-    <value>Default value                </value>
+    <value>Значение по умолчанию                </value>
   </data>
   <data name="AcceptsPipelineInput" xml:space="preserve">
-    <value>Accept pipeline input?       </value>
+    <value>Принимать входные данные конвейера?       </value>
   </data>
   <data name="AcceptsWildCardCharacters" xml:space="preserve">
-    <value>Accept wildcard characters?  </value>
+    <value>Принимать подстановочные знаки?  </value>
   </data>
   <data name="Category" xml:space="preserve">
-    <value>(Category: </value>
+    <value>(Категория: </value>
   </data>
   <data name="SuggestedActionColon" xml:space="preserve">
-    <value>Suggested Action: </value>
+    <value>Рекомендуемое действие: </value>
   </data>
   <data name="VerboseHelpInfo" xml:space="preserve">
-    <value>For more information, type: </value>
+    <value>Чтобы получить дополнительные сведения, введите: </value>
   </data>
   <data name="FullHelpInfo" xml:space="preserve">
-    <value>For technical information, type: </value>
+    <value>Чтобы просмотреть технические сведения, введите: </value>
   </data>
   <data name="ExampleHelpInfo" xml:space="preserve">
-    <value>To see the examples, type: </value>
+    <value>Чтобы просмотреть примеры, введите: </value>
   </data>
   <data name="RelatedLinksHelpInfo" xml:space="preserve">
-    <value>For online help, type: </value>
+    <value>Чтобы получить справку в Интернете, введите: </value>
   </data>
   <data name="CommonParameters" xml:space="preserve">
     <value>&lt;CommonParameters&gt;</value>
   </data>
   <data name="RemarksSection" xml:space="preserve">
-    <value>REMARKS</value>
+    <value>ПРИМЕЧАНИЯ</value>
   </data>
   <data name="TrueShort" xml:space="preserve">
     <value>true</value>
   </data>
   <data name="NamedParameter" xml:space="preserve">
-    <value>Named</value>
+    <value>Именованный</value>
   </data>
   <data name="Drives" xml:space="preserve">
-    <value>DRIVES</value>
+    <value>ДИСКИ</value>
   </data>
   <data name="Capabilities" xml:space="preserve">
-    <value>CAPABILITIES</value>
+    <value>ВОЗМОЖНОСТИ</value>
   </data>
   <data name="Tasks" xml:space="preserve">
-    <value>TASKS</value>
+    <value>ЗАДАЧИ</value>
   </data>
   <data name="Task" xml:space="preserve">
-    <value>TASK: </value>
+    <value>ЗАДАЧА: </value>
   </data>
   <data name="Filters" xml:space="preserve">
-    <value>FILTERS</value>
+    <value>ФИЛЬТРЫ</value>
   </data>
   <data name="DynamicParameters" xml:space="preserve">
-    <value>DYNAMIC PARAMETERS</value>
+    <value>ДИНАМИЧЕСКИЕ ПАРАМЕТРЫ</value>
   </data>
   <data name="CmdletsSupported" xml:space="preserve">
-    <value>Cmdlets Supported: </value>
+    <value>Поддерживаемые командлеты: </value>
   </data>
   <data name="AliasesSection" xml:space="preserve">
-    <value>ALIASES</value>
+    <value>ПСЕВДОНИМЫ</value>
   </data>
   <data name="GetLatestHelpContent" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.
-    -- To view the Help topic for this cmdlet online, type: "Get-Help {0} -Online" or
-       go to {1}.</value>
+    <value>Get-Help не удается найти файлы справки для указанного командлета на этом компьютере. Справка отображается частично.
+    -- Чтобы скачать и установить файлы справки для модуля, который включает этот командлет, используйте Update-Help.
+    -- Чтобы просмотреть раздел справки для этого командлета в Интернете, введите: "Get-Help {0} -Online" или
+       перейдите сюда: {1}.</value>
   </data>
   <data name="None" xml:space="preserve">
     <value>Нет</value>
   </data>
   <data name="ParameterAliases" xml:space="preserve">
-    <value>Aliases                      </value>
+    <value>Псевдонимы                      </value>
   </data>
   <data name="ParameterIsDynamic" xml:space="preserve">
-    <value>Dynamic?                     </value>
+    <value>Динамический?                     </value>
   </data>
   <data name="ParameterSetName" xml:space="preserve">
-    <value>Parameter set name           </value>
+    <value>Имя набора параметров           </value>
   </data>
   <data name="UnableToRetrieveHelpInfoXml" xml:space="preserve">
-    <value>Unable to retrieve the HelpInfo XML file for UI culture {0}. Make sure the HelpInfoUri property in the module manifest is valid or check your network connection and then try the command again.</value>
+    <value>Не удается получить XML-файл HelpInfo для языка и региональных параметров пользовательского интерфейса {0}. Убедитесь, что свойство HelpInfoUri в манифесте модуля допустимо, или проверьте сетевое подключение, а затем повторите команду.</value>
   </data>
   <data name="PipelineByPropertyName" xml:space="preserve">
     <value>ByPropertyName</value>
@@ -298,176 +298,176 @@
     <value>FromRemainingArguments</value>
   </data>
   <data name="HelpCultureNotSupported" xml:space="preserve">
-    <value>The specified culture is not supported: {0}. Specify a culture from the following list: {{{1}}}.</value>
+    <value>Указанные язык и региональные параметры не поддерживаются: {0}. Укажите язык и региональные параметры из следующего списка: {{{1}}}.</value>
   </data>
   <data name="HelpCultureNotSupportedFallback" xml:space="preserve">
-    <value>Postponing error and trying fallback cultures, will show as error if none of fallbacks are supported:
+    <value>Откладывание обработки ошибки и попытка использовать резервные варианты языка и региональных параметров будет отображаться как ошибка, если ни один из резервных вариантов не поддерживается:
 {0}</value>
   </data>
   <data name="ModuleBaseMustExist" xml:space="preserve">
-    <value>The ModuleBase directory cannot be found. Verify the directory and try again.</value>
+    <value>Не удается найти каталог ModuleBase. Проверьте каталог и повторите попытку.</value>
   </data>
   <data name="PathMustBeValidContainers" xml:space="preserve">
-    <value>The path {0} is not a valid directory. Make sure the directory exists and retry.</value>
+    <value>Путь {0} не является допустимым каталогом. Убедитесь, что каталог существует, и повторите попытку.</value>
   </data>
   <data name="TooManyRedirections" xml:space="preserve">
-    <value>A Help URI cannot contain more than 10 redirections. Specify a valid Help URI.</value>
+    <value>URI справки не может содержать более 10 перенаправлений. Укажите допустимый URI справки.</value>
   </data>
   <data name="UpdateProgressActivity" xml:space="preserve">
-    <value>Updating Help</value>
+    <value>Обновление справки</value>
   </data>
   <data name="UpdateProgressConnecting" xml:space="preserve">
-    <value>Connecting to Help Content...</value>
+    <value>Подключение к содержимому справки…</value>
   </data>
   <data name="UpdateProgressDownloading" xml:space="preserve">
-    <value>Downloading Help Content...</value>
+    <value>Скачивание содержимого справки…</value>
   </data>
   <data name="UpdateProgressInstalling" xml:space="preserve">
-    <value>Installing Help content...</value>
+    <value>Установка содержимого справки…</value>
   </data>
   <data name="UpdateProgressLocating" xml:space="preserve">
-    <value>Locating Help Content...</value>
+    <value>Поиск содержимого справки…</value>
   </data>
   <data name="AllParameterSetsName" xml:space="preserve">
-    <value>(All)</value>
+    <value>(все)</value>
   </data>
   <data name="CannotMatchModulePattern" xml:space="preserve">
-    <value>No PowerShell modules were found that match the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Не найдены модули PowerShell, соответствующие следующему шаблону: {0}. Проверьте шаблон и повторите команду.</value>
   </data>
   <data name="ModuleNotFoundWithFullyQualifiedName" xml:space="preserve">
-    <value>No PowerShell modules were found that match the specified FullyQualifiedModule {0}. Verify the FullyQualifiedModule value and then try the command again.</value>
+    <value>Не найдены модули PowerShell, соответствующие указанному FullyQualifiedModule {0}. Проверьте значение FullyQualifiedModule и повторите команду.</value>
   </data>
   <data name="HelpContentNotFound" xml:space="preserve">
-    <value>Help content cannot be found. Make sure the server is available and the help content location is properly defined in the HelpInfo XML.</value>
+    <value>Не удается найти содержимое справки. Убедитесь, что сервер доступен и что расположение содержимого справки правильно определено в XML-файле HelpInfo.</value>
   </data>
   <data name="HelpInfoUriNotFound" xml:space="preserve">
-    <value>The Update-Help command failed because the specified module does not support updatable help. Use Get-Help -Online or look online for help for the commands in this module.</value>
+    <value>Не удалось выполнить команду Update-Help, так как указанный модуль не поддерживает обновляемую справку. Используйте Get-Help -Online или выполните поиск в Интернете, чтобы получить справку по командам в этом модуле.</value>
   </data>
   <data name="ModuleNameNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Module.</value>
+    <value>Следующий параметр не должен быть пустым или иметь значение null: Модуль.</value>
   </data>
   <data name="PathNullOrEmpty" xml:space="preserve">
-    <value>The following parameter must not be null or empty: Path.</value>
+    <value>Следующий параметр не должен быть пустым или иметь значение null: Путь.</value>
   </data>
   <data name="UpdateHelpCompleted" xml:space="preserve">
-    <value>Update-Help has completed successfully.</value>
+    <value>Команда Update-Help выполнена.</value>
   </data>
   <data name="UnzipFailure" xml:space="preserve">
-    <value>Error extracting Help content.</value>
+    <value>Ошибка при извлечении содержимого справки.</value>
   </data>
   <data name="UnableToConnect" xml:space="preserve">
-    <value>Unable to connect to Help content. The server on which Help content is stored might not be available. Verify that the server is available, or wait until the server is back online, and then try the command again.</value>
+    <value>Не удается подключиться к содержимому справки. Возможно, сервер, на котором хранится содержимое справки, недоступен. Убедитесь, что сервер доступен, или дождитесь, пока он снова станет доступен, и повторите команду.</value>
   </data>
   <data name="HelpContentXmlValidationFailure" xml:space="preserve">
-    <value>The Help content at the specified location is not valid. Specify a location that contains valid Help Content.</value>
+    <value>Содержимое справки в указанном расположении недопустимо. Укажите расположение, в котором находится допустимое содержимое справки.</value>
   </data>
   <data name="HelpInfoXmlValidationFailure" xml:space="preserve">
-    <value>The HelpInfo XML is not valid. Specify valid HelpInfo XML.</value>
+    <value>XML-файл HelpInfo недопустим. Укажите допустимый XML-файл HelpInfo.</value>
   </data>
   <data name="SaveHelpCompleted" xml:space="preserve">
-    <value>Help content was successfully saved to the following location: {0}</value>
+    <value>Содержимое справки сохранено в следующем расположении: {0}</value>
   </data>
   <data name="HelpContentXsdNotFound" xml:space="preserve">
-    <value>The Help content XSD file cannot be found in {0}. Verify that the XSD file exists at the specified location, and then retry the command.</value>
+    <value>Не удается найти XSD-файл содержимого справки в {0}. Убедитесь, что XSD-файл существует в указанном расположении, и повторите команду.</value>
   </data>
   <data name="FailedToUpdateHelpForModule" xml:space="preserve">
-    <value>Failed to update Help for the module(s) :
-'{0}'
+    <value>Не удалось обновить справку для модулей: 
+"{0}"
 {1}</value>
   </data>
   <data name="SaveProgressActivity" xml:space="preserve">
-    <value>Saving Help</value>
+    <value>Сохранение справки</value>
   </data>
   <data name="HelpContentContainsInvalidFiles" xml:space="preserve">
-    <value>Help content contains files that are not valid. Only .txt and .xml files are supported.</value>
+    <value>Содержимое справки включает недопустимые файлы. Поддерживаются только файлы TXT и XML.</value>
   </data>
   <data name="FailedToSaveHelpForModule" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' : {1}</value>
+    <value>Не удалось сохранить справку для модулей "{0}": {1}</value>
   </data>
   <data name="FailedToSaveHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to save Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be saved using: Save-Help -UICulture en-US.</value>
+    <value>Не удалось сохранить справку для модулей "{0}" с языком и региональными параметрами пользовательского интерфейса {{{1}}}: {2}.
+Содержимое справки English-US доступно и может быть сохранено с помощью команды Save-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpForModuleWithCulture" xml:space="preserve">
-    <value>Failed to update Help for the module(s) '{0}' with UI culture(s) {{{1}}} : {2}.
-English-US help content is available and can be installed using: Update-Help -UICulture en-US.</value>
+    <value>Не удалось обновить справку для модулей "{0}" с языком и региональными параметрами пользовательского интерфейса {{{1}}}: {2}.
+Содержимое справки English-US доступно и может быть установлено с помощью команды Update-Help -UICulture en-US.</value>
   </data>
   <data name="FailedToUpdateHelpWithLocaleNoUICulture" xml:space="preserve">
-    <value>Your current culture is ({0}), which is not associated with any language, consider changing your system culture or install the English-US help content using: Update-Help -UICulture en-US.</value>
+    <value>Ваши текущие язык и региональные параметры — ({0}) и не связаны ни с одним языком. Попробуйте изменить язык и региональные параметры системы или установить содержимое справки English-US с помощью команды Update-Help -UICulture en-US.</value>
   </data>
   <data name="FalseShort" xml:space="preserve">
     <value>false</value>
   </data>
   <data name="CannotSpecifyRecurseWithoutPath" xml:space="preserve">
-    <value>The -Recurse parameter is only available if a source path is specified.</value>
+    <value>Параметр -Recurse доступен, только если указан путь к источнику.</value>
   </data>
   <data name="ProviderIsNotFileSystem" xml:space="preserve">
-    <value>The path {0} does not contain a FileSystem provider. Verify that the specified path contains the FileSystem provider, and then retry the command.</value>
+    <value>В пути {0} не указан поставщик FileSystem. Убедитесь, что в этом пути указан поставщик FileSystem, и повторите команду.</value>
   </data>
   <data name="SearchingForHelpContent" xml:space="preserve">
-    <value>Searching Help for {0} ...</value>
+    <value>Поиск справки для {0}…</value>
   </data>
   <data name="CannotMatchUICulturePattern" xml:space="preserve">
-    <value>No UI culture was found that matches the following pattern: {0}. Verify the pattern and then try the command again.</value>
+    <value>Не найдены язык и региональные параметры пользовательского интерфейса, соответствующие следующему шаблону: {0}. Проверьте шаблон и повторите команду.</value>
   </data>
   <data name="UseForceToSaveHelp" xml:space="preserve">
-    <value>Help was not saved for the module {0}, because the Save-Help command was run on this computer within the last 24 hours.
-To save help again, add the Force parameter to your command.</value>
+    <value>Справка для модуля {0} не сохранена, так как команда Save-Help выполнялась на этом компьютере в течение последних 24 часов.
+Чтобы снова сохранить справку, добавьте в команду параметр Force.</value>
   </data>
   <data name="UseForceToUpdateHelp" xml:space="preserve">
-    <value>Help was not updated for the module {0}, because the Update-Help command was run on this computer within the last 24 hours.
-To update help again, add the Force parameter to your command.</value>
+    <value>Справка для модуля {0} не обновлена, так как команда Update-Help выполнялась на этом компьютере в течение последних 24 часов.
+Чтобы снова обновить справку, добавьте в команду параметр Force.</value>
   </data>
   <data name="NewestContentAlreadyInstalled" xml:space="preserve">
-    <value>The most current Help files are already installed.</value>
+    <value>Самые актуальные файлы справки уже установлены.</value>
   </data>
   <data name="SuccessfullyUpdatedHelpContent" xml:space="preserve">
-    <value>{0}: {1}. Culture {2} Version {3}</value>
+    <value>{0}: {1}. Язык и региональные параметры {2} Версия {3}</value>
   </data>
   <data name="UpdatedHelpContent" xml:space="preserve">
-    <value>Updated {0}</value>
+    <value>Обновлено {0}</value>
   </data>
   <data name="InvalidHelpInfoUri" xml:space="preserve">
-    <value>The value of the HelpInfoUri key in the module manifest must resolve to a container or root URL on a website where the help files are stored. The HelpInfoUri '{0}' does not resolve to a container.</value>
+    <value>Значение ключа HelpInfoUri в манифесте модуля должно указывать на URL-адрес контейнера или корня на веб-сайте, где хранятся файлы справки. Ключ HelpInfoUri "{0}" не указывает на контейнер.</value>
   </data>
   <data name="HelpContentMustBeInTargetNamespace" xml:space="preserve">
-    <value>Help content must be in the namespace {0}.</value>
+    <value>Содержимое справки должно находиться в пространстве имен {0}.</value>
   </data>
   <data name="GetLatestHelpContentWithoutHelpUri" xml:space="preserve">
-    <value>Get-Help cannot find the Help files for this cmdlet on this computer. It is displaying only partial help.
-    -- To download and install Help files for the module that includes this cmdlet, use Update-Help.</value>
+    <value>Get-Help не удается найти файлы справки для указанного командлета на этом компьютере. Справка отображается частично.
+    -- Чтобы скачать и установить файлы справки для модуля, который включает этот командлет, используйте Update-Help.</value>
   </data>
   <data name="NewestContentAlreadyDownloaded" xml:space="preserve">
-    <value>The most current Help files are already downloaded.</value>
+    <value>Самые актуальные файлы справки уже скачаны.</value>
   </data>
   <data name="SavedHelpContent" xml:space="preserve">
-    <value>Saved {0}</value>
+    <value>Сохранено {0}</value>
   </data>
   <data name="InvalidHelpInfoUriFormat" xml:space="preserve">
-    <value>The HelpInfoURI {0} does not start with HTTP.</value>
+    <value>HelpInfoURI {0} не начинается с HTTP.</value>
   </data>
   <data name="RootElementMustBeHelpItems" xml:space="preserve">
-    <value>The root level element of the help content must be "helpItems".</value>
+    <value>Корневым элементом содержимого справки должен быть "helpItems".</value>
   </data>
   <data name="SaveProgressActivityForModule" xml:space="preserve">
-    <value>Saving Help for module {0}</value>
+    <value>Сохранение справки для модуля {0}</value>
   </data>
   <data name="UpdateProgressActivityForModule" xml:space="preserve">
-    <value>Updating Help for module {0}</value>
+    <value>Обновление справки для модуля {0}</value>
   </data>
   <data name="UpdateHelpResolveUriVerbose" xml:space="preserve">
-    <value>Resolving URI: "{0}"</value>
+    <value>Разрешение URI: "{0}"</value>
   </data>
   <data name="OnlineHelpUri" xml:space="preserve">
-    <value>Help URI: {0}</value>
+    <value>URI справки: {0}</value>
   </data>
   <data name="UpdateHelpShouldProcessActionMessage" xml:space="preserve">
-    <value>{0}, Current Version: {1}, Available Version: {2}, UICulture: {3}</value>
+    <value>{0}, текущая версия: {1}, доступная версия: {2}, UICulture: {3}</value>
   </data>
   <data name="Properties" xml:space="preserve">
-    <value>PROPERTIES</value>
+    <value>СВОЙСТВА</value>
   </data>
   <data name="Methods" xml:space="preserve">
-    <value>METHODS</value>
+    <value>МЕТОДЫ</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/Metadata.ru.resx
+++ b/src/System.Management.Automation/resources/ru/Metadata.ru.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>Не удается инициализировать атрибуты для "{0}": "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>Невозможно проверить аргумент, так как его тип "{0}" не совпадает с типом ({1}) максимальной и минимальной границ параметра. Убедитесь, что аргумент имеет тип {1}, а затем повторите команду.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>Невозможно проверить аргумент "{0}", так как его значение не больше нуля.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>Невозможно проверить аргумент "{0}", так как его значение меньше нуля.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>Невозможно проверить аргумент "{0}", так как его значение не меньше нуля.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>Невозможно проверить аргумент "{0}", так как его значение больше нуля.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>Указанный минимальный диапазон ({0}) не может быть принят, так как его тип не совпадает с типом указанного максимального диапазона ({1}). Обновите атрибут ValidateRange для параметра.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>Нельзя принять типы параметров MaxRange и MinRange. Оба параметра должны быть объектами, реализующими интерфейс IComparable.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>Указанный максимальный диапазон не может быть принят, так как он меньше указанного минимального диапазона. Обновите атрибут ValidateRange для параметра.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>Аргумент {0} больше максимально допустимого диапазона {1}. Укажите аргумент, который меньше или равен {1}, а затем повторите команду.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>Аргумент {0} меньше минимально допустимого диапазона {1}. Укажите аргумент, который больше или равен {1}, а затем повторите команду.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>Аргумент "{0}" не соответствует шаблону "{1}". Укажите аргумент, который соответствует "{1}", а затем повторите команду.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>Атрибут ValidateCount нельзя применить к параметру, который не является массивом. Удалите атрибут из параметра или сделайте параметр массивом.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>Требуемое количество значений для параметра: {0}, а указано {1}.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>Требуемое количество значений для параметра: не менее {0} и не более {1}, а указано {2}.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>Указанное максимальное число аргументов для параметра меньше указанного минимального числа аргументов. Обновите атрибут ValidateCount для параметра.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>Указанная максимальная длина аргумента меньше указанной минимальной длины аргумента. Обновите атрибут ValidateLength для параметра.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>Атрибут ValidateLength нельзя применить к параметру, который не является параметром string или string[]. Измените тип параметра на string или string[].</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>Длина аргумента в символах ({1}) слишком мала. Укажите аргумент длиной не менее "{0}", а затем повторите команду.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>Длина аргумента в символах ({1}) слишком велика. Укажите аргумент длиной не более "{0}", а затем повторите команду.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>Аргумент "{0}" не принадлежит к набору "{1}", указанному атрибутом ValidateSet. Укажите аргумент допустимого типа и повторите попытку.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>Генератор допустимых значений возвращает значение null.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>У "{0}" произошел сбой в свойстве "{1}" {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>Не удается получить или выполнить команду. Превышено максимальное число наборов параметров для этой команды.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>Невозможно обработать аргумент, так как его значение не является строкой. Значения аргументов параметров, для которых указан атрибут ArgumentTransformationAttribute, должны быть строками.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>Невозможно проверить переменную, так как значение {1} не является допустимым значением для переменной {0}.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>Нельзя добавить атрибут, так как переменная {0} со значением {1} больше не будет допустимой.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>Аргумент имеет значение null. Укажите допустимое значение аргумента, а затем повторите команду.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>Аргумент имеет значение null, или элемент коллекции аргумента содержит значение null. Укажите коллекцию, не содержащую значений null, а затем повторите команду.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>Аргумент имеет значение null или пуст. Укажите аргумент, который не имеет значения null и не пуст, а затем повторите команду.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>Аргумент имеет значение null, пуст, или элемент коллекции аргумента содержит значение null. Укажите коллекцию, не содержащую значений NULL, а затем повторите команду.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>Аргумент имеет значение null, пуст или состоит только из пробелов. Укажите аргумент, содержащий символы, отличные от пробела, а затем повторите команду.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Элемент коллекции аргумента имеет значение null, пуст или состоит только из пробелов. Укажите коллекцию, не содержащую таких значений, а затем повторите команду.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>Параметр "{0}" был определен для команды несколько раз.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>Нельзя указать псевдоним параметра, так как псевдоним с именем "{0}" уже был определен для этой команды несколько раз.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>Нельзя указать параметр "{0}'" так как он конфликтует с псевдонимом того же имени для параметра "{1}".</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>Скрипт проверки "{1}" для аргумента со значением "{0}" не вернул значение True. Определите причину сбоя скрипта проверки, а затем повторите команду.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>Аргумент "{0}" не содержит допустимую версию PowerShell. Укажите допустимый номер версии, а затем повторите команду.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>Невозможно проверить аргумент "{0}", так как он не является допустимым именем переменной.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>Тип преобразования задания должен наследовать IAstToScriptBlockConverter.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>Недопустимый аргумент пути. Укажите аргумент пути строкового типа.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>Диск аргумента пути {0} не входит в набор утвержденных дисков: {1}. Укажите аргумент пути с утвержденным диском.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>Аргумент пути содержит недопустимые символы.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>У аргумента пути нет корневого диска.  Укажите полный путь с корневым диском.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>Значение аргумента для параметра "{0}" не может быть null или пустой строкой.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Элемент перечисления "{0}" не является допустимым значением параметра "{1}". Укажите один из следующих элементов и повторите попытку: {2}..</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>Не удается обработать входные данные. Недоверенный аргумент "{0}".</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>Ошибка проверки атрибута ValidateTrustedData</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>Аргумент параметра "{0}" не является доверенным и приведет к сбою проверки атрибута параметра ValidateTrustedData в режиме ограниченного языка.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/Modules.ru.resx
+++ b/src/System.Management.Automation/resources/ru/Modules.ru.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Указанный модуль "{0}" не был загружен, так как ни в одном каталоге модулей не найден допустимый файл модуля.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Указанный модуль "{0}" с версией "{1}" не был загружен, так как ни в одном каталоге модулей не найден допустимый файл модуля.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Указанное значение MaximumVersion "{0}" неверно. Если используется "*", MaximumVersion поддерживает только один символ "*" и он должен располагаться в конце MaximumVersion.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Указанный модуль "{0}" с MaximumVersion "{1}" не был загружен, так как ни в одном каталоге модулей не был найден допустимый файл модуля.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Указанный модуль "{0}" с MinimumVersion "{1}" и MaximumVersion "{2}" не был загружен, так как ни в одном каталоге модулей не был найден допустимый файл модуля.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>Значение MinimumVersion "{0}" не должно быть больше значения MaximumVersion "{1}".</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>Сборка "{0}" не загружена, так как сборка с таким именем не найдена. Проверьте имя сборки и повторите попытку.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>Модуль для обработки "{0}", указанный в поле "{1}" манифеста модуля "{2}", не был обработан, так как ни в одном каталоге модулей не был найден допустимый модуль.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>Для модуля "{0}" не был возвращен пользовательский объект, так как параметр -AsCustomObject можно использовать только с модулями сценариев.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>Не удалось обработать манифест модуля "{0}", так как он не является допустимым файлом манифеста модуля PowerShell. Удалите запрещенные элементы: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>Обработка файла манифеста модуля "{0}" не привела к созданию допустимого объекта манифеста. Обновите файл, чтобы он содержал допустимый манифест модуля PowerShell. Допустимый манифест можно создать с помощью командлета New-ModuleManifest.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Не удается импортировать модуль "{0}", так как его манифест содержит один или несколько недопустимых элементов. Допустимые элементы манифеста: ({1}). Удалите недопустимые элементы ({2}), а затем повторите попытку импорта модуля.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>Хэш-таблица, описывающая модуль, содержит один или несколько недопустимых элементов. Допустимые элементы: ({0}). Удалите недопустимые элементы ({1}) и повторите попытку.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Не удается загрузить модуль "{0}", так как превышен предел вложенности модулей. Модули можно вложить только в следующее количество уровней: {1}. Оцените и измените порядок загрузки модулей, чтобы не превышать предел вложенности, а затем повторите попытку запуска сценария.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>Элемент "ModuleVersion" отсутствует в манифесте модуля. Этот элемент должен существовать, и ему должно быть назначено значение версии в формате "n.n.n.n". Добавьте отсутствующий элемент в файл "{0}".</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>Элемент "{0}" недопустим в файле манифеста модуля "{2}": {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>Версия "{0}" модуля "{1}" не соответствует требуемой минимальной версии "{2}". Проверьте, что номер версии поддерживается, а затем повторите попытку загрузки модуля.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>Версия PowerShell на этом компьютере — "{0}". Для запуска модуля "{1}" требуется минимальная версия PowerShell "{2}". Проверьте, что установлена требуемая минимальная версия PowerShell, и повторите попытку.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>Элемент манифеста модуля "NestedModules" нельзя использовать, если элемент "ModuleToProcess" является двоичным модулем. Измените файл манифеста модуля в "{0}" и повторите попытку.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Элемент "{0}" в манифесте модуля недопустим: {1}. Проверьте, что для этого поля в файле "{2}" указано допустимое значение.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>Путь к манифесту модуля "{0}" недопустим. Значение аргумента Path должно сопоставляться с одним файлом с расширением ".psd1". Измените значение аргумента Path так, чтобы оно указывало на допустимый файл psd1, а затем повторите попытку.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>Ключ ModuleVersion в манифесте модуля "{0}" указывает версию модуля "{1}", которая не совпадает с именем папки версии в "{2}". Измените значение ключа ModuleVersion, чтобы оно соответствовало имени папки версии.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Указанная запись NestedModule "{0}" в манифесте модуля "{1}" недопустима. Повторите попытку после обновления этой записи с использованием допустимых значений.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Указанная запись RequiredAssemblies "{0}" в манифесте модуля "{1}" недопустима. Повторите попытку после обновления этой записи с использованием допустимых значений.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Указанная запись FileList "{0}" в манифесте модуля "{1}" недопустима. Повторите попытку после обновления этой записи с использованием допустимых значений.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Указанная запись RequiredModules "{0}" в манифесте модуля "{1}" недопустима. Повторите попытку после обновления этой записи с использованием допустимых значений.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>Указанная запись ModuleList "{0}" в манифесте модуля "{1}" недопустима. Повторите попытку после обновления этой записи с использованием допустимых значений.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>Манифест модуля "{0}" указан с ключом CompatiblePSEditions, который поддерживается только в PowerShell версии "5.1" или более поздней. Обновите значение ключа PowerShellVersion до "5.1" или более поздней версии и повторите попытку.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>Указанное значение "{0}" для CompatiblePSEditions содержит повторяющиеся имена выпусков PowerShell. Повторите попытку после удаления повторяющихся имен выпусков PowerShell.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>Версия, указанная в ключе ModuleVersion, совпадает с именем папки версии.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Папка версии {0} в модуле {1} пропускается, так как в ней нет допустимого файла манифеста модуля.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>Элемент "ModuleName" не существует в хэш-таблице, описывающей этот модуль.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>Элементы "ModuleVersion", "MaximumVersion" и "RequiredVersion" отсутствуют в хэш-таблице, описывающей этот модуль. Должен существовать один из этих трех элементов, и ему должно быть присвоено значение версии в формате "n.n.n.n".</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Требуемый модуль "{1}" не загружен. Загрузите модуль или удалите его из "RequiredModules" в файле "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Требуемый модуль "{1}" с GUID "{2}" не загружен. Загрузите модуль или удалите его из "RequiredModules" в файле "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Требуемый модуль "{1}" версии "{2}" не загружен. Загрузите модуль или удалите его из "RequiredModules" в файле "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Требуемый модуль "{1}" с MaximumVersion "{2}" не загружен. Загрузите модуль или удалите его из "RequiredModules" в файле "{0}".</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Требуемый модуль "{1}" с MinimumVersion "{2}" и MaximumVersion "{3}" не загружен. Загрузите модуль или удалите его из "RequiredModules" в файле "{0}".</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>Не удается найти модуль "{0}" с ModuleVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>Не удается найти модуль "{0}" с RequiredVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>Не удается найти модуль "{0}" с MaximumVersion "{1}".</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>Не удается найти модуль "{0}" с ModuleVersion "{1}" и MaximumVersion "{2}".</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>Модуль "{0}" не найден.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Модули не удалены. Проверьте, что указаны правильные модули для удаления и что эти модули существуют в пространстве выполнения.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>Элемент "{0}", импортированный из модуля "{1}", нельзя удалить по следующей причине: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>Не удалось удалить модуль "{0}", так как он доступен только для чтения. Добавьте параметр Force в команду, чтобы удалить модули, доступные только для чтения.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>Не удалось удалить модуль "{0}", так как он помечен как "constant". Модуль нельзя удалить, если он помечен как "constant".</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>Не удалось удалить модуль "{0}", так как он требуется "{1}". Добавьте параметр Force в команду, чтобы удалить модуль.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Командлет Export-ModuleMember можно вызвать только изнутри модуля.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>Расширение "{0}" не является допустимым расширением модуля. Поддерживаемые расширения модулей: ".dll", ".ps1", ".psm1", ".psd1" и ".cdxml". Исправьте расширение и попробуйте добавить файл "{1}" еще раз.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Эту операцию нельзя выполнить для двоичного модуля. Ее можно выполнить только для модуля сценария.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>Файл "{0}" не допускается, так как у него нет расширения ".ps1".</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Неизвестно</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Все права защищены.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>Удаление импортированной функции "{0}".</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>Удаление импортированного псевдонима "{0}".</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>Удаление импортированной переменной "{0}".</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Загрузка модуля из пути "{0}".</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>Загрузка "{0}" из пути "{1}".</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>Вызов файла сценария "{0}" с использованием точки.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>Импорт функции "{0}".</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>Импорт командлета "{0}".</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>Импорт псевдонима "{0}".</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>Импорт переменной "{0}".</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>Экспорт командлета "{0}".</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>Экспорт функции "{0}".</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>Экспорт псевдонима "{0}".</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>Экспорт переменной "{0}".</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>Имена некоторых импортируемых команд из модуля "{0}" содержат неутвержденные глаголы, из-за чего их может быть сложнее обнаружить. Чтобы найти команды с неутвержденными глаголами, снова запустите команду Import-Module с параметром Verbose. Чтобы получить список утвержденных глаголов, введите Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>Команда "{0}" в модуле "{1}" была импортирована, но ее имя не содержит утвержденного глагола, поэтому ее может быть трудно найти. Чтобы получить список утвержденных глаголов, введите Get-Verb.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>Команда "{0}" в модуле "{2}" была импортирована, но ее имя не содержит утвержденного глагола, поэтому ее может быть трудно найти. Предлагаемые альтернативные глаголы: "{1}".</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Некоторые импортированные имена команд содержат один или несколько следующих ограниченных символов: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " " &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>Имя команды "{0}" из модуля "{1}" содержит один или несколько следующих ограниченных символов: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " " &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>Создание файла манифеста модуля "{0}".</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (путь: "{1}")</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>Текущая архитектура процессора: {0}. Модулю "{1}" требуется следующая архитектура: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Имя текущего узла PowerShell: "{0}". Для модуля "{1}" требуется следующий узел PowerShell: "{2}".</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>Текущий узел PowerShell: "{0}" (версия {1}). Для запуска модуля "{2}" требуется минимальная версия узла PowerShell "{3}".</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>Манифест модуля "{0}"</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Кем создано: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>Создано: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Файл модуля сценария или двоичного модуля, связанный с этим манифестом.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>Модули, которые нужно импортировать как вложенные модули модуля, указанного в RootModule/ModuleToProcess</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>Идентификатор, используемый для уникальной идентификации этого модуля</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Автор этого модуля</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Компания или поставщик этого модуля</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Заявление об авторских правах для этого модуля</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Номер версии этого модуля.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Описание функциональности, предоставляемой этим модулем</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Минимальная версия подсистемы PowerShell, необходимая для этого модуля</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Минимальная версия среды выполнения CLR, необходимая для этого модуля. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Модули, которые нужно импортировать в глобальную среду перед импортом этого модуля</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Файлы сценариев (.ps1), которые запускаются в среде вызывающего объекта перед импортом этого модуля.</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Файлы типов (.ps1xml), которые нужно загрузить при импорте этого модуля</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Файлы формата (.ps1xml), которые нужно загрузить при импорте этого модуля</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Сборки, которые нужно загрузить перед импортом этого модуля</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Список всех файлов, упакованных с этим модулем</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>Личные данные для передачи в модуль, указанный в RootModule/ModuleToProcess. Они также могут содержать хэш-таблицу PSData с дополнительными метаданными модуля, используемыми PowerShell.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Теги, применяемые к этому модулю. Они помогают находить модуль в онлайн-галереях.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>URL-адрес основного веб-сайта этого проекта.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>URL-адрес лицензии для этого модуля.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>URL-адрес значка, представляющего этот модуль.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Заметки о выпуске этого модуля</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Строка предварительного выпуска этого модуля</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Флаг, указывающий, требуется ли модулю явное принятие пользователем установки, обновления или сохранения</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Внешние зависимые модули этого модуля</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>Конец хэш-таблицы {0}</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>Значение параметра PrivateData должно быть хэш-таблицей, чтобы создать манифест модуля со следующими значениями параметров: Tags, ProjectUri, LicenseUri, IconUri или ReleaseNotes. Удалите значения параметров Tags, ProjectUri, LicenseUri, IconUri или ReleaseNotes либо поместите содержимое PrivateData в хэш-таблицу.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData должен быть определен как хэш-таблица, но в этом манифесте модуля он определен как объект. Рассмотрите возможность перенести содержимое PrivateData в хэш-таблицу. Это позволит позже добавить в манифест модуля свойства Tags, ProjectUri, LicenseUri, IconUri и ReleaseNotes.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Указанное значение "{0}" недопустимо. Повторите попытку, указав допустимое значение.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Функции для экспорта из этого модуля. Для оптимальной производительности не используйте подстановочные знаки и не удаляйте эту запись. Если функций для экспорта нет, используйте пустой массив.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Псевдонимы для экспорта из этого модуля. Для оптимальной производительности не используйте подстановочные знаки и не удаляйте этот элемент. Если псевдонимов для экспорта нет, используйте пустой массив.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Командлеты для экспорта из этого модуля. Для оптимальной производительности не используйте подстановочные знаки и не удаляйте эту запись. Если командлетов для экспорта нет, используйте пустой массив.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Переменные для экспорта из этого модуля</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Ресурсы DSC для экспорта из этого модуля</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Поддерживаемые PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Архитектура процессора (None, X86, Amd64), необходимая для этого модуля</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Список всех модулей, упакованных с этим модулем</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Минимальная версия Microsoft .NET Framework, необходимая для этого модуля. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Имя узла PowerShell, требуемого для этого модуля</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Минимальная версия узла PowerShell, необходимая для этого модуля</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>URI HelpInfo этого модуля</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>Так как модуль {0} предоставляет PSDrive в текущем сеансе PowerShell, ни один модуль не был удален. Измените текущего поставщика PSDrive, а затем повторите попытку удаления модулей.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Не удалось импортировать командлет "{0}", так как в текущей области есть элемент с таким же именем.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Псевдоним "{0}" не был импортирован, так как в текущей области есть элемент с таким же именем.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Функция "{0}" не была импортирована, так как в текущей области есть элемент с таким же именем.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Не удалось импортировать переменную "{0}", так как в текущей области есть элемент с таким же именем.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>В элементах "ModuleToProcess", "RootModule" и "NestedModules" манифеста модуля "{0}" не допускаются подстановочные знаки.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>Модуль "{0}" является основным модулем для PowerShell. Добавьте в команду параметр Force, чтобы удалить основные модули.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Манифест модуля не может одновременно содержать элементы "ModuleToProcess" и "RootModule". Измените файл манифеста модуля в "{0}", удалив один из этих элементов, и повторите попытку.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>Элемент манифеста модуля "ModuleToProcess" является нерекомендуемым. Вместо него используйте элемент "RootModule".</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Префикс по умолчанию для команд, экспортируемых из этого модуля. Переопределите префикс по умолчанию с помощью Import-Module -Prefix.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>Параметры "Global" и "Scope" нельзя указывать вместе. Удалите один из этих параметров, а затем повторите попытку выполнения команды.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Требуемый модуль "{0}" не загружен. Модуль "{0}" содержит requiredModule "{1}" в манифесте модуля "{2}", что указывает на циклическую зависимость.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Требуемый модуль "{0}" не был загружен, так как ни в одном каталоге модулей не найден допустимый файл модуля.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>Некоторые команды из модуля {0} невозможно импортировать через CimSession. Чтобы получить все команды, проверьте, что на удаленном сервере включено удаленное управление PowerShell, а затем попробуйте добавить параметр PSSession в командлет Import-Module.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>Модуль {0} загружен в Windows PowerShell с использованием удаленного сеанса {1}; обратите внимание, что все входные и выходные данные команд из этого модуля будут представлять собой десериализованные объекты. Если вы хотите загрузить этот модуль в PowerShell, используйте синтаксис "Import-Module -SkipEditionCheck".</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Обнаружена версия Windows PowerShell {0}. Для загрузки модулей с использованием функции совместимости с Windows PowerShell требуется Windows PowerShell 5.1. Установите Windows Management Framework (WMF) 5.1 со страницы https://aka.ms/WMF5Download, чтобы включить эту функцию.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>Загрузка модуля "{0}" через функцию совместимости Windows PowerShell заблокирована параметром "WindowsPowerShellCompatibilityModuleDenyList" в файле конфигурации PowerShell.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>Невозможно импортировать модуль {0} через CimSession. Попробуйте использовать параметр PSSession командлета Import-Module.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>Значение архитектуры процессора {0} не поддерживается. Выполните команду New-ModuleManifest еще раз, указав одно из следующих поддерживаемых значений перечисления для архитектуры процессора: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>При выполнении командлета Get-Module на удаленном компьютере можно получить только список доступных модулей. Добавьте в команду параметр ListAvailable и повторите попытку.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>Модуль "{0}" не был импортирован, так как оснастка "{0}" уже импортирована.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>В элементе "RequiredAssemblies" манифеста модуля "{0}" не допускаются подстановочные знаки.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>Значение ключа {0} в {1} равно {2}, а модуль содержит вложенные модули. Если файл CDXML является корневым модулем, команда Import-Module завершится ошибкой, так как команды во вложенных модулях нельзя экспортировать. Переместите файл CDXML в ключ NestedModules и повторите команду.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Сбой удаленной команды: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>Не удалось создать прокси-серверы для удаленного модуля "{0}". {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>Не удалось обработать удаленный модуль {0}. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Не удалось получить данные модуля от удаленного CimSession. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Требуемый модуль "{0}" с GUID "{1}" и версией "{2}" не был загружен, так как ни в одном каталоге модулей не найден допустимый файл модуля.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>Поставщик CIM для обнаружения модулей не найден на сервере CIM. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>Не удается проверить версию Microsoft .NET Framework {0}, так как она не включена в список разрешенных версий.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>Анализ {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Подготовка модулей к первому использованию.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Поиск доступных модулей</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>Поиск общей папки UNC {0}.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Запуск командлета Get-Module на удаленном компьютере возможен только для имен модулей, которые не содержат путь. Параметр Name содержит элемент "{0}", который сопоставляется с путем. Обновите параметр Name так, чтобы он не содержал элементов пути, а затем повторите попытку.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Запуск командлета Get-Module без параметра ListAvailable не поддерживается для имен модулей, которые содержат путь. Параметр Name содержит элемент "{0}", который сопоставляется с путем. Обновите параметр Name так, чтобы он не содержал элементов пути, а затем повторите попытку.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Указанный модуль "{0}" не найден. Обновите параметр Name, чтобы он указывал на допустимый путь, и повторите попытку. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>Заполнение свойства RepositorySourceLocation для модуля {0}.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>Модуль для обработки "{0}", указанный в поле "{1}" манифеста модуля "{2}", не был обработан. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Это предварительное требование действительно только для выпуска классической версии PowerShell.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>Модуль "{0}" не поддерживает текущий выпуск PowerShell "{1}". Поддерживаемые выпуски: "{2}". Чтобы проигнорировать совместимость этого модуля, используйте "Import-Module -SkipEditionCheck".</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>Модуль "{0}" поддерживает выпуск PowerShell "{1}" и не может быть загружен неявно с помощью функции совместимости Windows, так как она отключена в файле параметров. Используйте "Import-Module -UseWindowsPowerShell", чтобы загрузить этот модуль с помощью Windows PowerShell, или "Import-Module -SkipEditionCheck", чтобы попытаться загрузить модуль с текущим PowerShell.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Для экспериментальной функции, объявленной в манифесте модуля, следует указать непустое строковое значение.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Обнаружено одно или несколько недопустимых имен экспериментальных функций: {0}. Имя экспериментальной функции модуля должно соответствовать соглашению: "ModuleName.FeatureName".</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>Параметр-переключатель -SkipEditionCheck нельзя использовать без параметра-переключателя -ListAvailable.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>Импорт файлов *.ps1 в качестве модулей не разрешен в режиме ConstrainedLanguage.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>Произошла ошибка при загрузке модуля сценария {0}, потому что его языковой режим отличается от языкового режима манифеста модуля. Языковой режим манифеста — {1}, а языковой режим модуля — {2}. Убедитесь, что все файлы модуля подписаны или иным образом включены в конфигурацию списка разрешений приложения.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>В этом модуле используется оператор dot-source при экспорте функций с подстановочными знаками, что запрещено, если в системе применяется принудительная проверка приложений.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Нельзя экспортировать элементы модуля из модуля, языковой режим которого отличается от языкового режима текущего сеанса.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Нельзя создать новый модуль, пока сеанс находится в режиме ConstrainedLanguage.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>Не удается найти встроенный модуль "{0}", совместимый с выпуском "Core". Убедитесь, что встроенные модули PowerShell доступны. Обычно они поставляются вместе с пакетом PowerShell в пути $PSHOME к модулю и необходимы для корректной работы PowerShell.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Командлет Export-ModuleMember</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>Экспорт элементов модуля завершится сбоем в ограниченном языковом режиме, так как модуль "{0}" использует языковой режим "{1}", отличный от текущего сеанса "{2}".</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Неявный экспорт функций модуля</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>Неявный экспорт функций для модуля "{0}" будет запрещен, так как он является доверенным (работает в полном языковом режиме), а сеанс не является доверенным (работает в ограниченном языковом режиме). Рекомендуется всегда экспортировать функции модуля по отдельности, указывая полное имя.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Импорт файла сценария в виде модуля</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>Импорт файла сценария "{0}" в качестве модуля будет запрещен в режиме ConstrainedLanguage.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Модуль содержит оператор Dot-Source</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>Импорт модуля "{0}" завершится сбоем в ограниченном языковом режиме, так как он экспортирует функции с использованием подстановочных знаков и при этом использует оператор dot-source.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"Функции, экспортируемые модулем</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>Модуль "{0}" экспортирует функции с использованием подстановочных знаков в именах. Имена всех функций вложенных модулей будут удалены при работе в ограниченном языковом режиме.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"Командлет New-Module</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Для нового модуля из недоверенного сеанса ограниченного языка будет заблокировано предоставление блока сценария FullLanguage.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"Несовместимые языковые режимы модуля</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Загружается зависимый модуль с языковым режимом, отличным от режима родительского модуля. В ограниченном языковом режиме это будет запрещено.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/PSConfigurationStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/PSConfigurationStrings.ru.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>Windows PowerShell перестал работать из-за проблемы безопасности: Не удается прочитать файл конфигурации: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/PathUtilsStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/PathUtilsStrings.ru.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>Кодирование "UTF-7" устарело. Используйте UTF-8.</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>Файл {0} уже существует, и указан {1}.</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Невозможно открыть файл, поскольку текущий поставщик ({0}) не может открывать файлы.</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Невозможно выполнить операцию, так как путь разрешается в несколько файлов. Эта команда не может работать с несколькими файлами.</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Невозможно выполнить операцию, так как путь с подстановочными знаками {0} не разрешен в файл.</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>Неизвестное кодирование {0}; допустимые значения — {1}.</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>Каталог "{0}" уже существует.  Используйте параметр Force, если хотите перезаписать каталог и файлы в нем.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>Путь к пользовательскому модулю не существует, поэтому невозможно создать папку модуля для указанного имени модуля "{0}".</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>Не удается создать модуль {0} по следующей причине: {1}. Используйте другой аргумент для параметра -OutputModule и повторите попытку.</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>Не удается загрузить модуль, так как он был создан с помощью несовместимой версии командлета {0}. Создайте модуль с помощью командлета {0} из текущего сеанса и попробуйте загрузить модуль еще раз.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/RemotingErrorIdStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/RemotingErrorIdStrings.ru.resx
@@ -1471,7 +1471,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>Переданный набор потоков вывода недопустим. В качестве потока вывода поддерживается только {0}.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>Предоставленные данные WSMAN_SENDER_DETAILS недействительны. Не удается обработать значение WSMAN_SENDER_DETAILS, равное нулю.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
     <value>Указанный контекст оболочки недействителен.</value>
@@ -1498,7 +1498,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>Подключаемый модуль PowerShell не распознает параметр {0}. Убедитесь, что клиент совместим с сборкой {1} и версией протокола {2} PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>От клиента ожидается параметр с именем {0}. Убедитесь, что клиент совместим с сборкой {1} и версией протокола {2} PowerShell.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
     <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Подключаемый модуль PowerShell не поддерживает версию протокола {2}, запрошенную клиентом.&lt;/PSProtocolVersionError&gt;</value>
@@ -1507,7 +1507,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>При передаче контекста службе WSMan в подключаемом модуле PowerShell произошла неустранимая ошибка.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>Не удалось создать сеанс управляемого сервера.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
     <value>При регистрации дескриптора ожидания для уведомления о завершении работы в подключаемом модуле PowerShell произошла неустранимая ошибка.</value>

--- a/src/System.Management.Automation/resources/ru/RunspaceStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/RunspaceStrings.ru.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>Указанное состояние пространства выполнения недопустимо для этой операции.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>Не удается открыть пространство выполнения, так как оно не находится в состоянии BeforeOpen. Текущее состояние пространства выполнения: "{0}".</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Не удается выполнить операцию, так как пространство выполнения не находится в состоянии "Открыто". Текущее состояние пространства выполнения: "{0}".</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Не удается вызвать конвейер, так как пространство выполнения не находится в состоянии "Открыто". Текущее состояние пространства выполнения: "{0}".</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>Состояние конвейера недопустимо для этой операции.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>Не удается вызвать конвейер, так как он уже был вызван.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>Допустимое значение параметра — PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>Конвейер не содержит команды.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>Конвейер не был запущен, так как уже выполняется другой конвейер. Конвейеры не могут выполняться одновременно.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>Вложенный конвейер не может быть вызван асинхронно. Используйте вызов метода.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>Вложенный конвейер следует запускать только из выполняющегося конвейера.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>Пространство выполнения невозможно закрыть, пока выполняется вызов метода SessionStateProxy.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>Конвейер невозможно вызвать, пока выполняется вызов метода SessionStateProxy.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Выполняется вызов метода SessionStateProxy. Параллельные вызовы метода SessionStateProxy не разрешены.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Конвейер уже выполняется. Параллельные вызовы метода SessionStateProxy не разрешены.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Это свойство не может быть изменено после открытия пространства выполнения.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Произошла одна или несколько ошибок при обработке модуля "{0}", указанного в объекте InitialSessionState, который используется для создания этого пространства выполнения. Полный список ошибок см. в свойстве ErrorRecords. Первая ошибка: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>Параметры потока можно изменить, только если используется многопотоковое подразделение (MTA), текущие параметры — UseNewThread или UseCurrentThread, а новое значение — ReuseThread.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>{0} не может иметь значение false, если языковой режим — {1} или {2}.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>Невозможно отключить пространство выполнения, доступное только локально.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>Операция подключения не поддерживается в локальных пространствах выполнения.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>Сеанс занят. Подключение к сеансу будет установлено, как только он станет доступным. Чтобы отменить команду Enter-PSSession, нажмите Ctrl-C.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>Не удается выполнить команду. В этой конфигурации сеанса вызов сценария не поддерживается. Это может происходить, если конфигурация сеанса работает в режиме без языка.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>Операции отключения и подключения не разрешается использовать в локальных пространствах выполнения.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>Не удается подключить конвейер, так как пространство выполнения не находится в состоянии "Открыто".  Текущее состояние пространства выполнения: "{0}".</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>Не удается создать RemoteRunspace. Указанный объект RunspacePool недопустим.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>С этим пространством выполнения не связана ни одна отключенная команда.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>Операция отключения не поддерживается на удаленном компьютере. Чтобы поддерживать отключение, на удаленном компьютере должна быть запущена оболочка Windows PowerShell 3.0 или более поздней версии, а также должен использоваться транспорт WSMan.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>Не удается подключить PSSession, так как сеанс не находится в состоянии "Отключено" или недоступен для подключения.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>Параметр не может иметь значение PipelineResultTypes.None или PipelineResultTypes.Output.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>Допустимое значение параметра — PipelineResultTypes.Output или PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>Перенаправление потока отладки не поддерживается на целевом удаленном компьютере.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>Перенаправление детализированного потока не поддерживается на целевом удаленном компьютере.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>Перенаправление потока предупреждения не поддерживается на целевом удаленном компьютере.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>Перенаправление потока информации не поддерживается на целевом удаленном компьютере.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>Вы вошли в сеанс, который занят выполнением команды или сценария.  Выходные данные направляются в задание "{0}", поэтому они не будут отображаться в консоли.  Вы можете дождаться завершения выполнения команды или отменить ее и получить запрос на ввод, нажав Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>Вы вошли в сеанс, который занят выполнением команды или сценария. Выходные данные будут отображаться в консоли.  Вы можете дождаться завершения выполнения команды или отменить ее и получить запрос на ввод, нажав Ctrl-C.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>Вы вошли в сеанс, который сейчас остановлен в точке останова отладки в выполняемой команде или сценарии.  Используйте отладчик командной строки PowerShell, чтобы продолжить отладку.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>Свойство DefaultRunspace должно иметь значение LocalRunspace</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>Статическое свойство PrimaryRunspace можно задать только один раз. Оно уже задано.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/SessionStateStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/SessionStateStrings.ru.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>Невозможно обработать возвращенные сведения, так как сведения, возвращенные методом Start поставщика, относятся к поставщику, отличному от переданного.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>Невозможно обработать возвращенные сведения, так как сведения, возвращенные методом Start поставщика, имеют значение null.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию SetItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции SetItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию ClearItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию InvokeDefaultAction с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции InvokeDefaultAction для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию ItemExists с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции ItemExists для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию IsValidPath с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию IsItemContainer с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию RemoveItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetChildItems с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetChildItems для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetChildNames с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetChildNames для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию RenameItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции RenameItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию NewItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции NewItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию HasChildItems с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию CopyItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции CopyItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetParentPath с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию NormalizeRelativePath с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию MakePath с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetChildName с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию MoveItem с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции MoveItem для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию SetProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции SetProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию ClearProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции ClearProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию NewProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции NewProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию RemoveProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции RemoveProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию CopyProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции CopyProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию MoveProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции MoveProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию RenameProperty с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для RenameProperty для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Не удается получить средство чтения содержимого для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetContentReader для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>Не удается получить модуль записи содержимого для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции GetContentWriter для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>Не удается получить содержимое, так как это каталог: "{0}". Вместо этого используйте "Get-ChildItem".</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>Не удалось записать содержимое, так как это каталог: "{0}".</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>Не осталось журнала расположений, чтобы перейти назад.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>Не осталось журнала расположений, чтобы перейти вперед.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>Элемент BoundedStack пустой.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию ClearContent с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>Не удается очистить содержимое "{0}", так как это каталог. Clear-Content поддерживается только для файлов.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>Не удается получить динамические параметры для операции ClearContent для поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию GetSecurityDescriptor с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>Попытка выполнить операцию SetSecurityDescriptor с поставщиком "{0}" для пути "{1}" не удалась. {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>Попытка выполнить операцию Start с поставщиком "{0}" не удалась. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>Попытка выполнить операцию InitializeDefaultDrives с поставщиком "{0}" не удалась.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>Попытка выполнить операцию NewDrive с поставщиком "{0}" для диска с корнем "{1}" не удалась. {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>Не удается получить динамические параметры для NewDrive для поставщика "{0}". {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>Сбой вызова RemoveDrive с поставщиком "{0}". {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>Невозможно удалить диск "{0}", так как это запрещено поставщиком "{1}".</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>Путь "{0}" указывал на элемент, расположенный за пределами базы '{1}'.</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Сбой вызова Seek в модуле записи содержимого поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>Сбой вызова Close в модуле чтения или записи содержимого поставщика "{0}" для пути "{1}". {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>Сбой вызова Read в модуле чтения содержимого поставщика "{0}" для пути "{1}". {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>Сбой вызова Write в модуле записи содержимого поставщика "{0}" на пути "{1}". {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>Поставщик "{0}" нельзя использовать для получения или задания данных с помощью синтаксиса переменных. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>Синтаксис переменных нельзя использовать для получения или задания данных в поставщике. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>Псевдоним не подлежит записи, так как псевдоним {0} является константой или доступен только для чтения, и запись в него не может быть выполнена.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>Невозможно записать в функцию {0}, так как она доступна только для чтения или является константой.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>Невозможно перезаписать переменную {0}, так как она доступна только для чтения или является константой.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>Невозможно получить доступ к переменной "${0}", так как это частная переменная.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>Невозможно получить доступ к команде "{0}", так как это частная команда.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>Невозможно получить доступ к команде, так как это частная команда.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>Невозможно получить доступ к ресурсу состояния сеанса, так как это частный ресурс. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>Псевдоним не был удален, так как псевдоним {0} является константой или доступен только для чтения.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>Невозможно удалить функцию {0}, так как она является константой.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>Невозможно удалить переменную {0}, так как она является константой или доступна только для чтения. Если переменная доступна только для чтения, повторите операцию, указав параметр Force.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>Невозможно изменить псевдоним {0}, так как он является константой.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>Псевдоним {0} нельзя изменить, поскольку он доступен только для чтения.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>Невозможно изменить функцию {0}, так как она является константой.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>Невозможно изменить функцию {0}, так как она доступна только для чтения.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>После создания псевдоним {0} нельзя сделать константой. Псевдонимы можно делать константами только при создании.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>Существующую функцию {0} нельзя сделать константой. Функции можно делать константами только при создании.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>Существующую переменную {0} нельзя сделать константой. Переменные можно сделать константами только при создании.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>Параметр AllScope нельзя удалить из псевдонима "{0}".</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>Параметр AllScope нельзя удалить из функции "{0}".</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>Параметр AllScope нельзя удалить из переменной "{0}".</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>Определение функции "{0}" содержало квалификатор области, но не содержало имени функции.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>Не удается удалить поставщика {0}. Перед удалением поставщика {0} необходимо удалить все диски, связанные с поставщиком {0}.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>Невозможно обработать имя диска, так как оно содержит один или несколько следующих недопустимых символов: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>Не удалось создать новый диск, так как поставщик не разрешает создание нового диска.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>Указанное значение "{0}" разрешено в более чем один стек расположений.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>Не удается найти стек расположений "{0}". Он не существует или не является контейнером.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>не удается найти путь "{0}", поскольку он не существует.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>Невозможно найти псевдоним, так как псевдоним "{0}" не существует.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>Невозможно задать расположение, так как путь "{0}" был разрешен в несколько контейнеров. Можно задать расположение только для одного контейнера за раз.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>Невозможно обработать переменную, так как путь к переменной "{0}" разрешается в несколько элементов. Получать или задавать значение переменной можно только для одного элемента за раз.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>Не удается найти диск. Диск с именем "{0}" не существует.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>Не удается найти поставщика с именем "{0}".</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>Не удается найти поставщика с именем "{0}". Имя указано в неправильном формате. Имя поставщика может содержать только буквенно-цифровые символы или имя оснастки PowerShell, за которым следует один символ "\", а затем буквенно-цифровые символы.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>"{0}" разрешается в несколько имен поставщиков. Возможные совпадения:{1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Произошла ошибка при попытке создать экземпляр поставщика. Имя типа поставщика "{0}" не найдено в сборке.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>Указанное имя поставщика "{0}" нельзя использовать, так как оно содержит один или несколько следующих недопустимых символов: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>Произошла ошибка при попытке создать экземпляр поставщика "{0}". {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>Не удается найти переменную с именем "{0}".</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>Не удается найти источник трассировки с именем "{0}".</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>Диск с именем "{0}" уже существует.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>Переменная с именем "{0}" уже существует.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>Псевдоним недопустим, так как псевдоним с именем "{0}" уже существует.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>Невозможно зарегистрировать поставщика командлетов, так как поставщик командлетов с именем "{0}" уже существует.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>Путь не указывал на путь файловой системы.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>Нельзя удалить глобальную область.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>Число области "{0}" превышает количество активных областей.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>Невозможно сравнить PSDriveInfo. Экземпляр PSDriveInfo можно сравнивать только с другим экземпляром PSDriveInfo.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Поставщик командлетов не может передавать результаты в виде потока, так как не указан командлет, через который следует передавать выходные данные.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Поставщик командлетов не может передавать результаты в виде потока, так как не указан командлет, через который следует передавать ошибку.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>Не задано домашнее расположение для этого поставщика. Чтобы задать домашнее расположение, вызовите "(get-psprovider '{0}').Home = 'path'".</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>Неправильный формат пути. Пути поставщика должны содержать идентификатор поставщика, за которым следует "::", а затем путь, относящийся к конкретному поставщику.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>Невозможно переместить элемент, так как путь назначения может быть разрешено только в один путь.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>Невозможно переместить элемент, так как исходный путь и путь назначения не были разрешены в одинаковый поставщик.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>Невозможно переместить элемент, так как исходный путь указывает на один или несколько элементов, а путь назначения не является контейнером. Убедитесь, что путь назначения является контейнером, и повторите попытку.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>Невозможно переместить элемент, так как назначение разрешено в несколько путей. Укажите путь назначения, который разрешается в одно назначение, и повторите попытку.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>Невозможно скопировать контейнер в существующий конечный элемент.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>Невозможно скопировать контейнер в другой контейнер. Параметр -Recurse или -Container не указан.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>Исходный путь и путь назначения не разрешились в одинаковый поставщик.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>Невозможно переименовать элемент, так как путь разрешен в несколько элементов. Можно переименовать только один элемент за раз.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>Поставщик "{0}" нельзя использовать для разрешения пути "{1}" из-за ошибки в поставщике.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>Невозможно использовать интерфейс. Интерфейс IContentCmdletProvider не реализован этим поставщиком.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>Невозможно использовать интерфейс. Интерфейс IPropertyCmdletProvider не поддерживается этим поставщиком.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>Невозможно использовать интерфейс. Интерфейс IDynamicPropertyCmdletProvider не реализован этим поставщиком.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>Методы NavigationCmdletProvider не поддерживаются этим поставщиком.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Методы поставщика не обработаны. Методы ContainerCmdletProvider не поддерживаются этим поставщиком.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>Невозможно вызвать методы. Методы ItemCmdletProvider не поддерживаются этим поставщиком.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>Методы DriveCmdletProvider не поддерживаются этим поставщиком.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>Операция поставщика остановлена, так как этот поставщик не поддерживает ее.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>Операция поставщика остановлена, так как поставщик не поддерживает параметр "Depth".</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>Невозможно вызвать метод. Метод Seek для содержимого не поддерживается этим поставщиком.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>Не удается выполнить операцию ClearContent. Операция ClearContent не поддерживается этим поставщиком.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>Поставщик не поддерживает использование учетных данных. Повторите операцию, не указывая учетные данные.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>Поставщик FileSystem поддерживает учетные данные только в командлете New-PSDrive. Повторите операцию, не указывая учетные данные.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>Поставщик не поддерживает транзакции. Выполните операцию еще раз без параметра -UseTransaction.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>Невозможно вызвать метод. Поставщик не поддерживает использование фильтров.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>Не удается создать диск. Поставщик не поддерживает использование учетных данных.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>Элемент в пути "{0}" уже существует.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>Невозможно скопировать элемент. Элемент на пути "{0}" не существует.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>Элемент на пути "{0}" не существует.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Диск, содержащий представление псевдонимов, хранящихся в состоянии сеанса</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>Диск, содержащий представление переменных сред процесса</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Диск, содержащий представление функций, хранящихся в состоянии сеанса</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Диск, содержащий представление тех переменных, которые хранятся в состоянии сеанса</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Диск, сопоставляемый с путем к временному каталогу текущего пользователя</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>Невозможно создать связь "{0}", так как не указано целевое значение.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Ссылки на переменную null всегда возвращают значение null. Присваивания не имеют эффекта.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Максимальное число объектов журнала, сохраняемых в сеансе</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>Невозможно переименовать функцию, так как функция {0} доступна только для чтения или является константой.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>Невозможно переименовать псевдоним, так как псевдоним {0} доступен только для чтения или является константой.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>Невозможно переименовать переменную, так как переменная {0} доступна только для чтения или является константой.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>Не удается задать параметры для локальной переменной {0}. Используйте New-Variable, чтобы создать переменную, для которой можно задать параметры.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Командлет {0} нельзя изменить, поскольку он доступен только для чтения.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>Невозможно удалить переменную {0}, так как она оптимизирована и не подлежит удалению. Попробуйте использовать командлет Remove-Variable (без псевдонимов) или вызвать с использованием точки команду, которую используете для удаления переменной.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>Невозможно перезаписать переменную {0}, так как она была оптимизирована. Попробуйте использовать командлет New-Variable или Set-Variable (без псевдонимов) либо вызвать, с использованием точки, команду, которой задаете переменную.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>Параметры {0} и {1} нельзя использовать вместе. Укажите только один из этих параметров.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Параметр Tail сейчас поддерживается только для поставщика FileSystem.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>Псевдоним недопустим, так как команда с именем "{0}" и типом команды "{1}" уже существует.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>Не удается запустить программное обеспечение. Разрешение отклонено.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>Параметры "-{0}" и "-{1}" являются взаимоисключающими, то есть не могут быть указаны одновременно.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>Путь "{0}" недопустим. В операциях удаленного копирования поддерживаются только абсолютные пути.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>Невозможно проверить удаленный путь "{0}".</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>Невозможно выполнить операцию, так как для сеанса {0} задано значение {1}.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>Параметр "{0}" не может быть пустым или иметь значение null.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Переменные состояния сеанса</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>В режиме ConstrainedLanguage будет запрещено устанавливать или изменять значение AllScope для области переменной "{0}".</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/ru/TransactionStrings.ru.resx
+++ b/src/System.Management.Automation/resources/ru/TransactionStrings.ru.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>Невозможно использовать транзакцию. Нет активных транзакций.</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>Невозможно зафиксировать транзакцию. Нет активных транзакций.</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>Невозможно выполнить откат транзакции, так как нет активной транзакции.</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>Невозможно откатить транзакцию. Транзакция уже зафиксирована.</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>Невозможно зафиксировать транзакцию. Транзакция уже зафиксирована.</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Невозможно зафиксировать транзакцию. Выполнен откат транзакции, или время ожидания истекло.</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>Невозможно откатить транзакцию. Для транзакции уже был выполнен откат или время ожидания истекло.</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>Не удается задать активную транзакцию. Нет созданных транзакций.</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>Не удается задать активную транзакцию. Для активной транзакции был выполнен откат или время ожидания истекло.</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>Для данного командлета необходима действующая транзакция. Для текущей транзакции уже выполнен откат или ее зафиксировано.</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>Для этого командлета требуется транзакция. Выполните команду еще раз с параметром -UseTransaction.</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>Невозможно использовать транзакцию. Нет запущенных транзакций.</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>Невозможно использовать транзакцию. Транзакция зафиксирована.</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>Невозможно использовать транзакцию. Выполнен откат транзакции, или время ожидания истекло.</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>Невозможно использовать транзакцию. Время ожидания транзакции истекло.</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>Базовая транзакция не задана.</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>Базовая транзакция неактивна.</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>Базовую транзакцию нельзя задать после создания других транзакций.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/Authenticode.tr.resx
+++ b/src/System.Management.Automation/resources/tr/Authenticode.tr.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>Bu yazılımı şimdi çalıştırmamayı seçtiğiniz için dosya {0} yüklenemiyor.</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>Bu yayımcının yazılımını hiçbir zaman çalıştırmamayı seçtiğiniz için dosya {0} yüklenemiyor.</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>Dosya {0}, {1} tarafından yayımlanmış. Bu yayımcıya sisteminizde açıkça güvenilmiyor. Betik sistemde çalıştırılmayacak. Daha fazla bilgi için "get-help about_signing" komutunu çalıştırın.</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>Bu sistemde betiklerin çalıştırılması devre dışı bırakıldığından dosya {0} yüklenemiyor. Daha fazla bilgi için https://go.microsoft.com/fwlink/?LinkID=135170 adresindeki about_Execution_Policies sayfasına bakın.</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>Dosya {0} yüklenemiyor. {1}.</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>İşlemi, Grup İlkesi kullanılarak oluşturulanlar gibi yazılım kısıtlama ilkeleri tarafından engellendiğinden dosya {0} yüklenemiyor.</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>İçeriği okunamadığından dosya {0} yüklenemiyor.</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>Kod imzalanamıyor. Belirtilen sertifika kod imzalama için uygun değil.</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>Kod imzalanamıyor. Zaman damgası sunucusu URL'si tam olarak belirtilmeli ve http://&lt;server url&gt; veya https://&lt;server url&gt; biçiminde olmalıdır.</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>Kod imzalanamıyor. Karma algoritması desteklenmiyor.</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>Bu güvenilmeyen yayımcının yazılımını çalıştırmak istiyor musunuz?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>Dosya {0}, {1} tarafından yayımlanmış ve sisteminizde dosyaya güvenilmiyor. Yalnızca güvenilir yayımcıların betiklerini çalıştırın.</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>Yazılım {0} bilinmeyen bir yayımcı tarafından yayımlanmış. Bu yazılımı çalıştırmamanız önerilir.</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>Güvenlik uyarısı</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>Yalnızca güvendiğiniz betikleri çalıştırın. İnternet'ten gelen betikler kullanışlı olabildiği gibi bilgisayarınıza zarar da verebilir. Bu betiğe güveniyorsanız betiğin bu uyarı iletisi olmadan çalışmasına izin vermek için Unblock-File cmdlet'ini kullanın. {0} betiğini çalıştırmak istiyor musunuz?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>Hiçb&amp;ir zaman çalıştırma</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>Bu yayımcının betiğini şimdi çalıştırma ve gelecekte bu betiği çalıştırmam için bana sorma. Gelecekte bu betiği çalıştırma girişimleri sessizce başarısız olur.</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>Ç&amp;alıştırma</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Bu yayımcının betiğini şimdi çalıştırma ve gelecekte bu betiği çalıştırmam için bana sormaya devam et.</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>&amp;Bir kez çalıştır</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>Bu yayımcının betiğini şimdi çalıştır ve gelecekte bu betiği çalıştırmam için bana sormaya devam et.</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>&amp;Her zaman çalıştır</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>Bu yayımcının betiğini şimdi çalıştır ve gelecekte bu betiği çalıştırmam için bana sorma.</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>&amp;Askıya Al</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>Geçerli işlem hattını duraklatın ve komut istemine dönün. İşiniz bittiğinde işlemi sürdürmek için exit yazın.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/CredUI.tr.resx
+++ b/src/System.Management.Automation/resources/tr/CredUI.tr.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>PowerShell kimlik bilgisi isteği </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>Kimlik bilgilerinizi girin. </value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>Kimlik bilgilerinizi girin.</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>Başlığın maksimum uzunluğu {0} karakterdir.</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>İletinin maksimum uzunluğu {0} karakterdir.</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>UserName değerinin maksimum uzunluğu {0} karakterdir.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/DebuggerStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/DebuggerStrings.tr.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>'${0}' üzerinde değişken kesme noktası ({1} erişimi)</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>'{0}:${1}' üzerinde değişken kesme noktası ({2} erişimi)</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>'{0}:{1}' üzerinde satır kesme noktası</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>'{0}:{1}, {2}' üzerinde satır kesme noktası</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>'{0}' üzerinde komut kesme noktası</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>'{0}:{1}' üzerinde komut kesme noktası</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>{0} kesme noktasına isabet edilmeyecek</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Tek adım (işlevlere, betiklere vb. gir)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}, {1,-16} Sonraki deyime geç (işlevlerin, betiklerin vb. üzerinden adımla)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}, {1,-16} Geçerli işlevin, betiğin vb. dışına çık.</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}, {1,-16} İşlemi sürdür</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}, {1,-16} İşlemi durdur ve hata ayıklayıcıdan çık</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}, Get-PSCallStack Çağrı yığınını görüntüle</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}, {1,-16} Geçerli betik için kaynak kodu listele.  </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     Geçerli satırdan başlamak için "list" kullanın, "list &lt;m&gt;"  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     &lt;m&gt; satırından başlamak için ve &lt;n&gt; öğesini listelemek için "list &lt;m&gt; &lt;n&gt;" </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     &lt;m&gt; satırından başlayarak</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             Son komut {0}, {1} veya {2} ise tekrarla</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}, {1,-16} bu yardım iletisini görüntüler.</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>Hata ayıklayıcı isteminizi özelleştirmeyle ilgili yönergeler için "help about_prompt" yazın.</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+Geçerli oturum hata ayıklamayı desteklemiyor; işlem devam edecek.
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: satır {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>Kullanılabilir kaynak kodu yok.</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>Başlangıç satırı, {0} değerinden büyük olmayan pozitif bir tam sayı olmalıdır</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>Satır sayısı pozitif bir tamsayı olmalıdır.</value>
   </data>
   <data name="NoFile" xml:space="preserve">
-    <value>&lt;No file&gt;</value>
+    <value>&lt;Dosya yok&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>{0} konumunda, {1}: satır {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>Hata ayıklayıcı, Durduruldu durumunda olmadığı sürece komutları işleyemez.</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>SetDebugAction yerel betik hata ayıklayıcısı için uygulanmadı.</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>Uzak oturumdaki hata ayıklayıcı Durduruldu durumunda olmadığından, hata ayıklayıcısı bir sürdürme eylemi ayarlayamıyor.</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>Hata ayıklayıcısı şu anda meşgul olduğundan işte hata ayıklanamıyor.</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>Sağlanan iş ve tüm alt işler incelendi ancak hata ayıklanabilecek iş bulunamadı.  Bir iş veya alt işte hata ayıklamak için işin hata ayıklamayı desteklemesi ve çalışır durumda olması gerekir.</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>Hata ayıklayıcı, hata ayıklama modu None olarak ayarlandığında kapalı olduğu için adım modu için etkinleştirilemiyor.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>Konak hata ayıklayıcısı şu anda meşgul olduğundan Çalışma alanında hata ayıklanamıyor.</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>Çalışma alanında hata ayıklanamıyor. Çalışma alanı hata ayıklayıcısı şu anda kapalı (DebugMode değeri 'None').</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>Açık durumda olmayan bir Çalışma alanında hata ayıklanamıyor. Bu Çalışma alanının durumu {0}.</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>Çalışma alanında hata ayıklanamıyor. Çalışma alanı {0} ile ilişkili bir hata ayıklayıcı yok.</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>Hata ayıklayıcı zaten geçersiz kılınmış.</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>Hata ayıklayıcı nesnesi kendisi üzerine gönderilemez.</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>{0} komutu, uzak çalışma alanında çalışan PowerShell sürümünde uzak kullanım için desteklenmiyor.</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>İşlem</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}, {1,-16} İşleme devam et ve hata ayıklayıcıyı ayır.</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>Hata ayıklayıcı ayırma komutu uygulanamaz.  Ayırma komutu yalnızca Debug-Job veya Debug-Runspace cmdlet'leriyle işlerde ve çalışma alanlarında hata ayıklanırken geçerlidir.</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>Geçersiz çalışma alanı kimliği: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>Çalışma alanı alınamıyor.</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>Breakpoint veya BreakpointList belirtilmelidir.</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>BreakpointList, kesme noktası olmayan bir öğe içeriyordu.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/EtwLoggingStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/EtwLoggingStrings.tr.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>{0} komutu: {1}.</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>{0} altyapı durumu {1} olarak değiştirildi.</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>Tam Hata Kimliği = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>Hata İletisi = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>Önerilen Eylem = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>Yürütme İlkesi</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>İş Komutu = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>İş Kimliği = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>İş Örneği Kimliği = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>İş Yeri = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>İş Adı = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>İş Durumu = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        Komut Adı = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        Komut Yolu = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        Komut Türü = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        Altyapı Sürümü = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        Konak Kimliği = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        Ana Bilgisayar Adı = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        Konak Uygulama = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        Konak Sürümü = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        İşlem Hattı Kimliği = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        Çalışma Alanı Kimliği = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        Betik Adı = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        Sıra Numarası = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        Önem derecesi = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
-    <value>        Shell ID = </value>
+    <value>        Kabuk Kimliği = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        Saat = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        Kullanıcı = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        Bağlı Kullanıcı = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>NULL İş</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>Sağlayıcı adı</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>{0} sağlayıcısı durumu {1} olarak değiştirdi.</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>Betik yürütme: {0}.</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>{1} olan {0} değişkeni {2} olarak değiştirildi.</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>{0} değişkeni {1} olarak değiştirildi.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/ExperimentalFeatureStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/ExperimentalFeatureStrings.tr.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>'{0}' adıyla eşleşen deneysel özellik bulunamadı.</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>Deneysel özellikleri etkinleştirme ve devre dışı bırakma işlemleri, PowerShell bir sonraki kez başlatılana kadar etkili olmaz.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/ExtendedTypeSystem.tr.resx
+++ b/src/System.Management.Automation/resources/tr/ExtendedTypeSystem.tr.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>“{0}" üyesi zaten var.</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>Genişletilmiş tür veri dosyasından "{0}" boyut üyesi zaten mevcut.</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>“{0}" üyesi mevcut değil.</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>“{0}" özelliğini ayarlarken özel durum oluştu: "{1}”</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>“{0}" alınırken özel durum oluştu: "{1}”</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>Aşağıdaki özel durum, koleksiyon numaralandırılırken oluştu: "{0}".</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>“{0}" üyesine PSObject dışında erişilemez.</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>Tür yapılandırmasından oluşturulan üye değiştirilemiyor: "{0}”</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>“{0}" üye adı ayrılmıştır.</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin türünü alamıyor.</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>“{0}" araması sırasında "{1}" bağımsız değişkeniyle özel durum oluştu: "{2}”</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>“{1}” türündeki bir nesnenin içeriğini ayıklamak için “{0}” çağrılmaya çalışılırken özel durum oluştu: “{2}”</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>“{0}" için ve bağımsız değişken sayısı "{1}" için bir aşırı yükleme bulunamadı.</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>“{0}" için "{1}" tür parametreleri ve bağımsız değişken sayısı "{2}" ile uygun bir genel metot aşırı yüklemesi bulunamadı.</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>“{0}" ve bağımsız değişken sayısı "{1}" için birden çok belirsiz aşırı yükleme bulundu.</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>“{0}" bağımsız değişkeni, "{1}" değeriyle, "{2}" için "{3}" türüne dönüştürülemez: "{4}”</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>“{0}" özelliğinin get erişimcisi kullanılamaz.</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>“{0}" özelliğinin Set erişimcisi kullanılamaz.</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>Ayarlayıcı metot genel, void, statik olmalı ve iki parametreye sahip olmalıdır. İlk parametre PSObject türünde olmalıdır. Alıcı metot da kullanılabiliyorsa ikinci bir parametre gerekir ve alıcı metodun dönüş türüyle aynı türe sahip olmalıdır.</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>Alıcı metot genel olmalı, void olmamalı, statik olmalı ve PSObject türünde bir parametreye sahip olmalıdır.</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>CodeProperty bir alıcı veya ayarlayıcı yöntem kullanmalıdır.</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>Yöntem biçimi nedeniyle kod yöntemi oluşturulamıyor. Yöntem public, static olmalı ve PSObject türünde bir parametreye sahip olmalıdır.</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>“{0}" adlı diğer ad bir tekil anket içeriyor.</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>“{0}" değerinin "{1}" türünden "{2}" türüne dönüştürülmesi mümkün değil.</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>“{0}" değerinin türü "{1}" türüne dönüştürülemiyor.</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>“{0}" değerini "{1}" türüne dönüştürülemiyor. Hata: "{2}"</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>“{0}" değerini "{1}" türüne dönüştürülemez; çünkü bu numaralandırma için virgüllere izin verilmez.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>“{0}" değerini "{1}" türüne dönüştürülemez; çünkü bu numaralandırma için geçersiz değerler var. Lütfen aşağıdaki numaralandırma değerlerinden birini belirtin ve yeniden deneyin. Olası numaralandırma değerleri "{2}".</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>Geçersiz numaralandırma değerleri nedeniyle null, "{0}" türüne dönüştürülemez. Lütfen aşağıdaki numaralandırma değerlerinden birini belirtin ve yeniden deneyin. Olası numaralandırma değerleri "{1}".</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>null değeri "{0}" türüne dönüştürülemiyor.</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>Değer “{0}” türüne dönüştürülemiyor.  Hata: "{1}"</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>Değer System.String türüne dönüştürülemiyor.</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>Bağımsız değişkende başvuru türü bekleniyor.</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>“{0}" IComparable olmadığı için karşılaştırılamıyor.</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>“{0}" ile "{1}" karşılaştırılamadı. Hata: "{2}"</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>Nesneler aynı türde olmadığından veya “{0}” nesnesi “{2}” öğesini uygulamadığından “{0}” ile “{1}” karşılaştırılamaz.</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>“{0}" değerini "{1}" türüne dönüştürülemez; çünkü en az iki eşleşme bulundu ({2}, {3}) ve bu sabit listesi için yalnızca bir eşleşmeye izin verilir.</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>“{0}" değerini "{1}" türüne dönüştürülemiyor. Boolean parametreler yalnızca boolean değerleri ve $True, $False, 1 veya 0 gibi sayıları kabul eder.</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>“{0}" bir yazma amaçlı özelliktir, bu nedenle özellik değeri alınamıyor.</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>“{0}" salt okunur bir özelliktir.</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>“{0}" ayarlanamıyor çünkü XmlNode özelliklerinin değeri olarak yalnızca dizeler kullanılabilir.</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>“{0}" ayarlanamıyor çünkü yalnızca benzersiz özellikler veya özniteliği olmayan benzersiz yaprak düğümler ayarlanabilir.</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>Bu koleksiyona bir PSProperty veya PSMethod nesnesi eklenemez.</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>“{0}" değiştirilemez.</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>Dize alınırken aşağıdaki özel durum oluştu: "{0}”</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>“{1}” türü için “{0}” alanı veya özelliği, “{2}” alanı veya özelliğinden yalnızca büyük/küçük harf kullanımı bakımından farklıdır. Tür Common Language Specification (CLS) ile uyumlu olmalıdır.</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>Aşağıdaki özel durum, tür adı hiyerarşisi alınırken oluştu: "{0}".</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" üyesi alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>Aşağıdaki özel durum, üyeler alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özelliği için okuma durumu alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özelliği için yazma durumu alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özelliği için tür alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özelliği için dize beyanı alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>“{1}" özelliği için öznitelikler alınırken aşağıdaki özel durum oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" metodu için tanımlar alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özelliği için dize beyanı alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, parametreli özellik "{1}" için tür alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, parametreli özellik "{1}" için okuma durumu alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, parametreli özellik "{1}" için yazma durumu alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, parametreli özellik "{1}" için tanımlar alınırken oluştu: "{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, parametreli özellik "{1}" için dize beyanı alınırken oluştu: "{0}”</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>Türü "{0}" olan PSMemberInfo nesnesi için Value özelliği ayarlanamıyor.</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>Bağımsız değişken: '{0}' bir {1} olmalıdır. Şunu kullanın: {2}.</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>Bağımsız değişken: '{0}' bir {1} olmamalıdır. {2} kullanmayın.</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>Özellik "{0}" bulunamadı.</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>Özellik değerini almak veya kümelemek mümkün değil. “{0}" bağımsız değişkeni "{1}" veya "{2}" türünde olmalıdır.</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>“{0}" özelliğinin değerini ayarlayamıyorum çünkü nesnenin türü "{1}" ve "{2}" değil.</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>“{0}" çağrılırken özel durum oluştu: "{1}”</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>“{0}" geçerli bir sınıf yolu değil.</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} geçerli bir yol değil.</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin değiştirilebilir olup olmadığını belirleyemiyor.</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin alınabilir olup olmadığını belirleyemiyor.</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin değerini alamıyor.</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin değerini ayarlayamıyor.</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>Bağdaştırıcı, "{0}" özelliğinin türünü alamıyor.</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>Bağdaştırıcı, "{0}" öğesinin tür hiyerarşisini alamıyor.</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>Bağdaştırıcı, "{0}" öğesinin özelliklerini alamıyor.</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>Bağdaştırıcı, “{1}” için “{0}” özelliğini alamıyor.</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>“{0}" null değerini döndürdü.</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>‘{0}' özelliği, '{1}' nesnesi için bulunamadı. Ayarlanabilir özellikler şunlardır: {2}.</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>‘{0}' özelliği, '{1}' nesnesi için bulunamadı. Kullanılabilir bir ayarlanabilir özellik yok.</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>“{0}" türünde nesne oluşturulamıyor. {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>Açık genel tür {0} üzerinde statik yöntemler çağrılamaz veya statik özelliklere erişilemez.  Tür parametrelerini belirtin ve yeniden deneyin.  Örneğin, [System.Collections.Generic.HashSet``1]::CreateSetComparer() yerine [System.Collections.Generic.HashSet[int]]::CreateSetComparer() kullanın.</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>Aşağıdaki özel durum, "{1}" özniteliği oluşturulurken oluştu: "{0}”</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>“{0}" değeri bir dize dizisine dönüştürülemiyor.</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>Değer “{0}” türüne dönüştürülemiyor. Bu dil modunda yalnızca çekirdek türler desteklenir.</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef benzeri türe "{0}" dönüştürme yapılamaz. ByRef benzeri türler Windows PowerShell'de desteklenmez.</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>“{0}" özelliğini veya alanını ByRef benzeri "{1}" türünden alamaz veya ayarlayamaz. ByRef benzeri türler PowerShell'de desteklenmez.</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>“{1}” ByRef benzeri dönüş türünün “{0}” yöntemi çağrılamıyor. ByRef benzeri türler PowerShell'de desteklenmez.</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>ByRef benzeri türe sahip bir örnek oluşturulamıyor: "{0}” ByRef benzeri türler Windows PowerShell'de desteklenmez.</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Genişletilmiş Tür Sistemi Hashtable Dönüşümü</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>HashTable'dan '{0}' türüne dönüştürme, ConstrainedLanguage modunda izin verilmeyecektir.</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>Genişletilmiş Tür Sistemi Hashtable Dönüşümü</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>KısıtlanmışDil modunda '{0}' türünden '{1}' türüne dönüştürmeye izin verilmeyecek.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/Metadata.tr.resx
+++ b/src/System.Management.Automation/resources/tr/Metadata.tr.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>“{0}" için "{1}" özellikleri başlatılamıyor</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>"{0}" türü, parametrenin maksimum ve minimum sınırlarıyla aynı türde ({1}) olmadığından bağımsız değişken doğrulanamıyor. Bağımsız değişkenin  {1}  türünde olduğundan emin olun ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>‘{0}' bağımsız değişkeni, değeri sıfırdan büyük olmadığı için doğrulanamıyor.</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>“{0}" bağımsız değişkeni doğrulanamıyor çünkü değeri sıfıra eşit veya sıfırdan büyük değil.</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>“{0}" bağımsız değişkeni, değeri sıfırdan küçük olmadığı için doğrulanamıyor.</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>“{0}" bağımsız değişkeni doğrulanamıyor çünkü değeri sıfıra eşit veya sıfırdan küçük değil.</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>Belirtilen en küçük aralık ({0}), belirtilen en büyük aralık ({1}) ile aynı türde olmadığı için kabul edilemiyor. Parametre için ValidateRange özniteliğini güncelleştirin.</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>MaxRange ve MinRange parametre türleri kabul edilemez. Her iki parametre de IComparable arabirimini uygulayan nesneler olmalıdır.</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>Belirtilen en büyük aralık, belirtilen en küçük aralıktan küçük olduğu için kabul edilemiyor. Parametre için ValidateRange özniteliğini güncelleştirin.</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>{0} bağımsız değişkeni, {1} için izin verilen en büyük aralıktan büyüktür. {1} değerinden küçük veya ona eşit bir bağımsız değişken sağlayın ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>{0} bağımsız değişkeni, {1} için izin verilen en küçük aralıktan küçüktür. {1} değerinden büyük veya ona eşit bir bağımsız değişken sağlayın ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>“{0}" bağımsız değişkeni "{1}" desenine uymuyor. “{1}" ile eşleşen bir bağımsız değişken sağlayın ve komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>ValidateCount özniteliği, dizi olmayan bir parametreye uygulanamaz. Özniteliği parametreden kaldırın veya parametreyi dizi parametresi yapın.</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>Parametre tam olarak {0} değer gerektirir - {1} değer sağlandı.</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>Parametre en az {0} değer ve en fazla {1} değer gerektirir - {2} değer sağlandı.</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>Bir parametre için belirtilen en büyük bağımsız değişken sayısı, belirtilen en küçük bağımsız değişken sayısından azdır. Parametre için ValidateCount özniteliğini güncelleştirin.</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>Belirtilen bağımsız değişken karakter süresi üst sınırı, belirtilen bağımsız değişken karakter süresi alt sınırından kısadır. Parametre için ValidateLength özniteliğini güncelleştirin.</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>ValidateLength özniteliği, dize veya dize[] parametresi olmayan bir parametreye uygulanamaz. Parametreyi dize veya dize[] parametresi yapın.</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>Bağımsız değişkenin karakter süresi ({1}) çok kısa. Uzunluğu "{0}" değerinden büyük veya buna eşit olan bir bağımsız değişken belirtin ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>Bağımsız değişkenin karakter süresi ({1}) çok uzundur. Uzunluğu "{0}" değerinden kısa veya buna eşit olan bir bağımsız değişken belirtin ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>“{0}" bağımsız değişkeni, ValidateSet özniteliği tarafından belirtilen "{1}" kümesine ait değil. Kümede olan bir bağımsız değişken sağlayın ve sonra komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>Geçerli değerler oluşturucu null bir değer geri gönderir.</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>“{0}" özelliğinde "{1}" için başarısız oldu {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>Komut alınamıyor veya çalıştırılamıyor. Bu komut için en fazla parametre kümesi sayısı aşıldı.</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>Bağımsız değişkeni işleyemiyor çünkü bağımsız değişken değeri bir dize değil. ArgumentTransformationAttribute belirtilmiş olan parametre bağımsız değişkenlerinin değerleri dize olmalıdır.</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value> {1}  değeri  {0}  değişkeni için geçerli bir değer olmadığından değişken doğrulanamıyor.</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>{1}  değerine sahip  {0}  değişkeni artık geçerli olmayacağından öznitelik eklenemiyor.</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>Bağımsız değişken null. Bağımsız değişken için geçerli bir değer sağlayın ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>Bağımsız değişken null bir değer içeriyor veya bağımsız değişken koleksiyonundaki bir öğe null bir değer içeriyor. Null değer içermeyen bir koleksiyon sağlayın ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>Bağımsız değişken null veya boş. Null veya boş olmayan bir bağımsız değişken sağlayın ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>Bağımsız değişken null, boş ya da bağımsız değişken koleksiyonundaki bir öğe null değer içeriyor. Null değer içermeyen bir koleksiyon sağlayın ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>Bağımsız değişken null, boş veya yalnızca boşluk karakterlerinden oluşuyor. Boşluk olmayan karakterler içeren bir bağımsız değişken sağlayın ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>Bağımsız değişken koleksiyonundaki bir öğe null, boş ya da yalnızca boşluk karakterlerinden oluşuyor. Null değer içermeyen bir koleksiyon sağlayın ve sonra komutu tekrar deneyin.</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>‘{0}' adlı bir parametre komut için birden çok kez tanımlandı.</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>Parametre diğer adı '{0}' adlı bir diğer ad komut için zaten birden çok kez tanımlandığından belirtilemez.</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>‘{0}' parametresi, '{1}' parametresi için aynı adlı parametre diğer adıyla çakıştığı için belirtilemez.</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>"{0}" değerine sahip bağımsız değişken için "{1}" doğrulama betiği True sonucu döndürmedi. Doğrulama betiğinin neden başarısız olduğunu belirleyin ve ardından komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>“{0}" bağımsız değişkeni geçerli bir Windows PowerShell sürümü içermiyor. Geçerli bir sürüm numarası sağlayın ve sonra komutu yeniden deneyin.</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>'{0}' geçerli bir değişken adı olmadığından bağımsız değişken doğrulanamıyor.</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>İş dönüşüm türü, IAstToScriptBlockConverter'dan türetilmelidir.</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>Yol bağımsız değişkeni geçersiz. Dize türünde bir yol bağımsız değişkeni sağlayın.</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>Yol bağımsız değişkeni sürücü {0}, onaylanmış sürücüler kümesine ait değil: {1}. Onaylanmış bir sürücüye sahip bir yol bağımsız değişkeni sağlayın.</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>Yol bağımsız değişkeni geçersiz karakterler içeriyor.</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>Yol bağımsız değişkeninin kök sürücüsü yok.  Kök sürücüsü olan tam bir yol bağımsız değişkeni sağlayın.</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>‘{0}' parametresi için bağımsız değişken değeri null ya da boş bir dize olamaz.</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>Sabit Listesi üyesi '{0}', '{1}' parametresi için geçerli bir değer değil. Aşağıdaki üyelerden birini belirtin ve yeniden deneyin: {2}.</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>Giriş işlenemiyor. “{0}" bağımsız değişkeni güvenilir değil.</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>ValidateTrustedData Öznitelik Denetimi Hatası</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>“{0}" parametre bağımsız değişkeni güvenilir değil ve Kısıtlanmış Dil modunda ValidateTrustedData parametre özniteliği denetiminde başarısız olacak.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/Modules.tr.resx
+++ b/src/System.Management.Automation/resources/tr/Modules.tr.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından belirtilen '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından '{1}' sürümü ile belirtilen '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>Belirtilen MaximumVersion '{0}' yanlıştı. '*' kullanıyorsanız, MaximumVersion yalnızca bir '*' destekler ve bu karakter her zaman MaximumVersion'ın sonunda yer almalıdır.</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından MaximumVersion '{1}' ile belirtilen '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından MinimumVersion '{1}' ve MaximumVersion '{2}' ile belirtilen '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion '{0}', MaximumVersion '{1}' değerinden büyük olmamalıdır.</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>Bu ada sahip bir derleme bulunamadığından '{0}' derlemesi yüklenmedi. Derleme adını doğrulayın ve yeniden deneyin.</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>'{2}' modül bildiriminin '{1}' alanında listelenen, '{0}' öğesini işleyecek modül, herhangi bir modül dizininde geçerli bir modül bulunamadığından işlenmedi.</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>-AsCustomObject parametresi yalnızca betik modülleriyle kullanılabildiğinden '{0}' modülü için özel nesne döndürülmedi.</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>'{0}' modül bildirimi, geçerli bir PowerShell modül bildirim dosyası olmadığından işlenemedi. İzin verilmeyen öğeleri kaldırın: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>'{0}' modül bildirim dosyasının işlenmesi geçerli bir bildirim nesnesi ile sonuçlanmadı. Dosyayı geçerli bir PowerShell modül bildirimi içerecek şekilde güncelleştirin. Geçerli bir bildirim, New-ModuleManifest cmdlet'i kullanılarak oluşturulabilir.</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>Bildirimi bir veya daha fazla geçersiz üye içerdiğinden '{0}' modülü içeri aktarılamıyor. Geçerli bildirim üyeleri: ({1}). Geçerli olmayan üyeleri ({2}) kaldırın ve ardından modülü yeniden içeri aktarmayı deneyin.</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>Bir modül açıklayan hashtable bir veya daha fazla geçersiz üye içeriyor. Geçerli üyeler: ({0}). Geçerli olmayan üyeleri ({1}) kaldırın, ardından yeniden deneyin.</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>Modül iç içe yerleştirme sınırı aşıldığından '{0}' modülü yüklenemiyor. Modüller yalnızca {1} düzey iç içe yerleştirilebilir. İç içe yerleştirme sınırının aşılmasını önlemek için modülleri yüklediğiniz sırayı değerlendirip değiştirin ve sonra betiğinizi yeniden çalıştırmayı deneyin.</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>'ModuleVersion' üyesi modül bildiriminde yok. Bu üye mevcut olmalı ve üyeye 'n.n.n.n' biçiminde bir sürüm numarası atanmalıdır. Eksik üyeyi '{0}' dosyasına ekleyin.</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>'{2}' modül bildirimindeki '{0}' üyesi geçerli değil: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>'{1}' modülünün '{0}' sürümü, gereken en düşük '{2}' sürümünü karşılamıyor. Sürüm numarasının desteklendiğini doğrulayın ve modülü yeniden yüklemeyi deneyin.</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>Bu bilgisayardaki PowerShell sürümü: '{0}'. '{1}' modülünü çalıştırmak için en düşük PowerShell sürümü '{2}' gerekir. Gerekli en düşük PowerShell sürümünün yüklü olduğunu doğrulayın ve ardından yeniden deneyin.</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>'ModuleToProcess' üyesi ikili bir modülse 'NestedModules' modül bildirimi üyesi kullanılamaz. '{0}' konumundaki modül bildirimi dosyasını düzenleyin ve ardından yeniden deneyin.</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>Modül bildirimindeki '{0}' üyesi geçerli değil: {1}. Lütfen '{2}' dosyasında bu alan için geçerli bir değer belirtildiğini doğrulayın.</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>'{0}' modül bildirim yolu geçerli değil. Path bağımsız değişkeninin değeri, uzantısı '.psd1' olan tek bir dosyaya çözümlenmelidir. Path bağımsız değişkeninin değerini geçerli bir psd1 dosyasına işaret edecek şekilde değiştirin ve ardından yeniden deneyin.</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>'{0}' modül bildirimindeki ModuleVersion anahtarı, '{2}' konumundaki sürüm klasörü adıyla eşleşmeyen '{1}' modül sürümünü belirtiyor. ModuleVersion anahtarının değerini sürüm klasörü adıyla eşleşecek şekilde değiştirin.</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>'{1}' modül bildiriminde belirtilen '{0}' NestedModule girdisi geçersiz. Bu girdiyi geçerli değerlerle güncelleştirdikten sonra yeniden deneyin.</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>'{1}' modül bildiriminde belirtilen '{0}' RequiredAssemblies girdisi geçersiz. Bu girdiyi geçerli değerlerle güncelleştirdikten sonra yeniden deneyin.</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>'{1}' modül bildiriminde belirtilen '{0}' FileList girdisi geçersiz. Bu girdiyi geçerli değerlerle güncelleştirdikten sonra yeniden deneyin.</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>'{1}' modül bildiriminde belirtilen '{0}' RequiredModules girdisi geçersiz. Bu girdiyi geçerli değerlerle güncelleştirdikten sonra yeniden deneyin.</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>'{1}' modül bildiriminde belirtilen '{0}' ModuleList girdisi geçersiz. Bu girdiyi geçerli değerlerle güncelleştirdikten sonra yeniden deneyin.</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>'{0}' modül bildirimi, yalnızca PowerShell '5.1' veya üzeri bir sürümünde desteklenen CompatiblePSEditions anahtarıyla belirtilir. PowerShellVersion anahtarının değerini '5.1' veya üzeri olacak şekilde güncelleştirin ve yeniden deneyin.</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>CompatiblePSEditions için belirtilen '{0}' değeri yinelenen PowerShell Edition adları içeriyor. Yinelenen PowerShell Edition adlarını kaldırdıktan sonra yeniden deneyin.</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>ModuleVersion anahtarında belirtilen sürüm, sürüm klasörü adıyla aynı.</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>Geçerli bir modül bildirim dosyasına sahip olmadığından {1} Modülü altındaki {0} Sürüm klasörü atlanıyor.</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>'ModuleName' üyesi, bu modülü açıklayan karma tabloda yoktur.</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>'ModuleVersion', 'MaximumVersion' ve 'RequiredVersion' üyeleri bu modülü açıklayan karma tabloda yok. Bu üç üyeden biri mevcut olmalı ve ona 'n.n.n.n' biçiminde bir sürüm numarası atanmalıdır.</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>Gerekli '{1}' modülü yüklenmedi. Modülü yükleyin veya '{0}' dosyasındaki 'RequiredModules' içinden modülü kaldırın.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>GUID'si '{2}' olan gerekli '{1}' modülü yüklenmedi. Modülü yükleyin veya '{0}' dosyasındaki 'RequiredModules' içinden modülü kaldırın.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>'{2}' sürümüne sahip gerekli '{1}' modülü yüklenmedi. Modülü yükleyin veya '{0}' dosyasındaki 'RequiredModules' içinden modülü kaldırın.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>MaximumVersion '{2}' değerine sahip gerekli '{1}' modülü yüklenmedi. Modülü yükleyin veya '{0}' dosyasındaki 'RequiredModules' içinden modülü kaldırın.</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>MinimumVersion '{2}' ve MaximumVersion '{3}' değerlerine sahip gerekli '{1}' modülü yüklenmedi. Modülü yükleyin veya '{0}' dosyasındaki 'RequiredModules' içinden modülü kaldırın.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>'{0}' modülü, ModuleVersion '{1}' ile bulunamadı.</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>'{0}' modülü, RequiredVersion '{1}' ile bulunamadı.</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>'{0}' modülü, MaximumVersion '{1}' ile bulunamadı.</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>'{0}' modülü, ModuleVersion '{1}' ve MaximumVersion '{2}' ile bulunamıyor.</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>'{0}' modülü bulunamıyor.</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>Hiçbir modül kaldırılmadı. Kaldırılacak modüllerin belirtiminin doğru olduğunu ve bu modüllerin çalışma alanında bulunduğunu denetleyin.</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>'{1}' modülünden içeri aktarılan '{0}' üyesi şu nedenle kaldırılamıyor: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>'{0}' modülü salt okunur olduğundan kaldırılamıyor. Salt okunur modülleri kaldırmak için komutunuza Force parametresini ekleyin.</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>'{0}' modülü 'constant' olarak işaretlendiğinden kaldırılamıyor. Bir modül 'constant' olarak işaretlendiyse kaldırılamaz.</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>'{0}' modülü '{1}' için gerekli olduğundan kaldırılamıyor. Modülü kaldırmak için komutunuza Force parametresini ekleyin.</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>Export-ModuleMember cmdlet'i yalnızca bir modülün içinden çağrılabilir.</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>'{0}' uzantısı geçerli bir modül uzantısı değil. Desteklenen modül uzantıları şunlardır: '.dll', '.ps1', '.psm1', '.psd1' ve '.cdxml'. Uzantıyı düzeltin ve ardından '{1}' dosyasını yeniden eklemeyi deneyin.</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>Bu işlem ikili modülde gerçekleştirilemez. Yalnızca bir betik modülünde gerçekleştirilebilir.</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>'.ps1' uzantısına sahip olmadığından '{0}' dosyasına izin verilmiyor.</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>Bilinmiyor</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}. Tüm hakları saklıdır.</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>İçeri aktarılan "{0}" işlevi kaldırılıyor.</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>İçeri aktarılan "{0}" diğer adı kaldırılıyor.</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>İçeri aktarılan "{0}" değişkeni kaldırılıyor.</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>Modül, '{0}' yolundan yükleniyor.</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>'{0}', '{1}' yolundan yükleniyor.</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>'{0}' betik dosyası nokta kaynak olarak kullanılıyor.</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>'{0}' işlevi içeri aktarılıyor.</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>'{0}' cmdlet'i içeri aktarılıyor.</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>'{0}' diğer adı içeri aktarılıyor.</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>'{0}' değişkeni içeri aktarılıyor.</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>'{0}' cmdlet'i dışarı aktarılıyor.</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>'{0}' işlevi dışarı aktarılıyor.</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>'{0}' diğer adı dışarı aktarılıyor.</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>'{0}' değişkeni dışarı aktarılıyor.</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>'{0}' modülünden içeri aktarılan bazı komutların adları, onaylanmamış fiiller içeriyor ve bu da komutların bulunmasını zorlaştırabilir. Onaylanmamış fiil içeren komutları bulmak için Import-Module komutunu Verbose parametresiyle yeniden çalıştırın. Onaylanan fiillerin listesi için Get-Verb yazın.</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>'{1}' modülündeki '{0}' komutu içeri aktarıldı, ancak adı onaylanmış bir fiil içermediğinden bulunması zor olabilir. Onaylanan fiillerin listesi için Get-Verb yazın.</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>'{2}' modülündeki '{0}' komutu içeri aktarıldı, ancak adı onaylanmış bir fiil içermediğinden bulunması zor olabilir. Önerilen alternatif fiiller: "{1}".</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>İçeri aktarılan bazı komut adları, şu kısıtlanmış karakterlerden bir veya daha fazlasını içeriyor: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>'{1}' modülündeki '{0}' komut adı, şu kısıtlanmış karakterlerden bir veya daha fazlasını içeriyor: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>"{0}" modülü bildirim dosyası oluşturuluyor.</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (Yol: '{1}')</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>Geçerli işlemci mimarisi: {0}. '{1}' modülü şu mimariyi gerektiriyor: {2}.</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>Geçerli PowerShell konağının adı: '{0}'. '{1}' modülü için gerekli PowerShell konağı: '{2}'.</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>Geçerli PowerShell konağı: '{0}' (sürüm {1}). '{2}' modülünü çalıştırmak için en düşük PowerShell konak sürümü '{3}' gerekir.</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>'{0}' modülü için modül bildirimi</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>Oluşturan: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>{0} tarihinde oluşturuldu</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>Bu bildirimle ilişkilendirilmiş betik modülü veya ikili modül dosyası.</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>RootModule/ModuleToProcess içinde belirtilen modülün iç içe modülleri olarak içeri aktarılacak modüller</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>Bu modülü benzersiz olarak tanımlamak için kullanılan kimlik</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>Bu modülün yazarı</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>Bu modülün şirketi veya satıcısı</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>Bu modül için telif hakkı bildirimi</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>Bu modülün sürüm numarası.</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>Bu modülün sağladığı işlevselliğin açıklaması</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>Bu modülün gerektirdiği PowerShell altyapısının en düşük sürümü</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>Bu modülün gerektirdiği en düşük ortak dil çalışma zamanı (CLR) sürümü. {0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>Bu modül içeri aktarılmadan önce genel ortama aktarılması gereken modüller</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>Bu modül içeri aktarılmadan önce çağıranın ortamında çalıştırılan betik dosyaları (.ps1).</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>Bu modül içeri aktarılırken yüklenecek tür dosyaları (.ps1xml)</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>Bu modül içeri aktarılırken yüklenecek biçim dosyaları (.ps1xml)</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>Bu modül içeri aktarılmadan önce yüklenmesi gereken derlemeler</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>Bu modülle paketlenmiş tüm dosyaların listesi</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>RootModule/ModuleToProcess içinde belirtilen modüle geçirilecek özel veriler. Bu, PowerShell tarafından kullanılan ek modül meta verilerine sahip bir PSData karma tablosu da içerebilir.</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>Bu modüle uygulanan etiketler. Bunlar, çevrimiçi galerilerde modül bulmaya yardımcı olur.</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>Bu proje için ana web sitesinin URL'si.</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>Bu modül lisansının URL'si.</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>Bu modülü temsil eden simgenin URL'si.</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>Bu modülün sürüm notları</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>Bu modülün ön sürüm dizesi</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>Modülün yükleme/güncelleştirme/kaydetme işlemleri için kullanıcıdan açık onay gerektirip gerektirmediğini gösteren bayrak</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>Bu modülün dış bağımlı modülleri</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>{0} hashtable'ın sonu</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>PrivateData parametre değeri, modül bildirimini Tags, ProjectUri, LicenseUri, IconUri veya ReleaseNotes parametre değerleriyle oluşturmak için bir karma tablo olmalıdır. Tags, ProjectUri, LicenseUri, IconUri veya ReleaseNotes parametre değerlerini kaldırın ya da PrivateData içeriklerini bir karma tablo içinde sarmalayın.</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData bir karma tablo olarak tanımlanmalıdır, ancak bu modül bildirimi bunu bir nesne olarak tanımlıyor. Lütfen PrivateData içeriklerini bir karma tablo içinde sarmalamayı deneyin. Bu, daha sonra modül bildirimine Tags, ProjectUri, LicenseUri, IconUri ve ReleaseNotes özelliklerini eklemenizi sağlar.</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>Belirtilen '{0}' değeri geçersiz. Geçerli bir değerle yeniden deneyin.</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>Bu modülden dışarı aktarılacak işlevler için en iyi performansı elde etmek amacıyla joker karakterler kullanmayın ve girdiyi silmeyin. Dışarı aktarılacak işlev yoksa boş bir dizi kullanın.</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>Bu modülden dışarı aktarılacak diğer adlar için en iyi performansı elde etmek amacıyla joker karakterler kullanmayın ve girdiyi silmeyin. Dışarı aktarılacak diğer ad yoksa boş bir dizi kullanın.</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>Bu modülden dışarı aktarılacak cmdlet'ler için en iyi performansı elde etmek amacıyla joker karakterler kullanmayın ve girdiyi silmeyin. Dışarı aktarılacak cmdlet yoksa boş bir dizi kullanın.</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>Bu modülden dışarı aktarılacak değişkenler</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>Bu modülden dışarı aktarılacak DSC kaynakları</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>Desteklenen PSEdition'lar</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>Bu modülün gerektirdiği işlemci mimarisi (None, X86, Amd64)</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>Bu modülle paketlenmiş tüm modüllerin listesi</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>Bu modül için gereken en düşük Microsoft .NET Framework sürümü. {0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>Bu modül için gerekli PowerShell konağının adı</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>Bu modülün gerektirdiği PowerShell konağının en düşük sürümü</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>Bu modülün HelpInfo URI'si</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>{0} modülü geçerli PowerShell oturumunda PSDrive'ı sağladığından, hiçbir modül kaldırılmadı. Geçerli PSDrive sağlayıcısını değiştirin ve ardından modülleri yeniden kaldırmayı deneyin.</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Geçerli kapsamda aynı ada sahip bir üye olduğundan '{0}' cmdlet'i içeri aktarılmadı.</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Geçerli kapsamda aynı ada sahip bir üye olduğundan '{0}' diğer adı içeri aktarılmadı.</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Geçerli kapsamda aynı ada sahip bir üye olduğundan '{0}' işlevi içeri aktarılmadı.</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>Geçerli kapsamda aynı ada sahip bir üye olduğundan '{0}' değişkeni içeri aktarılmadı.</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>'{0}' modül bildirimindeki 'ModuleToProcess', 'RootModule' veya 'NestedModules' üyelerinde joker karakterlere izin verilmiyor.</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>'{0}' modülü PowerShell için bir çekirdek modüldür. Çekirdek modülleri kaldırmak için komutunuza Force parametresini ekleyin.</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>Modül bildirimi hem 'ModuleToProcess' hem de 'RootModule' üyelerini içeremez. Modül bildirimi dosyasını değiştirerek '{0}' konumundaki bu üyelerden birini kaldırın ve ardından yeniden deneyin.</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>'ModuleToProcess' modül bildirimi üyesi kullanım dışı bırakıldı. Bunun yerine 'RootModule' üyesini kullanın.</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>Bu modülden dışarı aktarılan komutlar için varsayılan ön ek. Varsayılan ön eki Import-Module -Prefix kullanarak geçersiz kılın.</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>'Global' ve 'Scope' parametreleri birlikte belirtilemez. Bu parametrelerden birini kaldırın ve ardından komutu yeniden çalıştırmayı deneyin.</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>Gerekli '{0}' modülü yüklenmedi. '{0}' modülü, '{2}' modül bildiriminde döngüsel bağımlılığa işaret eden requiredModule '{1}' içeriyor.</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından gerekli '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>{0} modülündeki bazı komutlar CimSession üzerinden içeri aktarılamıyor. Tüm komutları almak için uzak sunucuda PowerShell uzaktan yönetiminin etkin olduğunu doğrulayın ve ardından Import-Module cmdlet'ine PSSession parametresini eklemeyi deneyin.</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>{0} modülü, {1} uzaktan iletişim oturumu kullanılarak Windows PowerShell'de yüklenir. Lütfen bu modüldeki tüm komut giriş ve çıkışlarının seri durumdan çıkarılmış nesneler olacağını unutmayın. Bu modülü PowerShell'e yüklemek istiyorsanız lütfen 'Import-Module -SkipEditionCheck' söz dizimini kullanın.</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>Windows PowerShell sürümü {0} algılandı. Windows PowerShell uyumluluk özelliğini kullanarak modülleri yüklemek için Windows PowerShell 5.1 gerekir. Bu özelliği etkinleştirmek için https://aka.ms/WMF5Download adresinden Windows Management Framework (WMF) 5.1 yükleyin.</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>'{0}' modülünün, PowerShell yapılandırma dosyasındaki 'WindowsPowerShellCompatibilityModuleDenyList' ayarı tarafından Windows PowerShell uyumluluk özelliği kullanılarak yüklenmesi engellendi.</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>{0} modülü CimSession üzerinden içeri aktarılamıyor. Import-Module cmdlet'inin PSSession parametresini kullanmayı deneyin.</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>{0} işlemci mimarisi değeri desteklenmiyor. İşlemci mimarisi için desteklenen şu numaralandırma değerlerinden birini belirterek New-ModuleManifest komutunu yeniden çalıştırın: None, MSIL, X86, Amd64, Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>Get-Module cmdlet'i uzak bilgisayarda çalıştırıldığında yalnızca kullanılabilir modüller listelenebilir. Komutunuza ListAvailable parametresini ekleyin ve ardından yeniden deneyin.</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>'{0}' ek bileşeni zaten içeri aktarıldığından '{0}' modülü içeri aktarılmadı.</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>'{0}' modül bildirimindeki 'RequiredAssemblies' üyesinde joker karakterlere izin verilmiyor.</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>{1} içindeki {0} anahtarının değeri {2} ve modülde iç içe modüller var. CDXML dosyası kök modül olduğunda, iç içe modüllerdeki komutlar dışarı aktarılamadığından Import-Module komutu başarısız olur. CDXML dosyasını NestedModules anahtarına taşıyın ve komutu yeniden deneyin.</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>Uzak komuttaki hata: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>'{0}' uzak modülü için ara sunucular oluşturulamadı. {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>{0} uzak modülü işlenemedi. {1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>Uzak CimSession'dan modül verileri alınamadı. {0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>Herhangi bir modül dizininde geçerli bir modül dosyası bulunamadığından GUID'si '{1}' ve sürümü '{2}' olan gerekli '{0}' modülü yüklenmedi.</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>CIM sunucusunda modül bulmaya yönelik bir CIM sağlayıcısı bulunamadı. {0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>İzin verilen sürümler listesinde yer almadığı için Microsoft .NET Framework sürümü {0} doğrulanamıyor.</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>{0} analiz ediliyor.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>Modüller ilk kullanım için hazırlanıyor.</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>Kullanılabilir modüller aranıyor</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>{0} UNC paylaşımı aranıyor.</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Bir uzak bilgisayarda Get-Module cmdlet’ini çalıştırmak yalnızca yol içermeyen modül adları için yapılabilir. Name parametresi, bir yola çözümlenen şu öğeyi içeriyor: '{0}'. Name parametresini yol öğeleri içermeyecek şekilde güncelleştirin ve sonra yeniden deneyin.</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>Get-Module cmdlet’inin ListAvailable parametresi olmadan çalıştırılması, yol içeren modül adları için desteklenmiyor. Name parametresi, bir yola çözümlenen şu öğeyi içeriyor: '{0}'. Name parametresini yol öğeleri içermeyecek şekilde güncelleştirin ve sonra yeniden deneyin.</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>Belirtilen '{0}' modülü bulunamadı. Name parametresini geçerli bir yola işaret edecek şekilde güncelleştirin ve yeniden deneyin. </value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>RepositorySourceLocation özelliği {0} modülü için dolduruluyor.</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>'{2}' modül bildiriminin '{1}' alanında listelenen, '{0}' öğesini işleyecek modül işlenmedi. {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>Bu önkoşul yalnızca PowerShell Desktop sürümü için geçerlidir.</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>'{0}' modülü, geçerli PowerShell sürümü '{1}' için desteklenmiyor. Desteklenen sürümleri: '{2}'. Bu modülün uyumluluk denetimini yoksaymak için 'Import-Module -SkipEditionCheck' kullanın.</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>'{0}' modülü, PowerShell '{1}' sürümünü destekler ve ayarlar dosyasında devre dışı bırakıldığı için Windows Uyumluluk özelliği kullanılarak örtük olarak yüklenemez. Bu modülü Windows PowerShell ile yüklemek için 'Import-Module -UseWindowsPowerShell' komutunu ya da modülü geçerli PowerShell ile yüklemeyi denemek için 'Import-Module -SkipEditionCheck' komutunu kullanın.</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>Modül bildiriminde tanımlanan deneysel bir özellik için boş olmayan bir dize değeri belirtilmelidir.</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>Bir veya daha fazla geçersiz deneysel özellik adı bulundu: {0}. Modül deneysel özellik adı şu kuralı izlemelidir: 'ModuleName.FeatureName'.</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>-SkipEditionCheck anahtar parametresi, -ListAvailable anahtar parametresi olmadan kullanılamaz.</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage modunda *.ps1 dosyalarının modül olarak içeri aktarılmasına izin verilmiyor.</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>{0} betik modülü, modül bildiriminden farklı bir dil moduna sahip olduğundan betik modülü yüklenirken bir hata oluştu. Bildirim dil modu {1} ve modül dil modu {2}. Tüm modül dosyalarının imzalı olduğundan veya uygulamanızın izin verilenler listesi yapılandırmasının bir parçası olduğundan emin olun.</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>Bu modül, joker karakterler kullanarak işlevleri dışarı aktarırken nokta kaynak işlecini kullanıyor ve sistem uygulama doğrulama zorlaması altındayken buna izin verilmiyor.</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>Modül üyeleri, çalışan oturumdan farklı bir dil moduna sahip bir modülden dışarı aktarılamaz.</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>Oturum ConstrainedLanguage modundayken yeni modül oluşturulamaz.</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>'Core' sürümüyle uyumlu yerleşik '{0}' modülü bulunamıyor. Lütfen PowerShell yerleşik modüllerinin kullanılabilir olduğundan emin olun. Bunlar genellikle PowerShell paketinin içinde, $PSHOME modül yolunun altında yer alır ve PowerShell’in düzgün çalışması için gereklidir.</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
-    <value>Export-ModuleMember Cmdlet</value>
+    <value>Export-ModuleMember Cmdlet'i</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>'{0}' modülü, geçerli '{2}' oturumundan farklı olan '{1}' dil moduna sahip olduğundan modül üyelerinin dışarı aktarılması Kısıtlı Dil modunda başarısız olur.</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>Modül Örtük İşlev Dışarı Aktarma</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>'{0}' modülü güvenilir (Tam Dil modunda çalışıyor) ancak oturum güvenilir olmadığından (Kısıtlı Dil modunda çalışıyor) bu modül için örtük işlev dışarı aktarma işlemi reddedilecek. En iyi uygulama olarak, modül işlevlerini her zaman tam ada göre tek tek dışarı aktarın.</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>Betik Dosyası Modül Olarak İçeri Aktarılıyor</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>'{0}' betik dosyasının modül olarak içeri aktarılmasına ConstrainedLanguage modunda izin verilmeyecek.</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>Modül Nokta Kaynak İşleci İçeriyor</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>'{0}' modülünün içeri aktarılması, joker karakterler kullanırken aynı zamanda nokta kaynak işlecini de kullanarak işlevleri dışarı aktardığından Kısıtlı Dil modunda başarısız olacak.</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"Modül Dışarı Aktaran İşlevler</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>'{0}' modülü, işlevleri ad joker karakterleri kullanarak dışarı aktarır. Kısıtlı Dil modunda çalıştırıldığında iç içe modül işlev adlarının tümü kaldırılır.</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
-    <value>"New-Module Cmdlet</value>
+    <value>"Yeni Modül Cmdlet'i</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>Güvenilmeyen bir Kısıtlı Dil oturumundaki yeni bir modülün FullLanguage betik bloğu sağlaması engellenir.</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"Modül Eşleşmeyen Dil Modları</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>Üst modülden farklı bir dil moduna sahip bağımlı bir modül yükleniyor. Kısıtlı Dil modunda buna izin verilmez.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/PSConfigurationStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/PSConfigurationStrings.tr.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell, bir güvenlik sorunu nedeniyle çalışmayı durdurdu: Yapılandırma dosyası okunamıyor: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/PathUtilsStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/PathUtilsStrings.tr.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>'UTF-7' kodlaması kullanım dışıdır, lütfen UTF-8 kullanın.</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>Dosya {0} zaten var ve {1} belirtildi.</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>Geçerli sağlayıcı ({0}) bir dosya açamadığı için dosya açılamıyor.</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>Yol birden fazla dosyaya çözümlendiği için işlem gerçekleştirilemiyor. Bu komut birden fazla dosya üzerinde çalışamaz.</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>Joker karakter yolu {0} bir dosyaya çözümlenemediği için işlem gerçekleştirilemiyor.</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>Bilinmeyen kodlama {0}; geçerli değerler {1}.</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>‘{0}' dizini zaten var.  Dizini ve dizin içindeki dosyaları üzerine yazmak istiyorsanız -Force parametresini kullanın.</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>Kullanıcı modülü yolu mevcut değil ve bu nedenle sağlanan modül adı '{0}' için bir modül klasörü oluşturulamıyor.</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>Aşağıdaki nedenle {0} modülü oluşturulamıyor: {1}. -OutputModule parametresi için farklı bir bağımsız değişken kullanın ve yeniden deneyin.</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>Modül, {0} cmdlet'inin uyumsuz bir sürümüyle oluşturulduğu için yüklenemiyor. Geçerli oturumdaki {0} cmdlet'iyle modülü oluşturun ve modülü yeniden yüklemeyi deneyin.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/RemotingErrorIdStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/RemotingErrorIdStrings.tr.resx
@@ -549,7 +549,7 @@
     <value>A {0} cannot be specified when {1} is specified.</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>FilePath parametresi için joker karakterler desteklenmez. Joker karakter içermeyen bir yol belirtin.</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>The path specified as the value of the FilePath parameter is not from the FileSystem provider.</value>
@@ -612,7 +612,7 @@
     <value>Proxy credentials cannot be specified when using the following proxy access type: {0}. Either specify a different access type, or do not specify proxy credentials.</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>{1} oturum seçeneği için bir {0} değeri belirtilmelidir.</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>Session must be open.</value>
@@ -636,7 +636,7 @@
     <value>You cannot run Enter-PSSession from a nested prompt.</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>Uzak bilgisayara bağlanırken izin verilecek en fazla WS-Man URI yeniden yönlendirmesi sayısı</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>Default session options for new remote sessions</value>
@@ -846,7 +846,7 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The Wait and Keep parameters cannot be used together in the same command.</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>WriteEvents parametresi Wait parametresi olmadan kullanılamaz.</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell remoting endpoint versioning is not supported on PowerShell 7+.</value>
@@ -933,17 +933,17 @@ Note that 'Start-Job' is not supported by design in scenarios where PowerShell i
     <value>The command cannot find a PSSession that has the name "{0}".</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>PowerShell uzaktan iletişimi, Windows Önyükleme Ortamı'nda (WinPE) desteklenmiyor.</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>{0} tarafından yapılan değişiklikler, WinRM hizmeti yeniden başlatılana kadar etkili olamaz.</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0}, bu adı kullanan bir yapılandırmanın kaydı yakın zamanda kaldırıldıysa, WinRM hizmetinin yeniden başlatılması gerekebilir. Bazı sistem veri yapıları hala önbellekte olabilir. Bu durumda, WinRM’nin yeniden başlatılması gerekebilir.
+Microsoft.PowerShell gibi PowerShell oturum yapılandırmalarına ve Register-PSSessionConfiguration cmdlet’iyle oluşturulan oturum yapılandırmalarına bağlı tüm WinRM oturumlarının bağlantısı kesilir.</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>Uzak bir oturumda çalışıyorsunuz ve Zorla seçeneğini belirlediniz. Bu, WinRM hizmetinin yeniden başlatılabileceği anlamına gelir. WinRM hizmeti yeniden başlatılırsa bu uzak oturum sonlandırılır ve devam etmek için yeni bir oturum oluşturmanız gerekir</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>The job was null when trying to save identifiers. Specify a job to save its identifiers.</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>Error parsing configuration file {0} with the following message: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>-WriteJobInResults parametresi -Wait parametresi olmadan kullanılamaz</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>The member '{0}' is not an absolute path {1}. Change the member to an absolute path in the file {2}.</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>The supplied input data is not valid. Only input data of type {0} is supported.</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>Sağlanan giriş akışı geçerli değil. Giriş akışı olarak yalnızca {0} desteklenir.</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>Sağlanan çıkış akışı kümesi geçerli değil. Çıkış akışı olarak yalnızca {0} desteklenir.</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
-    <value>The supplied WSMAN_SENDER_DETAILS is not valid. Cannot process null WSMAN_SENDER_DETAILS.</value>
+    <value>Sağlanan WSMAN_SENDER_DETAILS geçerli değil. Null WSMAN_SENDER_DETAILS işlenemiyor.</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>Sağlanan kabuk bağlamı geçerli değil.</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>{1} eklenti yöntemine sahip {0} için NULL değerine izin verilmez.</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>Giriş akışı ve çıkış akışı kümeleri için NULL değerine izin verilmez. {0} ve {1}, desteklenen giriş ve çıkış akışlarıdır.</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>{1} eklenti yöntemine sahip {0} için NULL değerine izin verilmez.</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>{1} eklenti yöntemine sahip {0} için NULL değerine izin verilmez.</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>PowerShell eklentisi işlemi kapatılıyor. Bu durum, barındırma hizmeti veya uygulama kapatılıyorsa oluşabilir.</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>PowerShell eklentisi {0} seçeneğini anlamıyor. İstemcinin PowerShell'in derleme {1} ve protokol sürümü {2} ile uyumlu olduğundan emin olun.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>İstemciden {0} adlı bir seçenek bekleniyor. İstemcinin PowerShell'in derleme {1} ve protokol sürümü {2} ile uyumlu olduğundan emin olun.</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;PowerShell eklentisi, istemci tarafından istenen {2} protokol sürümünü desteklemiyor.&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>PowerShell eklentisi, WSMan hizmetine bağlam bildirirken önemli bir hatayla karşılaştı.</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
-    <value>Unable to create managed server session.</value>
+    <value>Yönetilen sunucu oturumu oluşturulamıyor.</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>PowerShell eklentisi, kapatma bildirimi için bekleme tanıtıcısını kaydederken önemli bir hatayla karşılaştı.</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>Cannot enter Runspace because a Runspace is already pushed in this session.</value>
@@ -1662,7 +1662,7 @@ SSH client process terminated before connection could be established.</value>
     <value>PowerShell 6+ does not support WOW64. The binary must match the architecture of the processor.</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>"{0}" yürütülebilir dosyası bulunamadı. WOW64 özelliğinin yüklü olduğunu doğrulayın.</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>Unable to install plugin {0} to directory {1}.</value>
@@ -1703,7 +1703,7 @@ SSH client process terminated before connection could be established.</value>
     <value>Remote debugger exception: {0}, error message: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>Bu makinede Windows PowerShell bulunamadığından Windows PowerShell işlemi oluşturulamıyor.</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>The Runspace argument to Create must be a non-null RemoteRunspace object.</value>

--- a/src/System.Management.Automation/resources/tr/RunspaceStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/RunspaceStrings.tr.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>Çalışma alanı durumu bu işlem için geçerli değil.</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>Çalışma alanı BeforeOpen durumunda olmadığından açılamıyor. Çalışma alanının geçerli durumu '{0}'.</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Çalışma alanı Açıldı durumunda olmadığından işlem gerçekleştirilemiyor. Çalışma alanının geçerli durumu '{0}'.</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>Çalışma alanı Açıldı durumunda olmadığından işlem hattı çağrılamıyor. Çalışma alanının geçerli durumu '{0}'.</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>İşlem hattı durumu bu işlem için geçerli değil.</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>İşlem hattı zaten çağrılmış olduğundan çağrılamıyor.</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>Parametre için geçerli değer: PipelineResultTypes.Output.</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>İşlem hattı bir komut içermiyor.</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>Bir işlem hattı zaten çalıştığından işlem hattı çalıştırılmadı. İşlem hatları eş zamanlı olarak çalıştırılamaz.</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>İç içe geçmiş bir işlem hattı zaman uyumsuz olarak çağrılamaz. Invoke yöntemini kullanın.</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>İç içe geçmiş bir işlem hattını yalnızca çalışan bir işlem hattının içinden çalıştırmalısınız.</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>Bir SessionStateProxy metot çağrısı sürerken çalışma alanı kapatılamaz.</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>Bir SessionStateProxy metot çağrısı sürerken işlem hattı çağrılamaz.</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>SessionStateProxy metot çağrısı devam ediyor. Eş zamanlı SessionStateProxy metot çağrılarına izin verilmiyor.</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>Bir işlem hattı zaten çalışıyor. Eş zamanlı SessionStateProxy metot çağrılarına izin verilmiyor.</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>Bu özellik, çalışma alanı açıldıktan sonra değiştirilemez.</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>Bu çalışma alanını oluşturmak için kullanılan InitialSessionState nesnesinde belirtilen '{0}' modülü işlenirken bir veya daha fazla hata oluştu. Hataların tam listesi için ErrorRecords özelliğine bakın. İlk hata şuydu: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>İş parçacığı seçenekleri yalnızca bölme durumu çok iş parçacıklı bölme (MTA) ise, geçerli seçenekler UseNewThread veya UseCurrentThread ise ve yeni değer ReuseThread ise değiştirilebilir.</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>Dil modu {1} veya {2} olduğunda {0} false olamaz.</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>Yalnızca yerel bir çalışma alanının bağlantısını kesemezsiniz.</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>Bağlan işlemi yerel çalışma alanlarında desteklenmez.</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>Oturum meşgul. Kullanılabilir olduğu anda oturuma bağlanacaksınız. Enter-PSSession komutunu iptal etmek için Ctrl-C tuşlarına basın.</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>Komut tamamlanamıyor. Betik çağrısı bu oturum yapılandırmasında desteklenmiyor. Oturum yapılandırması dil yok modundaysa bu durum oluşabilir.</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>Yerel çalışma alanlarında Bağlantıyı Kes ve Bağlan işlemlerini kullanamazsınız.</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>Çalışma alanı Açıldı durumunda olmadığından işlem hattına bağlanılamıyor.  Çalışma alanının geçerli durumu '{0}'.</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>RemoteRunspace oluşturulamıyor. Sağlanan RunspacePool nesnesi geçerli değil.</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>Bu çalışma alanıyla ilişkili bağlantısı kesilmiş komut yok.</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>Bağlantıyı kesme işlemi uzak bilgisayarda desteklenmiyor. Bağlantıyı kesmeyi desteklemek için uzak bilgisayarda Windows PowerShell 3.0 veya Windows PowerShell'in sonraki bir sürümü çalışıyor olmalı ve WSMan taşıma kullanılmalıdır.</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>Oturum Bağlantısı kesik durumunda olmadığından veya bağlantı için kullanılamadığından PSSession'a bağlanılamıyor.</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>Parametre değeri PipelineResultTypes.None veya PipelineResultTypes.Output olamaz.</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>Parametre için geçerli değerler: PipelineResultTypes.Output veya PipelineResultTypes.Null.</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>Hata ayıklama akışı yeniden yönlendirmesi hedeflenen uzak bilgisayarda desteklenmez.</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>Ayrıntılı akış yeniden yönlendirmesi hedeflenen uzak bilgisayarda desteklenmez.</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>Uyarı akışı yeniden yönlendirmesi hedeflenen uzak bilgisayarda desteklenmez.</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>Bilgi akışı yeniden yönlendirmesi hedeflenen uzak bilgisayarda desteklenmez.</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>Bir komut veya betik çalıştırmakla meşgul olan bir oturuma girdiniz.  Çıkış "{0}" işine yönlendirildiğinden konsolda çıkış görmezsiniz.  Çalışan komutun bitmesini bekleyebilir veya Ctrl-C tuşlarına basarak komutu iptal edip bir giriş istemi alabilirsiniz.
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>Bir komut veya betik çalıştırmakla meşgul olan bir oturuma girdiniz ve çıktı konsolda görüntülenecek.  Çalışan komutun bitmesini bekleyebilir veya Ctrl-C tuşlarına basarak komutu iptal edip bir giriş istemi alabilirsiniz.
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>Çalışan bir komut veya betik içindeki hata ayıklama kesme noktasında şu anda durdurulmuş bir oturuma girdiniz.  Hata ayıklamaya devam etmek için PowerShell komut satırı hata ayıklayıcısını kullanın.
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace bir LocalRunspace olmalıdır</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>Statik PrimaryRunspace özelliği yalnızca bir kez ayarlanabilir ve zaten ayarlanmıştır.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/Serialization.tr.resx
+++ b/src/System.Management.Automation/resources/tr/Serialization.tr.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AttributeExpected" xml:space="preserve">
-    <value>{0} attribute was expected.</value>
+    <value>{0} özniteliği bekleniyordu.</value>
   </data>
   <data name="InvalidElementTag" xml:space="preserve">
-    <value>{0} XML tag is not recognized.</value>
+    <value>{0} XML etiketi tanınmıyor.</value>
   </data>
   <data name="InvalidReferenceId" xml:space="preserve">
-    <value>No object found for referenceId {0}</value>
+    <value>{0} başvurusu için nesne bulunamadı.</value>
   </data>
   <data name="InvalidDictionaryKeyName" xml:space="preserve">
-    <value>Name attribute for dictionary key is incorrectly specified.</value>
+    <value>Sözlük anahtarı için ad özniteliği yanlış belirtilmiş.</value>
   </data>
   <data name="InvalidDictionaryValueName" xml:space="preserve">
-    <value>Name attribute for dictionary value is incorrectly specified.</value>
+    <value>Sözlük değeri için ad özniteliği yanlış belirtilmiş.</value>
   </data>
   <data name="InvalidVersion" xml:space="preserve">
-    <value>Version of PSObject is not valid.</value>
+    <value>PSObject sürümü geçersiz.</value>
   </data>
   <data name="UnexpectedVersion" xml:space="preserve">
-    <value>Version of incoming PSObject is {0}. Expected value is 1.</value>
+    <value>Gelen PSObject sürümü {0}. Beklenen değer 1.</value>
   </data>
   <data name="InvalidTypeHierarchyReferenceId" xml:space="preserve">
-    <value>Cannot process names because no TypeNames were found for referenceId {0}.</value>
+    <value>{0} başvurusu için TypeName bulunamadığından adlar işlenemiyor.</value>
   </data>
   <data name="DepthOfOneRequired" xml:space="preserve">
-    <value>Value of depth parameter must be greater than or equal to 1.</value>
+    <value>depth parametresinin değeri 1’den büyük veya 1’e eşit olmalıdır.</value>
   </data>
   <data name="InvalidNodeType" xml:space="preserve">
-    <value>Current Node type is {0}. Expected type is {1}.</value>
+    <value>Geçerli Düğüm türü {0}. Beklenen tür: {1}.</value>
   </data>
   <data name="DictionaryKeyNotSpecified" xml:space="preserve">
-    <value>Key for dictionary entry is not specified.</value>
+    <value>Sözlük girdisinin anahtarı belirtilmedi.</value>
   </data>
   <data name="DictionaryValueNotSpecified" xml:space="preserve">
-    <value>Value for dictionary entry is not specified.</value>
+    <value>Sözlük girdisi için değer belirtilmemiş.</value>
   </data>
   <data name="ReadCalledAfterDone" xml:space="preserve">
-    <value>There are no more objects to deserialize.</value>
+    <value>Seri durumdan çıkarılacak başka nesne yok.</value>
   </data>
   <data name="NullAsDictionaryKey" xml:space="preserve">
-    <value>Null is specified as dictionary key.</value>
+    <value>Null, sözlük anahtarı olarak belirtilmiştir.</value>
   </data>
   <data name="InvalidPrimitiveType" xml:space="preserve">
-    <value>The contents of the {0} primitive type are not valid.</value>
+    <value>{0} ilkel türünün içeriği geçersiz.</value>
   </data>
   <data name="DeserializationTooDeep" xml:space="preserve">
-    <value>Serialized XML is nested too deeply.</value>
+    <value>Serileştirilmiş XML çok derine yuvalanmış.</value>
   </data>
   <data name="Stopping" xml:space="preserve">
-    <value>Serializer was closed.</value>
+    <value>Serileştirici kapatıldı.</value>
   </data>
   <data name="DeserializationMemoryQuota" xml:space="preserve">
-    <value>The data in the command exceeded the maximum size that is allowed by the session configuration. The allowed maximum is {0} MB. Change the input, use a different session configuration, or change the "{1}" and "{2}" properties of the session configuration on the remote computer.</value>
+    <value>Komuttaki veri, oturum yapılandırmasının izin verdiği en büyük boyutu aştı. İzin verilen en büyük değer {0} MB'dir. Girişi değiştirin, farklı bir oturum yapılandırması kullanın veya uzak bilgisayardaki oturum yapılandırmasının "{1}" ve "{2}" özelliklerini değiştirin.</value>
   </data>
   <data name="DeserializeSecureStringFailed" xml:space="preserve">
-    <value>Deserialization of encrypted secure string failed</value>
+    <value>Şifrelenmiş güvenli dize seri durumundan çıkarılamadı.</value>
   </data>
   <data name="PrimitiveHashtableInvalidKey" xml:space="preserve">
-    <value>The key type {0} is not valid. The PSPrimitiveDictionary class accepts only keys of the type System.String.</value>
+    <value>{0} anahtar türü geçersiz. PSPrimitiveDictionary sınıfı yalnızca System.String türündeki anahtarları kabul eder.</value>
   </data>
   <data name="PrimitiveHashtableInvalidValue" xml:space="preserve">
-    <value>The type of the value {0} is not valid. The PSPrimitiveDictionary class accepts only values of types that are fully serializable over PowerShell remoting. See the Help topic about_Remoting for a list of fully-serializable types.</value>
+    <value>{0} değerinin türü geçerli değil. PSPrimitiveDictionary sınıfı, Windows PowerShell uzak iletişimi üzerinden tam olarak seri durumuna alınabilir türlerdeki değerleri yalnızca kabul eder. Tam olarak seri durumuna alınabilir türlerin bir listesi için about_Remoting Yardım konusuna bakın.</value>
   </data>
   <data name="InvalidKey" xml:space="preserve">
-    <value>Could not decrypt data. The data was not encrypted with this key.</value>
+    <value>Verinin şifresi çözülemedi. Veri bu anahtarla şifrelenmedi.</value>
   </data>
   <data name="InvalidEncryptedString" xml:space="preserve">
-    <value>The parameter value "{0}" is not a valid encrypted string.</value>
+    <value>“{0}” parametre değeri geçerli bir şifrelenmiş dize değil.</value>
   </data>
   <data name="InvalidKeyLength" xml:space="preserve">
-    <value>The specified {0} is not valid. Valid {0} length settings are either 128 bits, 192 bits, or 256 bits.</value>
+    <value>Belirtilen {0} geçerli değil. Geçerli {0} uzunluk ayarları 128 bit, 192 bit veya 256 bittir.</value>
   </data>
   <data name="DeserializeSecureStringNotSupported" xml:space="preserve">
-    <value>Deserialization of SecureString is currently only supported on Windows.</value>
+    <value>SecureString'in seri durumdan çıkarılması şu anda yalnızca Windows'ta destekleniyor.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/SessionStateStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/SessionStateStrings.tr.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>Sağlayıcının Start yönteminden döndürülen bilgi geçirilenden farklı bir sağlayıcıya ait olduğundan döndürülen bilgiler işlenemiyor.</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>Sağlayıcının Start yönteminden döndürülen bilgi null olduğundan döndürülen bilgiler işlenemiyor.</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında SetItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>SetItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında ClearItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında InvokeDefaultAction işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>InvokeDefaultAction işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında ItemExists işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ItemExists işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında IsValidPath işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında IsItemContainer işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında RemoveItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetChildItems işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetChildItems işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetChildNames işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetChildNames işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında RenameItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>RenameItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında NewItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>NewItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında HasChildItems işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında CopyItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>CopyItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetParentPath işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında NormalizeRelativePath işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında MakePath işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetChildName işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında MoveItem işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>MoveItem işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetProperty işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında SetProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>SetProperty işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında ClearProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ClearProperty işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında NewProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>NewProperty işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında RemoveProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>RemoveProperty işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında CopyProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>CopyProperty işleminin dinamik parametreleri '{1}' yolunun '{0}' sağlayıcısı için alınamıyor. {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında MoveProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>MoveProperty işleminin dinamik parametreleri '{1}' yolunun '{0}' sağlayıcısı için alınamıyor. {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında RenameProperty işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>'{1}' yolunun '{0}' sağlayıcısında RenameProperty için dinamik parametreler alınamıyor. {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>'{1}' yolunun '{0}' sağlayıcısı için içerik okuyucu alınamıyor. {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetContentReader işleminin dinamik parametreleri '{1}' yolunun '{0}' sağlayıcısı için alınamıyor. {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>'{1}' yolunun '{0}' sağlayıcısı için içerik yazıcı alınamıyor. {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>GetContentWriter işleminin dinamik parametreleri '{1}' yolunun '{0}' sağlayıcısı için alınamıyor. {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>İçerik dizin olduğundan alınamıyor: '{0}'. Lütfen bunun yerine 'Get-ChildItem' kullanın.</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>İçerik dizin olduğundan yazılamıyor: '{0}'.</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>Geriye gitmek için kalan konum geçmişi yok.</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>İleriye gitmek için kalan konum geçmişi yok.</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack boş.</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında ClearContent işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>'{0}' içeriği bir dizin olduğundan temizlenemiyor. Clear-Content yalnızca dosyalarda desteklenir.</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>ClearContent işleminin dinamik parametreleri '{1}' yolu için '{0}' sağlayıcısından alınamıyor. {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında GetSecurityDescriptor işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında SetSecurityDescriptor işlemini gerçekleştirme girişimi '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>'{0}' sağlayıcısında Start işlemini gerçekleştirme girişimi başarısız oldu. {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>'{0}' sağlayıcısında InitializeDefaultDrives işlemini gerçekleştirme girişimi başarısız oldu.</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısında NewDrive işlemini gerçekleştirme girişimi '{1}' köküne sahip sürücü için başarısız oldu. {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>NewDrive için dinamik parametreler '{0}' sağlayıcısı için alınamıyor. {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>'{0}' sağlayıcısında RemoveDrive çağrısı başarısız oldu. {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>'{1}' sağlayıcısı engellediğinden '{0}' sürücüsü kaldırılamıyor.</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>'{0}' yolu, '{1}' tabanının dışındaki bir öğeye başvurdu.</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısının içerik yazıcısında Seek çağrısı '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısının içerik okuyucusunda veya yazıcısında Close çağrısı '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısının içerik okuyucusunda Read çağrısı '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>'{0}' sağlayıcısının içerik yazıcısında Write çağrısı '{1}' yolu için başarısız oldu. {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>'{0}' sağlayıcısı, değişken söz dizimi kullanılarak veri almak veya ayarlamak için kullanılamaz. {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>Değişken söz dizimi sağlayıcıda veri almak veya ayarlamak için kullanılamaz. {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>{0} diğer adı salt okunur veya sabit olduğundan ve üzerine yazılamadığından diğer ad yazılabilir değil.</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>Salt okunur veya sabit olduğundan {0} işlevine yazılamıyor.</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>{0} değişkeni salt okunur veya sabit olduğundan değişken üzerine yazılamıyor.</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>'${0}' değişkeni özel bir değişken olduğundan bu değişkene erişilemiyor.</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>Özel bir komut olduğundan '{0}' komutuna erişilemiyor.</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>Özel bir komut olduğundan komuta erişilemiyor.</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>Özel bir kaynak olduğundan oturum durumu kaynağına erişilemiyor. </value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>{0} diğer adı sabit veya salt okunur olduğundan diğer ad kaldırılmadı.</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>{0} işlevi sabit olduğundan kaldırılamıyor.</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>Sabit veya salt okunur olduğundan {0} değişkeni kaldırılamıyor. Değişken salt okunursa, Zorla seçeneğini belirterek işlemi yeniden deneyin.</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>{0} diğer adı sabit olduğundan değiştirilemiyor.</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>{0} diğer adı salt okunur olduğundan değiştirilemiyor.</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>{0} işlevi sabit olduğundan değiştirilemiyor.</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>{0} işlevi salt okunur olduğundan değiştirilemiyor.</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>{0} diğer adı oluşturulduktan sonra sabit hale getirilemez. Diğer adlar yalnızca oluşturma sırasında sabit hale getirilebilir.</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>Mevcut {0} işlevi sabit hale getirilemiyor. İşlevler yalnızca oluşturulurken sabit hale getirilebilir.</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>Mevcut {0} değişkeni sabit hale getirilemiyor. Değişkenler yalnızca oluşturulurken sabit hale getirilebilir.</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>AllScope seçeneği '{0}' diğer adından kaldırılamıyor.</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>AllScope seçeneği '{0}' işlevinden kaldırılamıyor.</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>AllScope seçeneği '{0}' değişkeninden kaldırılamıyor.</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>'{0}' işlev tanımı kapsam niteleyicisi içeriyordu ancak işlev adı içermiyordu.</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>{0} sağlayıcısı kaldırılamıyor. {0} sağlayıcısı kaldırılmadan önce {0} sağlayıcısı ile ilişkili tüm sürücüler kaldırılmalıdır.</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>Sürücü adı şu geçersiz karakterlerden birini veya daha fazlasını içerdiğinden işlenemiyor: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>Sağlayıcı yeni sürücünün oluşturulmasına izin vermediğinden yeni sürücü oluşturulamadı.</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>Sağlanan '{0}' değeri birden fazla konum yığınına çözümlendi.</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>'{0}' konum yığını bulunamıyor. Bu yığın yok veya bir kapsayıcı değil.</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
-    <value>Cannot find path '{0}' because it does not exist.</value>
+    <value>‘{0}' yolu mevcut olmadığından bulunamıyor.</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>'{0}' diğer adı mevcut olmadığından diğer ad bulunamıyor.</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>'{0}' yolu birden çok kapsayıcıya çözümlendiğinden konum ayarlanamıyor. Konumu bir seferde yalnızca tek bir kapsayıcıya ayarlayabilirsiniz.</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>'{0}' değişken yolu birden çok öğeye çözümlendiğinden değişken işlenemiyor. Değişken değerini aynı anda yalnızca bir öğe için alabilir veya ayarlayabilirsiniz.</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>Sürücü bulunamıyor. '{0}' adlı bir sürücü yok.</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>'{0}' adlı bir sağlayıcı bulunamıyor.</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>'{0}' adlı bir sağlayıcı bulunamıyor. Ad doğru biçimde değil. Sağlayıcı adı yalnızca alfasayısal karakterlerden oluşabilir ya da arkasından tek bir '\' ve ardından alfasayısal karakterler gelen bir PowerShell ek bileşeni adı olabilir.</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>'{0}' birden fazla sağlayıcı adına çözümlendi. Olası eşleşmeler şunlardır:{1}.</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>Sağlayıcının bir örneği oluşturulmaya çalışılırken bir hata oluştu. '{0}' sağlayıcı türü adı derlemede bulunamadı.</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>Belirtilen '{0}' sağlayıcı adı, geçerli olmayan şu karakterlerden birini veya daha fazlasını içerdiğinden kullanılamıyor: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>'{0}' sağlayıcısının bir örneği oluşturulmaya çalışılırken bir hata oluştu. {1} </value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>'{0}' adlı bir değişken bulunamıyor.</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>'{0}' adlı bir izleme kaynağı bulunamıyor.</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>'{0}' adında bir sürücü zaten var.</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>'{0}' adlı bir değişken zaten var.</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>'{0}' adlı bir diğer ad zaten bulunduğundan diğer ada izin verilmiyor.</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>'{0}' adlı bir cmdlet sağlayıcısı zaten mevcut olduğundan cmdlet sağlayıcısı kaydedilemiyor.</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>Yol bir dosya sistemi yoluna başvurmuyor.</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>Genel kapsam kaldırılamıyor.</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>Kapsam numarası '{0}' etkin kapsam sayısını aşıyor.</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>PSDriveInfo karşılaştırılamıyor. Bir PSDriveInfo örneği yalnızca başka bir PSDriveInfo örneğiyle karşılaştırılabilir.</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Çıkışın akışla aktarılacağı bir cmdlet belirtilmediğinden cmdlet sağlayıcısı sonuçları akışla aktaramıyor.</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Hatanın akışla aktarılacağı bir cmdlet belirtilmediğinden cmdlet sağlayıcısı sonuçları akışla aktaramıyor.</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>Bu sağlayıcı için giriş konumu ayarlanmadı. Giriş konumunu ayarlamak için "(get-psprovider '{0}').Home = 'path'" komutunu çağırın.</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>Yol doğru biçimde değil. Sağlayıcı yolları bir sağlayıcı kimliği, ardından "::" ve ardından sağlayıcıya özgü bir yol içermelidir.</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>Hedef yol yalnızca tek bir yola çözümlenebildiğinden öğe taşınamıyor.</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>Kaynak ve hedef yollar aynı sağlayıcıya çözümlenmediğinden öğe taşınamıyor.</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>Kaynak yol bir veya daha fazla öğeye işaret ettiğinden ve hedef yol bir kapsayıcı olmadığından öğe taşınamıyor. Hedef yolun bir kapsayıcı olduğunu doğrulayın ve yeniden deneyin.</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>Hedef birden çok yola çözümlendiğinden öğe taşınamıyor. Tek bir hedefe çözümlenen bir hedef yolu belirtin ve yeniden deneyin.</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>Kapsayıcı mevcut olan yaprak öğenin üzerine kopyalanamıyor.</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>Kapsayıcı başka bir kapsayıcıya kopyalanamıyor. -Recurse veya -Container parametresi belirtilmemiş.</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>Kaynak ve hedef yol aynı sağlayıcıya çözülmedi.</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>Yol birden çok öğeye çözümlendiğinden öğe yeniden adlandırılamıyor. Bir kerede yalnızca bir öğe yeniden adlandırılabilir.</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>'{0}' sağlayıcısındaki bir hata nedeniyle sağlayıcı '{1}' yolunu çözümlemek için kullanılamıyor.</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>Arabirim kullanılamıyor. IContentCmdletProvider arabirimi bu sağlayıcı tarafından uygulanmıyor.</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>Arabirim kullanılamıyor. IPropertyCmdletProvider arabirimi bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>Arabirim kullanılamıyor. IDynamicPropertyCmdletProvider arabirimi bu sağlayıcı tarafından uygulanmıyor.</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>NavigationCmdletProvider yöntemleri bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>Sağlayıcı yöntemleri işlenmedi. ContainerCmdletProvider yöntemleri bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>Yöntemler çağrılamıyor. ItemCmdletProvider yöntemleri bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>DriveCmdletProvider yöntemleri bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>Sağlayıcı bu işlemi desteklemediğinden sağlayıcı işlemi durduruldu.</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>Sağlayıcı 'Depth' parametresini desteklemediğinden sağlayıcı işlemi durduruldu.</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>Yöntem çağrılamıyor. İçerik Seek yöntemi bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>ClearContent işlemi gerçekleştirilemiyor. ClearContent işlemi bu sağlayıcı tarafından desteklenmiyor.</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>Sağlayıcı kimlik bilgilerinin kullanımını desteklemiyor. İşlemi kimlik bilgileri belirtmeden yeniden gerçekleştirin.</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>FileSystem sağlayıcısı kimlik bilgilerini yalnızca New-PSDrive cmdlet'inde destekler. İşlemi kimlik bilgileri belirtmeden yeniden gerçekleştirin.</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>Sağlayıcı işlemleri desteklemiyor. İşlemi -UseTransaction parametresi olmadan yeniden gerçekleştirin.</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>Yöntem çağrılamıyor. Sağlayıcı filtrelerin kullanımını desteklemiyor.</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>Sürücü oluşturulamıyor. Sağlayıcı kimlik bilgilerinin kullanımını desteklemiyor.</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>'{0}' yolundaki öğe zaten var.</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>Öğe kopyalanamıyor. '{0}' yolundaki öğe yok.</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>'{0}' yolundaki öğe yok.</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>Oturum durumunda depolanan diğer adların görünümünü içeren sürücü</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>İşlem için ortam değişkenlerinin görünümünü içeren sürücü</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>Oturum durumunda depolanan işlevlerin görünümünü içeren sürücü</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>Oturum durumunda depolanan bu değişkenlerin görünümünü içeren sürücü</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>Geçerli kullanıcı için geçici dizin yoluyla eşlenen sürücü</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>Hedef Değer belirtilmediğinden '{0}' bağlantısı oluşturulamıyor.</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>Null değişkenine yapılan başvurular her zaman null değeri döndürür. Atamaların etkisi yoktur.</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>Bir oturumda saklanacak en fazla geçmiş nesnesi sayısı</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>{0} işlevi salt okunur veya sabit olduğundan işlev yeniden adlandırılamıyor.</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>{0} diğer adı salt okunur veya sabit olduğundan diğer ad yeniden adlandırılamıyor.</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>{0} değişkeni salt okunur veya sabit olduğundan değişken yeniden adlandırılamıyor.</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>Yerel {0} değişkeninde seçenekler ayarlanamıyor. Seçeneklerin ayarlanmasına olanak tanıyan bir değişken oluşturmak için New-Variable kullanın.</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>{0} cmdlet'i salt okunur olduğundan değiştirilemiyor.</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>{0} değişkeni iyileştirildiğinden ve kaldırılamadığından değişken kaldırılamıyor. Remove-Variable cmdlet'ini (diğer ad olmadan) kullanmayı veya değişkeni kaldırmak için kullandığınız komutu nokta kaynaklı çalıştırmayı deneyin.</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>{0} değişkeni iyileştirildiğinden değişkenin üzerine yazılamıyor. New-Variable veya Set-Variable cmdlet'ini (diğer ad olmadan) kullanmayı deneyin veya değişkeni ayarlamak için kullandığınız komutu nokta kaynaklı çalıştırın.</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>{0} ve {1} parametreleri birlikte kullanılamaz. Lütfen yalnızca bir parametre belirtin.</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>Tail parametresi şu anda yalnızca FileSystem sağlayıcısı için destekleniyor.</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>Adı '{0}' ve komut türü '{1}' olan bir komut zaten mevcut olduğundan diğer ada izin verilmiyor.</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>Yazılım çalıştırılamıyor. İzin reddedildi.</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>'-{0}' ve '-{1}' birbirini dışlar ve aynı anda belirtilemez.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>'{0}' yolu geçerli değil. Uzak kopyalama işlemlerinde yalnızca mutlak yollar desteklenir.</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>'{0}' uzak yolu doğrulanamıyor.</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>{0} oturumu {1} olarak ayarlandığından işlem gerçekleştirilemiyor.</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>'{0}' parametresi null veya boş olamaz.</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>Oturum Durumu Değişkenleri</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage modunda, '{0}' değişkeninin kapsamını AllScope olarak değiştirmek veya bu kapsamda oluşturmak engellenir.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/tr/TransactionStrings.tr.resx
+++ b/src/System.Management.Automation/resources/tr/TransactionStrings.tr.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>İşlem kullanılamıyor. Hiçbir işlem etkin değil.</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>İşlem yürütülemiyor. Hiçbir işlem etkin değil.</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>Etkin işlem olmadığından işlem geri alınamıyor.</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>İşlem geri alınamıyor. İşlem zaten yürütüldü.</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>İşlem yürütülemiyor. İşlem zaten yürütüldü.</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>İşlem yürütülemiyor. İşlem geri alındı veya zaman aşımına uğradı.</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>İşlem geri alınamıyor. İşlem zaten geri alındı veya zaman aşımına uğradı.</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>Etkin işlem ayarlanamıyor. İşlem oluşturulmadı.</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>Etkin işlem ayarlanamıyor. Etkin işlem geri alındı veya zaman aşımına uğradı.</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>Bu cmdlet için etkin bir işlem gerekiyor. Geçerli işlem zaten yürütüldü veya geri alındı.</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>Bu cmdlet için bir işlem gerekiyor. Komutu -UseTransaction parametresiyle yeniden çalıştırın.</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>İşlem kullanılamıyor. İşlem başlatılmadı.</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>İşlem kullanılamıyor. İşlem yürütüldü.</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>İşlem kullanılamıyor. İşlem geri alındı veya zaman aşımına uğradı.</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>İşlem kullanılamıyor. İşlem zaman aşımına uğradı.</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>Temel işlem ayarlanmadı.</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>Temel işlem etkin değil.</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>Diğer işlemler oluşturulduktan sonra temel işlem ayarlanamaz.</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/Authenticode.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/Authenticode.zh-Hans.resx
@@ -118,78 +118,78 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Reason_DoNotRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted not to run this software now.</value>
+    <value>无法加载文件 {0} ，因为你选择现在不运行此软件。</value>
   </data>
   <data name="Reason_NeverRun" xml:space="preserve">
-    <value>File {0} cannot be loaded because you opted never to run software from this publisher.</value>
+    <value>无法加载文件 {0}，因为你选择从不运行来自此发布者的软件。</value>
   </data>
   <data name="Reason_NotTrusted" xml:space="preserve">
-    <value>File {0} is published by {1}. This publisher is explicitly not trusted on your system. The script will not run on the system. For more information, run the command "get-help about_signing".</value>
+    <value>文件 {0} 由 {1} 发布。系统明确不信任此发布者。脚本不会在系统上运行。有关详细信息，请运行命令“get-help about_signing”。</value>
   </data>
   <data name="Reason_RestrictedMode" xml:space="preserve">
-    <value>File {0} cannot be loaded because running scripts is disabled on this system. For more information, see about_Execution_Policies at https://go.microsoft.com/fwlink/?LinkID=135170.</value>
+    <value>无法加载文件 {0}，因为此系统上已禁用脚本运行。有关详细信息，请参阅 https://go.microsoft.com/fwlink/?LinkID=135170. 处的 about_Execution_Policies。</value>
   </data>
   <data name="Reason_Unknown" xml:space="preserve">
-    <value>File {0} cannot be loaded. {1}.</value>
+    <value>无法加载文件 {0}。 {1}。</value>
   </data>
   <data name="Reason_DisallowedBySafer" xml:space="preserve">
-    <value>File {0} cannot be loaded because its operation is blocked by software restriction policies, such as those created by using Group Policy.</value>
+    <value>无法加载文件 {0} ，因为软件限制策略阻止了其操作，例如通过组策略创建的策略。</value>
   </data>
   <data name="Reason_FileContentUnavailable" xml:space="preserve">
-    <value>File {0} cannot be loaded because its content could not be read.</value>
+    <value>无法加载文件 {0} ，因为无法读取其内容。</value>
   </data>
   <data name="CertNotGoodForSigning" xml:space="preserve">
-    <value>Cannot sign code. The specified certificate is not suitable for code signing.</value>
+    <value>无法对代码进行签名。指定的证书不适用于代码签名。</value>
   </data>
   <data name="TimeStampUrlRequired" xml:space="preserve">
-    <value>Cannot sign code. The TimeStamp server URL must be fully qualified, and in the format http://&lt;server url&gt; or https://&lt;server url&gt;.</value>
+    <value>无法对代码进行签名。TimeStamp 服务器 URL 必须是完全限定的，格式应为 http://&lt;server url&gt; 或 https://&lt;server url&gt;。</value>
   </data>
   <data name="InvalidHashAlgorithm" xml:space="preserve">
-    <value>Cannot sign code. The hash algorithm is not supported.</value>
+    <value>无法对代码进行签名。不支持哈希算法。</value>
   </data>
   <data name="AuthenticodePromptCaption" xml:space="preserve">
-    <value>Do you want to run software from this untrusted publisher?</value>
+    <value>是否要运行来自此不受信任发布者的软件?</value>
   </data>
   <data name="AuthenticodePromptText" xml:space="preserve">
-    <value>File {0} is published by {1} and is not trusted on your system. Only run scripts from trusted publishers.</value>
+    <value>文件 {0} 由 {1} 发布，在你的系统上不受信任。仅运行来自受信任发布者的脚本。</value>
   </data>
   <data name="AuthenticodePromptText_UnknownPublisher" xml:space="preserve">
-    <value>Software {0} is published by an unknown publisher. It is recommended that you do not run this software.</value>
+    <value>软件 {0} 由未知发布者发布。建议不要运行此软件。</value>
   </data>
   <data name="RemoteFilePromptCaption" xml:space="preserve">
-    <value>Security warning</value>
+    <value>安全警告</value>
   </data>
   <data name="RemoteFilePromptText" xml:space="preserve">
-    <value>Run only scripts that you trust. While scripts from the internet can be useful, this script can potentially harm your computer. If you trust this script, use the Unblock-File cmdlet to allow the script to run without this warning message. Do you want to run {0}?</value>
+    <value>仅运行你信任的脚本。来自 Internet 的脚本虽然很有用，但此脚本可能会损害你的计算机。如果你信任此脚本，请使用 Unblock-File cmdlet 允许脚本运行而不显示此警告消息。是否要运行 {0}?</value>
   </data>
   <data name="Choice_NeverRun" xml:space="preserve">
-    <value>Ne&amp;ver run</value>
+    <value>永不运行(&amp;V)</value>
   </data>
   <data name="Choice_NeverRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and do not prompt me to run this script in future. Future attempts to run this script will result in a silent failure.</value>
+    <value>请勿现在运行来自此发布者的脚本，今后也不要提示我运行此脚本。将来尝试运行此脚本将导致无提示失败。</value>
   </data>
   <data name="Choice_DoNotRun" xml:space="preserve">
-    <value>&amp;Do not run</value>
+    <value>不运行(&amp;D)</value>
   </data>
   <data name="Choice_DoNotRun_Help" xml:space="preserve">
-    <value>Do not run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>请勿现在运行来自此发布者的脚本，并在以后继续提示我运行此脚本。</value>
   </data>
   <data name="Choice_RunOnce" xml:space="preserve">
-    <value>&amp;Run once</value>
+    <value>运行一次(&amp;R)</value>
   </data>
   <data name="Choice_RunOnce_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and continue to prompt me to run this script in the future.</value>
+    <value>立即运行来自此发布者的脚本，并在以后继续提示我运行此脚本。</value>
   </data>
   <data name="Choice_AlwaysRun" xml:space="preserve">
-    <value>&amp;Always run</value>
+    <value>始终运行(&amp;A)</value>
   </data>
   <data name="Choice_AlwaysRun_Help" xml:space="preserve">
-    <value>Run the script from this publisher now, and do not prompt me to run this script in the future.</value>
+    <value>立即运行来自此发布者的脚本，以后不再提示我运行此脚本。</value>
   </data>
   <data name="Choice_Suspend" xml:space="preserve">
-    <value>&amp;Suspend</value>
+    <value>暂停(&amp;S)</value>
   </data>
   <data name="Choice_Suspend_Help" xml:space="preserve">
-    <value>Pause the current pipeline and return to the command prompt. Type exit to resume operation when you are done.</value>
+    <value>暂停当前管道并返回到命令提示符。完成后，键入 exit 以恢复操作。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/CoreClrStubResources.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/CoreClrStubResources.zh-Hans.resx
@@ -118,24 +118,24 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgumentIllegalEnvVarName" xml:space="preserve">
-    <value>Environment variable name cannot contain equal character.</value>
+    <value>环境变量名不能包含等号字符。</value>
   </data>
   <data name="ArgumentLongEnvVarValue" xml:space="preserve">
-    <value>Environment variable name or value is too long.</value>
+    <value>环境变量名称或值太长。</value>
   </data>
   <data name="ArgumentStringFirstCharIsZero" xml:space="preserve">
-    <value>The first char in the string is the null character.</value>
+    <value>字符串中的第一个字符是空字符。</value>
   </data>
   <data name="ArgumentStringZeroLength" xml:space="preserve">
-    <value>String cannot be of zero length.</value>
+    <value>字符串长度不能为零。</value>
   </data>
   <data name="CannotGetComputerName" xml:space="preserve">
-    <value>Computer name could not be obtained.</value>
+    <value>无法获取计算机名称。</value>
   </data>
   <data name="CannotGetDomainName" xml:space="preserve">
-    <value>Current user's domain name could not be obtained.</value>
+    <value>无法获取当前用户的域名。</value>
   </data>
   <data name="UnknownErrorNumber" xml:space="preserve">
-    <value>Unknown error "{0}".</value>
+    <value>未知错误: {0}。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/CredUI.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/CredUI.zh-Hans.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>PowerShell 凭据请求 </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>输入凭据。</value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>输入凭据。</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>字幕的最大长度为 {0} 个字符。</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>消息的最大长度为 {0} 个字符。</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>UserName 值的最大长度为 {0} 个字符。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/DebuggerStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/DebuggerStrings.zh-Hans.resx
@@ -118,147 +118,147 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="VariableBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '${0}' ({1} access)</value>
+    <value>“${0}”上的变量断点({1} 访问)</value>
   </data>
   <data name="VariableScriptBreakpointString" xml:space="preserve">
-    <value>Variable breakpoint on '{0}:${1}' ({2} access)</value>
+    <value>“{0}:${1}”上的变量短点({2} 访问)</value>
   </data>
   <data name="LineBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}'</value>
+    <value>“{0}:{1}”上的行断点</value>
   </data>
   <data name="StatementBreakpointString" xml:space="preserve">
-    <value>Line breakpoint on '{0}:{1}, {2}'</value>
+    <value>“{0}:{1}”上的行断点，{2}</value>
   </data>
   <data name="CommandBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}'</value>
+    <value>“{0}”上的命令断点</value>
   </data>
   <data name="CommandScriptBreakpointString" xml:space="preserve">
-    <value>Command breakpoint on '{0}:{1}'</value>
+    <value>“{0}:{1}”上的命令断点</value>
   </data>
   <data name="WarningBreakpointWillNotBeHit" xml:space="preserve">
-    <value>Breakpoint {0} will not be hit</value>
+    <value>不会命中断点 {0}</value>
   </data>
   <data name="StepHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Single step (step into functions, scripts, etc.)</value>
+    <value> {0}，{1,-16} 单步执行(步入函数、脚本等)</value>
   </data>
   <data name="StepOverHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step to next statement (step over functions, scripts, etc.)</value>
+    <value> {0}，{1,-16} 单步执行下一个语句(步过函数、脚本等)</value>
   </data>
   <data name="StepOutHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Step out of the current function, script, etc.</value>
+    <value> {0}，{1,-16} 跳出当前函数、脚本等。</value>
   </data>
   <data name="ContinueHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation</value>
+    <value> {0}，{1,-16} 继续操作</value>
   </data>
   <data name="StopHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Stop operation and exit the debugger</value>
+    <value> {0}，{1,-16} 停止操作并退出调试程序</value>
   </data>
   <data name="GetStackTraceHelp" xml:space="preserve">
-    <value> {0}, Get-PSCallStack Display call stack</value>
+    <value> {0}，Get-PSCallStack 显示调用堆栈</value>
   </data>
   <data name="ListHelp" xml:space="preserve">
-    <value> {0}, {1,-16} List source code for the current script.  </value>
+    <value> {0}，{1,-16} 列出当前脚本的源代码。 </value>
   </data>
   <data name="AdditionalListHelp1" xml:space="preserve">
-    <value>                     Use "list" to start from the current line, "list &lt;m&gt;"  </value>
+    <value>                     使用 “list” 从当前行开始，使用 “list &lt;m&gt;” 则从 &lt;m&gt; 开始  </value>
   </data>
   <data name="AdditionalListHelp2" xml:space="preserve">
-    <value>                     to start from line &lt;m&gt;, and "list &lt;m&gt; &lt;n&gt;" to list &lt;n&gt; </value>
+    <value>                     以从行 &lt;m&gt; 开始，并执行 “list &lt;m&gt; &lt;n&gt;” 以列出 &lt;n&gt; </value>
   </data>
   <data name="AdditionalListHelp3" xml:space="preserve">
-    <value>                     lines starting from line &lt;m&gt;</value>
+    <value>                     从行 &lt;m&gt; 开始的行</value>
   </data>
   <data name="EnterHelp" xml:space="preserve">
-    <value> &lt;enter&gt;             Repeat last command if it was {0}, {1} or {2}</value>
+    <value> &lt;enter&gt;             如果为它为 {0}、{1} 或 {2}，则重复上一个命令</value>
   </data>
   <data name="HelpCommandHelp" xml:space="preserve">
-    <value> {0}, {1,-16} displays this help message.</value>
+    <value> {0}，{1,-16} 显示此帮助消息。</value>
   </data>
   <data name="PromptHelp" xml:space="preserve">
-    <value>For instructions about how to customize your debugger prompt, type "help about_prompt".</value>
+    <value>有关如何自定义调试程序提示的说明，请键入 “help about_prompt”。</value>
   </data>
   <data name="SessionDoesNotSupportDebugger" xml:space="preserve">
     <value>
-The current session does not support debugging; operation will continue.
+当前会话不支持调试；操作将继续。
 
 </value>
   </data>
   <data name="LocationFormat" xml:space="preserve">
-    <value>{0}: line {1}</value>
+    <value>{0}: 行 {1}</value>
   </data>
   <data name="NoSourceCode" xml:space="preserve">
-    <value>There is no source code available.</value>
+    <value>没有可用的源代码。</value>
   </data>
   <data name="BadStartFormat" xml:space="preserve">
-    <value>The starting line must be a positive integer no greater than {0}</value>
+    <value>起始行必须是不大于 {0} 的正整数</value>
   </data>
   <data name="BadCountFormat" xml:space="preserve">
-    <value>The line count must be a positive integer.</value>
+    <value>行计数必须是正整数。</value>
   </data>
   <data name="NoFile" xml:space="preserve">
     <value>&lt;No file&gt;</value>
   </data>
   <data name="StackTraceFormat" xml:space="preserve">
-    <value>at {0}, {1}: line {2}</value>
+    <value>位于 {0}，{1}: 行 {2}</value>
   </data>
   <data name="CannotProcessDebuggerCommandNotStopped" xml:space="preserve">
-    <value>The debugger cannot process commands unless it is in the Stopped state.</value>
+    <value>调试程序无法处理命令，除非它处于“已停止”状态。</value>
   </data>
   <data name="CannotSetDebuggerAction" xml:space="preserve">
-    <value>SetDebugAction is not implemented for the local script debugger.</value>
+    <value>未针对本地脚本调试程序实现 SetDebugAction。</value>
   </data>
   <data name="CannotSetRemoteDebuggerAction" xml:space="preserve">
-    <value>The debugger cannot set a resume action because the debugger in the remote session is not in a Stopped state.</value>
+    <value>调试程序无法设置恢复操作，因为远程会话中的调试程序未处于“已停止”状态。</value>
   </data>
   <data name="CannotStartJobDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The job cannot be debugged because the debugger is currently busy.</value>
+    <value>无法调试作业，因为调试程序当前正忙。</value>
   </data>
   <data name="NoDebuggableJobsFound" xml:space="preserve">
-    <value>The provided job and all child jobs were examined but no jobs were found that could be debugged.  In order to debug a job or child job the job must support debugging and also be in a running state.</value>
+    <value>已检查提供的作业和所有子作业，但未找到可调试的作业。 要调试作业或子作业，作业必须支持调试，并且还必须处于运行状态。</value>
   </data>
   <data name="CannotEnableDebuggerSteppingInvalidMode" xml:space="preserve">
-    <value>The debugger cannot be enabled for step mode because the debugger is turned off with debug mode set to None.</value>
+    <value>无法在单步模式下启用调试程序，因为调试程序处于关闭状态，并且调试模式设置为“无”。</value>
   </data>
   <data name="RunspaceDebuggingDebuggerBusy" xml:space="preserve">
-    <value>The Runspace cannot be debugged because the host debugger is currently busy.</value>
+    <value>无法调试运行空间，因为主机调试程序当前正忙。</value>
   </data>
   <data name="RunspaceDebuggingDebuggerIsOff" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace debugger is currently turned off (DebugMode is 'None').</value>
+    <value>无法调试运行空间。运行空间调试程序当前已关闭(DebugMode 为“无”)。</value>
   </data>
   <data name="RunspaceDebuggingInvalidRunspaceState" xml:space="preserve">
-    <value>Cannot debug a Runspace that is not in the Opened state. This Runspace state is {0}.</value>
+    <value>无法调试未处于“已打开”状态的运行空间。此运行空间状态为 {0}。</value>
   </data>
   <data name="RunspaceDebuggingNoRunspaceDebugger" xml:space="preserve">
-    <value>Cannot debug Runspace. The Runspace {0} has no associated debugger.</value>
+    <value>无法调试运行空间。运行空间 {0} 没有关联的调试程序。</value>
   </data>
   <data name="RemoteServerDebuggerAlreadyPushed" xml:space="preserve">
-    <value>The debugger is already overridden.</value>
+    <value>已替代调试程序。</value>
   </data>
   <data name="RemoteServerDebuggerCannotPushSelf" xml:space="preserve">
-    <value>Cannot push a debugger object onto itself.</value>
+    <value>无法将调试程序对象推送到其自身。</value>
   </data>
   <data name="CommandNotSupportedForRemoteUseInServerDebugger" xml:space="preserve">
-    <value>The {0} command is not supported for remote use in the version of PowerShell that is running in the remote runspace.</value>
+    <value>在远程运行空间中运行的 PowerShell 版本不支持远程使用 {0} 命令。</value>
   </data>
   <data name="NestedRunspaceDebuggerPromptProcessName" xml:space="preserve">
-    <value>Process</value>
+    <value>进程</value>
   </data>
   <data name="DetachHelp" xml:space="preserve">
-    <value> {0}, {1,-16} Continue operation and detach the debugger.</value>
+    <value> {0}，{1,-16} 继续执行操作并分离调试程序。</value>
   </data>
   <data name="InvalidDetachCommand" xml:space="preserve">
-    <value>The debugger detach command is not applicable.  The detach command only applies when debugging jobs and runspaces with the Debug-Job or Debug-Runspace cmdlets.</value>
+    <value>调试程序分离命令不适用。 分离命令仅适用于使用 Debug-Job 或 Debug-Runspace cmdlet 调试作业和运行空间的情况。</value>
   </data>
   <data name="InvalidRunspaceId" xml:space="preserve">
-    <value>Invalid runspace id: {0}</value>
+    <value>无效的运行空间 ID: {0}</value>
   </data>
   <data name="UnableToGetRunspace" xml:space="preserve">
-    <value>Unable to get Runspace.</value>
+    <value>无法获取运行空间。</value>
   </data>
   <data name="BreakpointOrBreakpointListNotSpecified" xml:space="preserve">
-    <value>Breakpoint or BreakpointList must be specified.</value>
+    <value>必须指定断点或 BreakpointList。</value>
   </data>
   <data name="BreakpointListContainedANonBreakpoint" xml:space="preserve">
-    <value>The BreakpointList contained an item that was not a breakpoint.</value>
+    <value>BreakpointList 包含了不是断点的项。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/ErrorPackage.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/ErrorPackage.zh-Hans.resx
@@ -121,18 +121,18 @@
     <value>{0}…{1}</value>
   </data>
   <data name="ErrorDetailsEmptyTemplate" xml:space="preserve">
-    <value>Error text is empty for error "{0}" : "{1}"</value>
+    <value>错误“{0}”的错误文本为空: “{1}”</value>
   </data>
   <data name="RedirectedException" xml:space="preserve">
-    <value>Object "{0}" is reported as an error.</value>
+    <value>对象“{0}”报告为错误。</value>
   </data>
   <data name="UnsupportedPreferenceError" xml:space="preserve">
-    <value>The value {0} is not supported for an ActionPreference variable. The provided value should be used only as a value for a preference parameter, and has been replaced by the default value. For more information, see the Help topic, "about_Preference_Variables."</value>
+    <value>ActionPreference 变量不支持值 {0}。提供的值应仅用作首选项参数的值，并且已替换为默认值。有关详细信息，请参阅帮助主题 "about_Preference_Variables"。</value>
   </data>
   <data name="ActionPreferenceReservedForFutureUseError" xml:space="preserve">
-    <value>The {0} ActionPreference value is reserved for future use and is not supported at this time. For more information about preference variables, see the Help topic, "about_Preference_Variables."</value>
+    <value>{0} ActionPreference 值将保留以供将来使用，目前不受支持。有关首选项变量的详细信息，请参阅帮助主题 "about_Preference_Variables"。</value>
   </data>
   <data name="ReservedActionPreferenceReplacedError" xml:space="preserve">
-    <value>The {0} ActionPreference value is reserved for future use and is not supported at this time. It has been replaced in your {1} variable by the default value of {2}. For more information about preference variables, see the Help topic, "about_Preference_Variables."</value>
+    <value>{0} ActionPreference 值将保留以供将来使用，目前不受支持。它已在你的 {1} 变量中替换为默认值 {2}。有关首选项变量的详细信息，请参阅帮助主题 "about_Preference_Variables"。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/EtwLoggingStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/EtwLoggingStrings.zh-Hans.resx
@@ -118,108 +118,108 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CommandStateChange" xml:space="preserve">
-    <value>Command {0} is {1}.</value>
+    <value>命令 {0} 为 {1}。</value>
   </data>
   <data name="EngineStateChange" xml:space="preserve">
-    <value>Engine state changed from {0} to {1}.</value>
+    <value>引擎状态已从“{0}”更改为“{1}”。</value>
   </data>
   <data name="ErrorRecordId" xml:space="preserve">
-    <value>Fully Qualified Error ID = {0}</value>
+    <value>完全限定错误 ID = {0}</value>
   </data>
   <data name="ErrorRecordMessage" xml:space="preserve">
-    <value>Error Message = {0}</value>
+    <value>错误消息 = {0}</value>
   </data>
   <data name="ErrorRecordRecommendedAction" xml:space="preserve">
-    <value>Recommended Action = {0}</value>
+    <value>建议的操作 = {0}</value>
   </data>
   <data name="ExecutionPolicyName" xml:space="preserve">
-    <value>Execution Policy</value>
+    <value>执行策略</value>
   </data>
   <data name="JobCommand" xml:space="preserve">
-    <value>Job Command = {0}</value>
+    <value>作业命令 = {0}</value>
   </data>
   <data name="JobId" xml:space="preserve">
-    <value>Job Id = {0}</value>
+    <value>作业 ID = {0}</value>
   </data>
   <data name="JobInstanceId" xml:space="preserve">
-    <value>Job Instance Id = {0}</value>
+    <value>作业实例 ID = {0}</value>
   </data>
   <data name="JobLocation" xml:space="preserve">
-    <value>Job Location = {0}</value>
+    <value>作业位置 = {0}</value>
   </data>
   <data name="JobName" xml:space="preserve">
-    <value>Job Name = {0}</value>
+    <value>作业名称 = {0}</value>
   </data>
   <data name="JobState" xml:space="preserve">
-    <value>Job State = {0}</value>
+    <value>作业状态 = {0}</value>
   </data>
   <data name="LogContextCommandName" xml:space="preserve">
-    <value>        Command Name = </value>
+    <value>        命令名称 = </value>
   </data>
   <data name="LogContextCommandPath" xml:space="preserve">
-    <value>        Command Path = </value>
+    <value>        命令路径 = </value>
   </data>
   <data name="LogContextCommandType" xml:space="preserve">
-    <value>        Command Type = </value>
+    <value>        命令类型 = </value>
   </data>
   <data name="LogContextEngineVersion" xml:space="preserve">
-    <value>        Engine Version = </value>
+    <value>        引擎版本 = </value>
   </data>
   <data name="LogContextHostId" xml:space="preserve">
-    <value>        Host ID = </value>
+    <value>        主机 ID = </value>
   </data>
   <data name="LogContextHostName" xml:space="preserve">
-    <value>        Host Name = </value>
+    <value>        主机名 = </value>
   </data>
   <data name="LogContextHostApplication" xml:space="preserve">
-    <value>        Host Application = </value>
+    <value>        主机应用程序 = </value>
   </data>
   <data name="LogContextHostVersion" xml:space="preserve">
-    <value>        Host Version = </value>
+    <value>        主机版本 = </value>
   </data>
   <data name="LogContextPipelineId" xml:space="preserve">
-    <value>        Pipeline ID = </value>
+    <value>        管道 ID = </value>
   </data>
   <data name="LogContextRunspaceId" xml:space="preserve">
-    <value>        Runspace ID = </value>
+    <value>        运行空间 ID = </value>
   </data>
   <data name="LogContextScriptName" xml:space="preserve">
-    <value>        Script Name = </value>
+    <value>        脚本名称 = </value>
   </data>
   <data name="LogContextSequenceNumber" xml:space="preserve">
-    <value>        Sequence Number = </value>
+    <value>        序列号 = </value>
   </data>
   <data name="LogContextSeverity" xml:space="preserve">
-    <value>        Severity = </value>
+    <value>        严重性 = </value>
   </data>
   <data name="LogContextShellId" xml:space="preserve">
     <value>        Shell ID = </value>
   </data>
   <data name="LogContextTime" xml:space="preserve">
-    <value>        Time = </value>
+    <value>        时间 = </value>
   </data>
   <data name="LogContextUser" xml:space="preserve">
-    <value>        User = </value>
+    <value>        用户 = </value>
   </data>
   <data name="LogContextConnectedUser" xml:space="preserve">
-    <value>        Connected User = </value>
+    <value>        已连接的用户 = </value>
   </data>
   <data name="NullJobName" xml:space="preserve">
-    <value>NULL Job</value>
+    <value>NULL 作业</value>
   </data>
   <data name="ProviderNameString" xml:space="preserve">
-    <value>Provider name</value>
+    <value>提供程序名称</value>
   </data>
   <data name="ProviderStateChange" xml:space="preserve">
-    <value>Provider {0} changed state to {1}.</value>
+    <value>提供程序 {0} 状态已更改为“{1}”。</value>
   </data>
   <data name="ScriptStateChange" xml:space="preserve">
-    <value>Script execution is {0}.</value>
+    <value>脚本执行为 {0}。</value>
   </data>
   <data name="SettingChange" xml:space="preserve">
-    <value>Variable {0} changed from {1} to {2}.</value>
+    <value>变量“{0}”已从“{1}”更改为“{2}”。</value>
   </data>
   <data name="SettingChangeNoPrevious" xml:space="preserve">
-    <value>Variable {0} changed to {1}.</value>
+    <value>变量 {0} 已更改为“{1}”。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/ExperimentalFeatureStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/ExperimentalFeatureStrings.zh-Hans.resx
@@ -59,9 +59,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ExperimentalFeatureNameNotFound" xml:space="preserve">
-    <value>No experimental feature was found that matched the name '{0}'.</value>
+    <value>未找到与名称“{0}”匹配的实验性功能。</value>
   </data>
   <data name="ExperimentalFeaturePending" xml:space="preserve">
-    <value>Enabling and disabling experimental features do not take effect until next start of PowerShell.</value>
+    <value>启用和禁用实验性功能将在下次启动 PowerShell 时生效。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/ExtendedTypeSystem.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/ExtendedTypeSystem.zh-Hans.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>成员 {0} 已存在。</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>扩展类型数据文件中已存在成员“{0}”。</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>成员“{0}”不存在。</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>设置“{0}”时出现异常：“{1}”</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>获取“{0}”时出现异常:“{1}”</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>尝试枚举集合时发生以下异常:“{0}”。</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>无法访问 PSObject 外部的成员“{0}”。</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>无法更改从类型配置创建的成员:“{0}”。</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>成员名称“{0}”为保留名称。</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>无法更改“{0}”。</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>调用“{0}”并传入“{1}”个参数时发生异常：“{2}”</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>尝试调用“{0}”以提取类型为“{1}”的对象的内容时引发了异常：“{2}”</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>找不到“{0}”的参数计数为“{1}”的重载。</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>对于类型参数“{0}”和参数计数“{1}”的“{2}”，找不到合适的泛型方法重载。</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>为“{0}”和参数计数“{1}”找到了多个不明确的重载。</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>无法将参数“{0}”转换为类型“{1}”，其值为“{2}”，用于“{3}”：“{4}”</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>属性“{0}”的 Get 访问器不可用。</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>属性“{0}”的 Set 访问器不可用。</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>setter 方法应为 public、void、static，并具有两个参数。第一个参数应为 PSObject 类型。如果 getter 方法也可用，则需要第二个参数，并且其类型应与 getter 方法的返回类型相同。</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>getter 方法应为 public、非 void、static，并且只有一个 PSObject 类型的参数。</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>CodeProperty 应使用 getter 或 setter 方法。</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>由于方法格式问题，无法创建代码方法。该方法应为 public、static，并且只有一个 PSObject 类型的参数。</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>别名名为“{0}”的别名包含循环。</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>无法将类型“{0}”的“{1}”值转换为类型“{2}”。</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>无法将类型“{0}”的值转换为类型“{1}”。</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>无法将值 "{0}" 转换为类型 "{1}"。错误:“{2}”</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>无法将值“{0}”转换为类型“{1}”，因为此枚举不允许使用逗号。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>由于枚举值无效，无法将值“{0}”转换为类型“{1}”。请指定以下枚举值之一，然后重试。可用的枚举值为“{2}”。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>由于枚举值无效，无法将 null 转换为类型“{0}”。请指定以下枚举值之一，然后重试。可用的枚举值为“{1}”。</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>无法将 null 转换为类型“{0}”。</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>无法将值转换为类型 "{0}"。 错误:“{1}”</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>无法将值转换为 System.String 类型。</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>参数中应为引用类型。</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>无法比较“{0}”，因为它不是 IComparable。</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>无法将“{0}”与“{1}”进行比较。错误:“{2}”</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>无法将“{0}”与“{1}”进行比较，因为对象不是同一类型，或者对象“{0}”未实现“{2}”。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>无法将值“{0}”转换为类型“{1}”，因为至少找到两个匹配项({2}、 {3})，而此枚举只允许一个匹配项。</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>无法将值 "{0}" 转换为类型 "{1}"。布尔参数只接受布尔值和数字，例如 $True、$False、1 或 0。</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>无法获取属性值，因为“{0}”是只写属性。</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>“{0}”是 ReadOnly 属性。</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>无法设置“{0}”，因为只有字符串才能用作值来设置 XmlNode 属性。</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>无法设置“{0}”，因为只能设置唯一属性或唯一的非属性化叶节点。</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>无法将 PSProperty 或 PSMethod 对象添加到此集合。</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>加载扩展类型数据文件时出现以下错误： {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>检索字符串时发生以下异常：“{0}”</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>类型“{0}”的字段或属性“{1}”仅在字母大小写上与字段或属性“{2}”不同。类型必须符合公共语言规范 (CLS)。</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>检索类型名称层次结构时发生以下异常：“{0}”。</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>检索成员“{1}”时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>检索成员时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>检索属性“{1}”的读取状态时发生以下异常: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>检索属性“{1}”的写入状态时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>检索属性“{1}”的类型时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>检索属性“{1}”的字符串表示形式时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>检索属性“{1}”的属性时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>检索方法“{1}”的定义时发生以下异常:“{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>检索方法“{1}”的字符串表示形式时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>检索参数化属性“{1}”的类型时发生以下异常:“{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>检索参数化属性“{1}”的读取状态时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>检索参数化属性“{1}”的写入状态时发生以下异常：“{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>检索参数化属性“{1}”的定义时发生以下异常:“{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>检索参数化属性“{1}”的字符串表示形式时发生以下异常:“{0}”</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>无法为类型为“{0}”的 PSMemberInfo 对象设置 Value 属性。</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>参数“{0}”应为 {1}。使用 {2}。</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>参数“{0}”不应为 {1}。请勿使用 {2}。</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>找不到属性“{0}”。</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>无法获取或设置属性值。“{0}”参数应为“{1}”或“{2}”类型。</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>无法设置属性“{0}”的值，因为对象的类型为“{1}”，而不是“{2}”。</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>调用“{0}”时出现异常:“{1}”</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0} 不是有效的类路径。</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} 不是有效的路径。</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>适配器无法确定属性“{0}”是否可以更改。</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>适配器无法确定属性“{0}”是否可读写。</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>适配器无法获取属性“{0}”的值。</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>适配器无法设置属性“{0}”的值。</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>适配器无法获取属性“{0}”的类型。</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>适配器无法获取“{0}”的类型层次结构。</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>适配器无法获取“{0}”的属性。</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>适配器无法获取“{0}”的属性“{1}”。</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>“{0}”返回了 null 值。</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>找不到“{0}”对象的属性“{1}”。可设置的属性为: {2}。</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>找不到“{0}”对象的属性“{1}”。没有可设置的属性。</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>无法创建类型“{0}”的对象。 {1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>无法在开放泛型类型 {0}上调用静态方法或访问静态属性。 请指定类型参数，然后重试。 例如，请使用 [System.Collections.Generic.HashSet[int]]::CreateSetComparer()，而不是 [System.Collections.Generic.HashSet``1]::CreateSetComparer()。</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>构造属性“{1}”时发生以下异常:“{0}”</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>无法将值“{0}”转换为字符串数组。</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>无法将值转换为类型 "{0}"。此语言模式仅支持核心类型。</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>无法转换为类似 ByRef 的类型“{0}”。PowerShell 不支持类似 ByRef 的类型。</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>无法获取或设置 ByRef-like 类型“{0}”的属性或字段“{1}”。PowerShell 不支持类似 ByRef 的类型。</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>无法调用 ByRef-like 返回类型“{0}”的方法“{1}”。PowerShell 不支持类似 ByRef 的类型。</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>无法创建 ByRef-like 类型“{0}”的实例。PowerShell 不支持类似 ByRef 的类型。</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>扩展类型系统哈希表转换</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式下，不允许将类型从 HashTable 转换为“{0}”。</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>扩展类型系统哈希表转换</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式下，不允许将类型从“{0}”转换为“{1}”。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/Modules.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/Modules.zh-Hans.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载指定的模块 "{0}"，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载指定的模块 "{0}" (版本为 "{1}")，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>指定的 MaximumVersion "{0}" 不正确。如果使用 "*"，则 MaximumVersion 只支持一个 "*"，并且它应始终位于 MaximumVersion 的末尾。</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载指定的模块 "{0}" (MinimumVersion 为 "{1}")，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载指定的模块 "{0}" (MinimumVersion 为 "{1}"，MaximumVersion 为 "{2}")，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion "{0}" 不应大于 MaximumVersion "{1}"。</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>未加载程序集 "{0}"，因为找不到具有该名称的程序集。请验证程序集名称，然后重试。</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>未处理模块清单 "{2}" 的字段 "{1}" 中列出的要处理的模块 "{0}"，因为在所有模块目录中都未找到有效模块。</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>未为模块 "{0}" 返回自定义对象，因为 -AsCustomObject 参数只能用于脚本模块。</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>无法处理模块清单 "{0}"，因为它不是有效的 PowerShell 模块清单文件。请删除不允许的元素: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>处理模块清单文件 "{0}" 后未得到有效的清单对象。请更新该文件，使其包含有效的 PowerShell 模块清单。可以使用 New-ModuleManifest cmdlet 创建有效的清单。</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>无法导入 "{0}" 模块，因为其清单包含一个或多个无效成员。有效的清单成员为({1})。请删除无效成员({2})，然后再次尝试导入该模块。</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>描述模块的哈希表包含一个或多个无效成员。有效成员为({0})。请删除无效成员({1})，然后重试。</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>无法加载模块 "{0}"，因为已超过模块嵌套限制。模块只能嵌套到 {1} 级。请评估并调整加载模块的顺序，以避免超过嵌套限制，然后再次尝试运行脚本。</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>模块清单中不存在成员 "ModuleVersion"。此成员必须存在并分配有 "n.n.n.n" 格式的版本号。请将缺少的成员添加到文件 "{0}" 中。</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>模块清单文件 "{2}" 中的成员 "{0}" 无效: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>模块 "{1}" 的版本 "{0}" 不符合所需的最低版本 "{2}"。请验证该版本号是否受支持，然后再次尝试加载该模块。</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>此计算机上的 PowerShell 版本为 "{0}"。模块 "{1}" 运行所需的最低 PowerShell 版本为 {2}。请验证是否已安装所需的最低 PowerShell 版本，然后重试。</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>如果 "ModuleToProcess" 成员是二进制模块，则无法使用模块清单成员 "NestedModules"。请编辑 "{0}" 处的模块清单文件，然后重试。</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>模块清单中的成员 "{0}" 无效: {1}。请验证是否在 "{2}" 文件中为此字段指定了有效值。</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>模块清单路径 "{0}" 无效。Path 参数的值必须解析为一个扩展名为 ".psd1" 的单个文件。请更改 Path 参数的值,使其指向有效的 psd1 文件，然后重试。</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>模块清单 "{0}" 中的 ModuleVersion 键指定的模块版本 "{1}" 与 "{2}" 中的版本文件夹名称不匹配。请更改 ModuleVersion 键的值，使其与版本文件夹名称一致。</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模块清单 "{1}" 中指定的 NestedModule 条目 "{0}" 无效。请使用有效值更新此条目，然后重试。</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模块清单 "{1}" 中指定的 RequiredAssemblies 条目 "{0}" 无效。请使用有效值更新此条目，然后重试。</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模块清单 "{1}" 中指定的 FileList 条目 "{0}" 无效。请使用有效值更新此条目，然后重试。</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模块清单 "{1}" 中指定的 RequiredModules 条目 "{0}" 无效。请使用有效值更新此条目，然后重试。</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模块清单 "{1}" 中指定的 ModuleList 条目 "{0}" 无效。请使用有效值更新此条目，然后重试。</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>模块清单 "{0}" 指定了 CompatiblePSEditions 键。此键仅在 PowerShell 5.1 或更高版本中受支持。请将 PowerShellVersion 键的值更新为 5.1 或更高版本，然后重试。</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>CompatiblePSEditions 的指定值 "{0}" 包含重复的 PowerShell 版本名称。请先删除重复的 PowerShell 版本名称，然后重试。</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>ModuleVersion 键中指定的版本等于版本文件夹名称。</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>正在跳过 Module {1} 下的 Version 文件夹 {0}，因为它没有有效的模块清单文件。</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>描述此模块的哈希表中不存在 "ModuleName" 成员。</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>描述此模块的哈希表中不存在 "ModuleVersion"、"MaximumVersion" 和 "RequiredVersion" 成员。这三个成员中必须存在一个，并分配了格式为 "n.n.n.n" 的版本号。</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未加载所需模块 "{1}"。请加载该模块，或从文件 "{0}" 中的 "RequiredModules" 删除该模块。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未加载 GUID 为 "{2}" 的所需模块 "{1}"。请加载该模块，或从文件 "{0}" 中的 "RequiredModules" 删除该模块。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未加载版本 "{2}" 的所需模块 "{1}"。请加载该模块，或从文件 "{0}" 中的 "RequiredModules" 删除该模块。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未加载 MaximumVersion 为 "{2}" 的所需模块 "{1}"。请加载该模块，或从文件 "{0}" 中的 "RequiredModules" 删除该模块。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未加载 MinimumVersion 为 "{2}" 且 MaximumVersion 为 "{3}" 的所需模块 "{1}"。请加载该模块，或从文件 "{0}" 中的 "RequiredModules" 删除该模块。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>找不到 ModuleVersion 为 "{1}" 的模块 "{0}"。</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>找不到 RequiredVersion 为 "{1}" 的模块 "{0}"。</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>找不到 MaximumVersion 为 "{1}" 的模块 "{0}"。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>找不到 ModuleVersion 为 "{1}" 且 MaximumVersion 为 "{2}" 的模块 "{0}"。</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>找不到模块 "{0}"。</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>未删除任何模块。请验证要删除的模块规范是否正确，以及这些模块是否存在于运行空间中。</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>无法删除从模块 "{1}" 导入的 "{0}" 成员，原因如下: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>无法删除模块 "{0}"，因为它是只读的。请在命令中添加 Force 参数，以删除只读模块。</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>无法删除模块 "{0}"，因为它被标记为 "constant"。如果模块被标记为 "constant"，则无法将其删除。</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>无法删除模块 "{0}"，因为它是 "{1}" 需要的。请在命令中添加 Force 参数，以删除该模块。</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>只能从模块内部调用 Export-ModuleMember cmdlet。</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>"{0}" 扩展不是有效的模块扩展。支持的模块扩展名为 ".dll"'、".ps1"、".psm1"、".psd1" 和 ".cdxml"。请更正扩展名，然后再次尝试添加文件 "{1}"。</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>无法在二进制模块上执行此操作。它只能在脚本模块上执行。</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>不允许使用文件 "{0}"，因为它没有扩展名 ".ps1"。</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}。保留所有权利。</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>正在删除已导入的 "{0}" 函数。</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>正在删除已导入的 "{0}" 别名。</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>正在删除已导入的 "{0}" 变量。</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>正在从路径 "{0}" 加载模块。</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>正在从路径 "{1}" 加载 "{0}"。</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>正在点源脚本文件 "{0}"。</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>正在导入函数 "{0}"。</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>正在导入 cmdlet "{0}"。</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>正在导入别名 "{0}"。</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>正在导入变量 "{0}"。</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>正在导出 cmdlet "{0}"。</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>正在导出函数 "{0}"。</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>正在导出别名 "{0}"。</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>正在导出变量 "{0}"。</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>来自模块 "{0}" 的某些导入命令名称包含未经批准的谓词，这可能会降低它们的可发现性。若要查找带有未经批准谓词的命令，请使用 Verbose 参数再次运行 Import-Module 命令。若要查看已批准谓词的列表，请输入 Get-Verb。</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>已导入模块 "{1}" 中的 "{0}" 命令，但由于其名称不包含已批准的谓词，可能很难找到。若要查看已批准谓词的列表，请输入 Get-Verb。</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>已导入模块 "{2}" 中的 "{0}" 命令，但由于其名称不包含已批准的谓词，可能很难找到。建议的替代谓词为“{1}”。</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>某些已导入的命令名称包含以下一个或多个受限字符: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>模块 "{1}" 中的命令名称 "{0}" 包含一个或多个以下受限字符: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>创建 "{0}" 模块清单文件。</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0}(路径: "{1}")</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>当前处理器体系结构为: {0}。模块 "{1}" 需要以下体系结构: {2}。</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>当前 PowerShell 主机名称为 "{0}"。模块 "{1}" 需要以下 PowerShell 主机: "{2}"。</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>当前 PowerShell 主机为: {0}(版本 {1})。模块 "{2}" 运行所需的最低 PowerShell 主机版本为 {3}。</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>模块 "{0}" 的模块清单</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>生成者: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>生成于: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>与此清单关联的脚本模块或二进制模块文件。</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>要作为 RootModule/ModuleToProcess 中指定模块的嵌套模块导入的模块</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>用于唯一标识此模块的 ID</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>此模块的作者</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>此模块的公司或供应商</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>此模块的版权声明</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>此模块的版本号。</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>此模块提供的功能说明</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>此模块要求的 PowerShell 引擎的最低版本</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>此模块所需的公共语言运行时(CLR)的最低版本。{0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>在导入此模块之前必须导入全局环境的模块</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>在导入此模块之前在调用方环境中运行的脚本文件(.ps1)。</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>导入此模块时要加载的类型文件(.ps1xml)</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>导入此模块时要加载的格式化文件 (.ps1xml)</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>在导入此模块之前必须加载的程序集</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>使用此模块打包的所有文件列表</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>要传递给 RootModule/ModuleToProcess 中指定的模块的私有数据。这还可能包含一个 PSData 哈希表，其中包含 PowerShell 使用的其他模块元数据。</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>应用于此模块的标记。这些标记有助于在联机库中发现模块。</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>指向此项目主网站的 URL。</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>指向此模块许可证的 URL。</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>指向表示此模块的图标的 URL。</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>此模块的发行说明</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>此模块的预发行版字符串</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>此标志指示模块是否要求用户明确同意安装、更新或保存。</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>此模块的外部依赖模块</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>{0} 哈希表末尾</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>PrivateData 参数值必须是哈希表，才能使用以下参数值创建模块清单: Tags、ProjectUri、LicenseUri、IconUri 或 ReleaseNotes。请删除 Tags、ProjectUri、LicenseUri、IconUri 或 ReleaseNotes 参数值，或将 PrivateData 的内容包装在哈希表中。</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>应将 PrivateData 定义为哈希表，但此模块清单将其定义为对象。请考虑将 PrivateData 的内容包装在哈希表中。这样，后续就可以向模块清单添加 Tags、ProjectUri、LicenseUri、IconUri 和 ReleaseNotes 属性。</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>指定的值 "{0}" 无效，请使用有效值重试。</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>要从此模块导出的函数。为获得最佳性能，请不要使用通配符，也不要删除此条目。如果没有要导出的函数，请使用空数组。</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>要从此模块导出的别名。为获得最佳性能，请不要使用通配符，也不要删除此条目。如果没有要导出的别名，请使用空数组。</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>要从此模块导出的 cmdlet。为获得最佳性能，请不要使用通配符，也不要删除此条目。如果没有要导出的 cmdlet，请使用空数组。</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>要从此模块导出的变量</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>要从此模块导出的 DSC 资源</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>受支持的 PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>此模块要求处理器体系结构(无、X86、Amd64)</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>使用此模块打包的所有模块列表</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>此模块所需的 Microsoft .NET Framework 最低版本。{0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>此模块所需的 PowerShell 主机名称</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>此模块要求的 PowerShell 主机的最低版本</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>此模块的 HelpInfo URI</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>因为 {0} 模块在当前 PowerShell 会话中提供 PSDrive，所以未删除任何模块。请更改当前 PSDrive 提供程序，然后再次尝试删除模块。</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未导入 cmdlet "{0}"，因为当前作用域中存在同名成员。</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未导入别名 "{0}"，因为当前作用域中存在同名成员。</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未导入函数 "{0}"，因为当前作用域中存在同名成员。</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未导入变量 "{0}"，因为当前作用域中存在同名成员。</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>模块清单 "{0}" 中的成员 "ModuleToProcess"、"RootModule" 或 "NestedModules" 不允许使用通配符。</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>模块 "{0}" 是 PowerShell 的核心模块。请在命令中添加 Force 参数，以删除核心模块。</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>模块清单不能同时包含 "ModuleToProcess" 和 "RootModule" 成员。请修改模块清单文件以删除 "{0}" 处的其中一个成员，然后重试。</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>模块清单成员 "ModuleToProcess" 已被弃用。请改用 "RootModule" 成员。</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>从此模块导出的命令的默认前缀。可使用 Import-Module -Prefix 覆盖默认前缀。</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>不能同时指定 "Global" 和 "Scope" 参数。请删除其中一个参数，然后再次运行该命令。</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>未加载所需模块 "{0}"。模块 "{0}" 在其模块清单 "{2}" 中的 requiredModule "{1}" 指向循环依赖项。</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载所需模块 "{0}"，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>模块 {0} 中的某些命令无法通过 CimSession 导入。若要获取所有命令，请验证远程服务器是否已启用 PowerShell 远程管理，然后尝试在 Import-Module cmdlet 中添加 PSSession 参数。</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>模块 {0} 使用 {1} 远程会话在 Windows PowerShell 中加载；请注意，该模块中所有命令的输入和输出都将是反序列化对象。如果要将此模块加载到 PowerShell 中，请使用 Import-Module -SkipEditionCheck 语法。</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>检测到的 Windows PowerShell 版本 {0}。使用 Windows PowerShell 兼容性功能加载模块需要 Windows PowerShell 5.1。请从 https://aka.ms/WMF5Download 安装 Windows Management Framework (WMF) 5.1 以启用此功能。</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>PowerShell 配置文件中的 "WindowsPowerShellCompatibilityModuleDenyList" 设置已阻止使用 Windows PowerShell 兼容性功能加载模块 "{0}"。</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>无法通过 CimSession 导入模块 {0}。请尝试使用 Import-Module cmdlet 的 PSSession 参数。</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>不支持 {0} 的处理器体系结构值。请再次运行 New-ModuleManifest 命令，并为处理器体系结构指定以下受支持的枚举值之一: None、MSIL、X86、Amd64、Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>对远程计算机运行 Get-Module cmdlet 只能列出可用模块。请将 ListAvailable 参数添加到命令中，然后重试。</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>未导入 "{0}" 模块，因为已导入 "{0}" 管理单元。</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>模块清单 "{0}" 中的成员 "RequiredAssemblies" 不允许使用通配符。</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>{1} 中 {0} 键的值为 {2} ，并且该模块具有嵌套模块。当 CDXML 文件是根模块时，Import-Module 命令会失败，因为无法导出嵌套模块中的命令。请将 CDXML 文件移到 NestedModules 键下，然后再次尝试运行该命令。</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>远程命令失败: {0}：{{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>无法为远程模块 "{0}" 生成代理。{{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>未能处理远程模块 {0}。{1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>未能从远程 CimSession 接收模块数据。{0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未加载所需模块 "{0}" (GUID 为 "{1}"，版本为 {2})，因为在所有模块目录中都未找到有效的模块文件。</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>在 CIM 服务器上找不到用于模块发现的 CIM 提供程序。{0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>无法验证 Microsoft .NET Framework 版本 {0}，因为它不在允许的版本列表中。</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>正在分析 {0}。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>正在为首次使用准备模块。</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>正在搜索可用模块</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>正在搜索 UNC 共享 {0}。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>只能针对不包含路径的模块名称对远程计算机运行 Get-Module cmdlet。Name 参数中的元素 "{0}" 会解析为路径。请更新 Name 参数，使其不包含路径元素，然后重试。</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>对于包含路径的模块名称，不支持在不使用 ListAvailable 参数的情况下运行 Get-Module cmdlet。Name 参数中的元素 "{0}" 会解析为路径。请更新 Name 参数，使其不包含路径元素，然后重试。</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>找不到指定的模块 "{0}"。请更新 Name 参数，使其指向有效路径，然后重试。</value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>正在填充模块 {0} 的 RepositorySourceLocation 属性。</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>未处理在模块清单 "{2}" 的字段 "{1}" 中列出的要处理模块 "{0}"。{3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>此先决条件仅适用于 PowerShell Desktop 版本。</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>模块 "{0}" 不支持当前的 PowerShell 版本 "{1}"。其支持的版本为 "{2}"。使用 "Import-Module -SkipEditionCheck" 可忽略此模块的兼容性。</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>模块 "{0}" 支持 PowerShell 版本 "{1}"，由于设置文件中已禁用 Windows 兼容性功能，因此无法使用该功能隐式加载。请使用 "Import-Module -UseWindowsPowerShell" 通过 Windows PowerShell 加载此模块，或使用 "Import-Module -SkipEditionCheck" 尝试使用当前 PowerShell 加载此模块。</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>应为模块清单中声明的实验性功能指定非空字符串值。</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>找到一个或多个无效的实验性功能名称: {0}。模块实验性功能名称应遵循此约定: "ModuleName.FeatureName"。</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>不能在不使用 -ListAvailable 开关参数的情况下使用 -SkipEditionCheck 开关参数。</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式下，不允许将 *.ps1 文件作为模块导入。</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>加载脚本模块 {0} 时发生错误，因为它的语言模式与模块清单不同。清单语言模式为 {1}，模块语言模式为 {2}。请确保所有模块文件都已签名，或以其他方式包含在应用允许列表配置中。</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>此模块在使用通配符导出函数时使用点源运算符，而在系统强制执行应用程序验证时，这是不允许的。</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>无法从语言模式与正在运行的会话不同的模块导出模块成员。</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>当会话处于 ConstrainedLanguage 模式时，无法创建新模块。</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>找不到与“核心”版本兼容的内置模块 "{0}"。请确保 PowerShell 内置模块可用。它们通常随 PowerShell 包一起位于 $PSHOME 模块路径下，并且是 PowerShell 正常运行所必需的。</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
     <value>Export-ModuleMember Cmdlet</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>在 Constrained Language 模式下导出模块成员将会失败，因为模块 "{0}" 的语言模式 "{1}" 与当前会话 "{2}" 的模式不同。</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>模块隐式函数导出</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>由于模块 "{0}" 受信任(在完整语言模式下运行)，但会话不受信任(在受约束语言模式下运行)，因此将拒绝隐式导出函数。最佳做法是始终按完整名称单独导出模块函数。</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>正在将脚本文件作为模块导入</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式下，不允许将脚本文件 "{0}" 作为模块导入。</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>模块包含点源运算符</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>模块 "{0}" 的导入在 Constrained Language 模式下会失败，因为它在使用点源运算符的同时，还使用通配符导出函数。</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>“模块导出函数</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>模块 "{0}" 使用名称通配符导出函数。在 Constrained Language 模式下运行时，任何嵌套模块的函数名称都将被删除。</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
     <value>"New-Module Cmdlet</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>系统将阻止来自不受信任的 Constrained Language 会话的新模块提供 FullLanguage 脚本块。</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>“模块语言模式不匹配</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>正在加载的依赖模块的语言模式与父模块的不同。在受约束语言模式下，不允许这样做。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/PSConfigurationStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/PSConfigurationStrings.zh-Hans.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>由于安全问题，PowerShell 已停止工作: 无法读取配置文件: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/PathUtilsStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/PathUtilsStrings.zh-Hans.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>编码 "UTF-7" 已过时，请使用 UTF-8。</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>文件 {0} 已存在，且已指定 {1}。</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>无法打开文件，因为当前提供程序({0})无法打开文件。</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>无法执行操作，因为路径解析为多个文件。此命令无法对多个文件执行操作。</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>无法执行操作，因为通配符路径 {0} 未解析为文件。</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>未知编码 {0}; 有效值为 {1}。</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>目录“{0}”已存在。 如果要覆盖目录及其中的文件，请使用 -Force 参数。</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>用户模块路径不存在，因此无法为所提供的模块名称“{0}”创建模块文件夹。</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>由于以下原因，无法创建模块 {0}: {1}。请为 -OutputModule 参数使用其他自变量，然后重试。</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>无法加载该模块，因为它是使用与 {0} cmdlet 不兼容的版本生成的。请使用当前会话中的 {0} cmdlet 生成该模块，然后再次尝试加载该模块。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/RemotingErrorIdStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/RemotingErrorIdStrings.zh-Hans.resx
@@ -549,7 +549,7 @@
     <value>指定 {1} 时，无法指定 {0}。</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>FilePath 参数不支持通配符。指定一个不包含通配符的路径。</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>指定为 FilePath 参数值的路径不是来自 FileSystem 提供程序。</value>
@@ -612,7 +612,7 @@
     <value>使用以下代理访问类型时，无法指定代理凭据: {0}。请指定其他访问类型，或者不指定代理凭据。</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>会话选项 {1} 必须指定 {0} 值。</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>会话必须处于打开状态。</value>
@@ -636,7 +636,7 @@
     <value>无法从嵌套提示符运行 Enter-PSSession。</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>连接到远程计算机时允许的最大 WS-Man URI 重定向次数</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>新远程会话的默认会话选项</value>
@@ -846,7 +846,7 @@
     <value>不能在同一命令中同时使用 Wait 和 Keep 参数。</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>WriteEvents 参数必须与 Wait 参数一起使用。</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell 7+ 不支持 PowerShell 远程处理终结点版本控制。</value>
@@ -933,17 +933,17 @@
     <value>该命令找不到名为 "{0}" 的 PSSession。</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>Windows 预安装环境(WinPE)不支持 PowerShell 远程处理。</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>{0} 所做的更改在重启 WinRM 服务后才会生效。</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>如果最近已取消注册使用此名称的配置，则 {0} 可能需要重启 WinRM 服务，因为某些系统数据结构可能仍处于缓存状态。在这种情况下，可能需要重启 WinRM。
+所有连接到 PowerShell 会话配置的 WinRM 会话(例如 Microsoft.PowerShell 和使用 Register-PSSessionConfiguration cmdlet 创建的会话配置)都会断开连接。</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>你正在远程会话中运行，并选择了“强制”选项，这意味着 WinRM 服务可能会重新启动。如果 WinRM 服务重新启动，则此远程会话将终止，你需要创建新会话才能继续</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>尝试保存标识符时，作业为 null。请指定一个作业，以保存其标识符。</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>分析配置文件 {0} 时出错，出现以下错误消息: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>-WriteJobInResults 参数必须与 -Wait parameter 参数一起使用</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>成员 '{0}' 不是绝对路径 {1}。请在文件 {2} 中将该成员更改为绝对路径。</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>提供的输入数据无效。仅支持 {0} 类型的输入数据。</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>提供的输入流无效。仅支持 {0} 作为输入流。</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>提供的输出流集无效。仅支持 {0} 作为输出流。</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
     <value>提供的 WSMAN_SENDER_DETAILS 无效。无法处理 null WSMAN_SENDER_DETAILS。</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>提供的 shell 上下文无效。</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>插件方法 {1} 不允许 {0} 为 NULL 值。</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>输入流和输出流集不允许使用 NULL 值。{0} 和 {1} 是受支持的输入流和输出流。</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>插件方法 {1} 不允许 {0} 为 NULL 值。</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>插件方法 {1} 不允许 {0} 为 NULL 值。</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>PowerShell 插件操作正在关闭。如果托管服务或应用程序正在关闭，则可能会发生这种情况。</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>PowerShell 插件无法识别选项 {0}。请确保客户端与 PowerShell 的内部版本 {1} 和协议版本 {2} 兼容。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
     <value>客户端应提供具有名称 {0} 的选项。请确保客户端与 PowerShell 的内部版本 {1} 和协议版本 {2} 兼容。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;PowerShell 插件不支持客户端请求的协议版本 {2}。&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>PowerShell 插件在向 WSMan 服务报告上下文时遇到错误。</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
     <value>无法创建托管服务器会话。</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>PowerShell 插件在注册关闭通知的等待句柄时遇到错误。</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>无法进入运行空间，因为已在此会话中推送了一个运行空间。</value>
@@ -1662,7 +1662,7 @@ SSH 客户端进程已在建立连接之前终止。</value>
     <value>PowerShell 6+ 不支持 WOW64。二进制文件必须与处理器的体系结构匹配。</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>找不到“{0}”可执行文件。请验证是否已安装 WOW64 功能。</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>无法将插件 {0} 安装到目录 {1}。</value>
@@ -1703,7 +1703,7 @@ SSH 客户端进程已在建立连接之前终止。</value>
     <value>远程调试器异常: {0}，错误消息: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>由于在此计算机上找不到 Windows PowerShell，因此无法创建 Windows PowerShell 进程。</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>要创建的 Runspace 自变量必须是非 null RemoteRunspace 对象。</value>

--- a/src/System.Management.Automation/resources/zh-Hans/RunspaceStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/RunspaceStrings.zh-Hans.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>运行空间状态对此操作无效。</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>无法打开运行空间，因为运行空间未处于 BeforeOpen 状态。运行空间的当前状态为 '{0}'。</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>无法执行此操作，因为运行空间未处于“已打开”状态。运行空间的当前状态为 '{0}'。</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>无法调用管道，因为运行空间未处于“已打开”状态。运行空间的当前状态为 '{0}'。</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>管道状态对此操作无效。</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>无法调用管道，因为它已被调用。</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>参数的有效值为 PipelineResultTypes.Output。</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>管道不包含命令。</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>由于已有一个管道正在运行，因此未运行该管道。管道不能并发运行。</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>无法异步调用嵌套管道。使用 Invoke 方法。</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>只能从正在运行的管道中运行嵌套管道。</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>在进行 SessionStateProxy 方法调用时，无法关闭运行空间。</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>在进行 SessionStateProxy 方法调用时，无法调用管道。</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>正在进行 SessionStateProxy 方法调用。不允许并发 SessionStateProxy 方法调用。</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>管道已在运行。不允许并发 SessionStateProxy 方法调用。</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>打开运行空间之后无法更改此属性。</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>处理用于创建此运行空间的 InitialSessionState 对象中指定的模块 '{0}' 时出现一个或多个错误。有关错误的完整列表，请参阅 ErrorRecords 属性。第一个错误是: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>仅当单元状态为多线程单元 (MTA)、当前选项为 UseNewThread 或 UseCurrentThread，且新值为 ReuseThread 时，才能更改线程选项。</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>当语言模式为 {0} 或 {1}时，{2} 不能为 false。</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>无法断开仅本地运行空间的连接。</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>本地运行空间不支持 Connect 操作。</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>会话正忙。会话可用后，你将立即连接到会话。若要取消 Enter-PSSession 命令，请按 Ctrl-C。</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>无法完成该命令。此会话配置中不支持脚本调用。如果会话配置处于无语言模式，则可能会发生这种情况。</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>无法在本地运行空间上使用 Disconnect 和 Connect 操作。</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>无法连接管道，因为运行空间未处于“已打开”状态。 运行空间的当前状态为 '{0}'。</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>无法构造 RemoteRunspace。提供的 RunspacePool 对象无效。</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>没有与此运行空间关联的断开连接命令。</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>远程计算机上不支持断开连接操作。若要支持断开连接，远程计算机必须运行 Windows PowerShell 3.0 或更高版本的 Windows PowerShell，并使用 WSMan 传输。</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>无法连接 PSSession，因为会话未处于 Disconnected 状态，或者无法连接。</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>参数值不能为 PipelineResultTypes.None 或 PipelineResultTypes.Output。</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>参数的有效值为 PipelineResultTypes.Output 或 PipelineResultTypes.Null。</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>目标远程计算机上不支持调试流重定向。</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>目标远程计算机上不支持详细流重定向。</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>目标远程计算机上不支持警告流重定向。</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>目标远程计算机上不支持信息流重定向。</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>你已进入一个正在忙于运行命令或脚本的会话。 由于输出已路由到作业“{0}”，因此你不会在控制台中看到输出。 你可以等待正在运行的命令完成，也可以按 Ctrl-C 取消命令并获取输入提示符。
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>进入的会话正忙于运行命令或脚本，输出将显示在控制台中。 可以等待正在运行的命令完成，也可以按 Ctrl-C 取消它并获取输入提示符。
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>你进入的会话当前在运行的命令或脚本中的调试断点处停止。 使用 PowerShell 命令行调试程序继续调试。
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>默认运行空间必须是本地运行空间</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>静态 PrimaryRunspace 属性只能设置一次，并且已设置。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/SessionStateStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/SessionStateStrings.zh-Hans.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>无法处理返回的信息，因为提供程序 Start 方法返回的信息属于其他提供程序，而不是传入的提供程序。</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>无法处理返回的信息，因为从提供程序的 Start 方法返回的信息为 null。</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetItem 操作失败。 {2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 GetItem 操作的动态参数。 {2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 SetItem 操作失败。 {2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 SetItem 操作的动态参数。 {2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 ClearItem 操作失败。 {2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 InvokeDefaultAction 操作失败。 {2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 InvokeDefaultAction 操作的动态参数。 {2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 ItemExists 操作失败。 {2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 ItemExists 操作的动态参数。 {2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 IsValidPath 操作失败。 {2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 IsItemContainer 操作失败。 {2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 RemoveItem 操作失败。 {2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetChildItems 操作失败。 {2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 GetChildItems 操作的动态参数。 {2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetChildNames 操作失败。 {2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 GetChildNames 操作的动态参数。 {2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 RenameItem 操作失败。 {2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 RenameItem 操作的动态参数。 {2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 NewItem 操作失败。 {2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 NewItem 操作的动态参数。 {2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 HasChildItems 操作失败。 {2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 CopyItem 操作失败。 {2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 CopyItem 操作的动态参数。 {2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetParentPath 操作失败。 {2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 NormalizeRelativePath 操作失败。 {2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 MakePath 操作失败。 {2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetChildName 操作失败。 {2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 MoveItem 操作失败。 {2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 MoveItem 操作的动态参数。 {2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 GetProperty 操作失败。 {2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 GetProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 SetProperty 操作失败。 {2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 SetProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 ClearProperty 操作失败。 {2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 ClearProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 NewProperty 操作失败。 {2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 NewProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 RemoveProperty 操作失败。 {2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 RemoveProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 CopyProperty 操作失败。 {2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索 CopyProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 MoveProperty 操作失败。 {2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索 MoveProperty 操作的动态参数。 {2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 RenameProperty 操作失败。 {2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索 RenameProperty 的动态参数。 {2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索内容读取器。 {2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索 GetContentReader 操作的动态参数。 {2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索内容编写器。 {2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法为路径 '{0}' 的 '{1}' 提供程序检索 GetContentWriter 操作的动态参数。 {2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>无法获取内容，因为它是目录：'{0}'。请改用 'Get-ChildItem'。</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>无法写入内容，因为它是目录：'{0}'。</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>没有可继续向后导航的位置历史记录。</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>没有可继续向前导航的位置历史记录。</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack 为空。</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 ClearContent 操作失败。 {2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>无法清除 '{0}' 的内容，因为它是一个目录。Clear-Content 仅支持文件。</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>无法从路径 '{0}' 的 '{1}' 提供程序检索 ClearContent 操作的动态参数。 {2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 ClearProperty 操作失败。 {2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>尝试对路径 '{0}' 的 '{1}' 提供程序执行 SetSecurityDescriptor 操作失败。 {2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>尝试对 '{0}' 提供程序执行 Start 操作失败。 {1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>尝试对 '{0}' 提供程序执行 InitializeDefaultDrives 操作失败。</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>尝试在 '{0}' 提供程序上对根为 '{1}' 的驱动器执行 NewDrive 操作失败。 {2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>无法检索 '{0}' 提供程序的 NewDrive 动态参数。 {1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>在 '{0}' 提供程序上调用 RemoveDrive 失败。 {1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>无法删除驱动器 '{0}'，因为提供程序 '{1}' 阻止了它。</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>路径 '{0}' 引用了基 '{1}' 之外的项。</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>对路径 '{0}' 调用 '{1}' 提供程序的内容编写器上的 Seek 失败。 {2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>在 '{0}' 提供程序的内容读取器或写入器上对路径 '{1}' 调用 Close 失败。 {2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>对路径 '{0}' 调用 '{1}' 提供程序的内容读取器上的 Read 失败。 {2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>对路径 '{0}' 调用 '{1}' 提供程序的内容编写器上的 Write 失败。 {2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>提供程序 '{0}' 不能用于使用变量语法获取或设置数据。 {2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>变量语法不能用于获取或设置提供程序中的数据。 {2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>S别名不可编写，因为别名 {0} 为只读或常量，且无法写入。</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>无法写入函数 {0} ，因为它是只读的或常量。</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>无法覆盖变量 {0} ，因为它是只读变量或常量。</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>无法访问变量 '${0}'，因为它是私有变量。</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>无法访问命令 {0}，因为它是专用命令。</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>无法访问该命令，因为它是专用命令。</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>无法访问会话状态资源，因为它是专用资源。</value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>未删除别名，因为别名 {0} 是常量或只读的。</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>无法删除函数 {0} ，因为它是常量。</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>无法删除变量 {0} ，因为它是常量或只读变量。如果变量是只读的，请指定 Force 选项后重试。</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>无法修改别名 {0}，因为它是常量。</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>别名 {0} 无法修改，因为它是只读的。</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>无法修改函数 {0} ，因为它是常量。</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>无法修改函数 {0} ，因为它是只读的。</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>别名 {0} 创建后不能设置为常量。只能在创建别名时将其设置为常量。</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>无法将现有函数 {0} 设为常量。只能在创建函数时将其设为常量。</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>现有变量 {0} 不能设为常量。变量只能在创建时设为常量。</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>Option 键无法从别名“{0}”中删除 AllScope 选项。</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>无法从函数 '{0}' 中删除 AllScope 选项。</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>无法从变量， '{0}' 中删除 AllScope 选项。</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>函数定义 '{0}' 包含作用域限定符，但没有函数名称。</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>无法删除提供程序 {0}。必须先删除与提供程序 {0} 关联的所有驱动器，然后才能删除提供程序 {0}。</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>无法处理驱动器名称，因为驱动器名称包含一个或多个以下无效字符：; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>新驱动器创建失败，因为提供程序不允许创建新驱动器。</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>提供的值 '{0}' 解析为多个位置堆栈。</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>找不到位置堆栈 '{0}'。它不存在或不是容器。</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>找不到路径“{0}”，因为该路径不存在。</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>找不到别名，因为别名 '{0}' 不存在。</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>无法设置位置，因为路径 '{0}' 解析为多个容器。一次只能将位置设置为一个容器。</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>无法处理变量，因为变量路径 '{0}' 解析为多个项。一次只能获取或设置一个变量值。</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>找不到驱动器。名为“{0}”的驱动器不存在。</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>找不到名称为 '{0}' 的提供程序。</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>找不到名称为 '{0}' 的提供程序。名称的格式不正确。提供程序名称只能包含字母数字字符，或者是后跟单个 '\' 再后跟字母数字字符的 PowerShell 管理单元名称。</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>'{0}' 解析为多个提供程序名称。可能的匹配项包括: {1}。</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>尝试创建提供程序的实例时出错。在程序集中找不到 '{0}' 的提供程序类型名称。</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>无法使用指定的提供程序名称 '{0}'，因为它包含一个或多个以下无效字符：\ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>尝试创建提供程序 '{0}' 的实例时出错。 {1}</value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>找不到名称为“{0}”的变量。</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>找不到名称为“{0}”的跟踪源。</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>名为 '{0}' 的驱动器已存在。</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>已存在名称为“{0}”的变量。</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>不允许使用该别名，因为名为 '{0}' 的别名已存在。</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>无法注册 cmdlet 提供程序，因为名为 '{0}' 的 cmdlet 提供程序已存在。</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>路径不是文件系统路径。</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>无法删除全局范围。</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>作用域编号 '{0}' 超过活动作用域数。</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>无法比较 PSDriveInfo。PSDriveInfo 实例只能与另一个 PSDriveInfo 实例进行比较。</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>cmdlet 提供程序无法流式传输结果，因为未指定用于流式传输输出的 cmdlet。</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>cmdlet 提供程序无法流式传输结果，因为未指定用于流式传输错误的 cmdlet。</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>未设置此提供程序的主位置。若要设置主位置，请调用"(get-psprovider '{0}').Home = 'path'"。</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>路径的格式不正确。提供程序路径必须包含提供程序 ID，后跟 "::"，再后跟提供程序特定路径。</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>无法移动该项，因为目标路径只能解析为单个路径。</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>无法移动该项，因为源路径和目标路径未解析为同一提供程序。</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>无法移动该项，因为源路径指向一个或多个项，而目标路径不是容器。请验证目标路径是否为容器，然后重试。</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>无法移动该项，因为目标已解析为多个路径。请指定会解析为单个目标的目标路径，然后重试。</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>无法将容器复制到现有叶项上。</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>无法将容器复制到其他容器。未指定 -Recurse 或 -Container 参数。</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>源路径和目标路径未解析为同一提供程序。</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>无法重命名项，因为路径已解析为多个项。一次只能重命名一个项。</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>由于提供程序中发生错误，因此无法使用提供程序 '{0}' 解析路径 '{1}'。</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>无法使用接口。此提供程序未实现 IContentCmdletProvider 接口。</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>无法使用接口。此提供程序不支持 IPropertyCmdletProvider 接口。</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>无法使用接口。此提供程序未实现 IDynamicPropertyCmdletProvider 接口。</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>此提供程序不支持 NavigationCmdletProvider 方法。</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>未处理提供程序方法。此提供程序不支持 ContainerCmdletProvider 方法。</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>无法调用方法。此提供程序不支持 ItemCmdletProvider 方法。</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>此提供程序不支持 DriveCmdletProvider 方法。</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>提供程序操作已停止，因为提供程序不支持此操作。</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>提供程序操作已停止，因为提供程序不支持“Depth”参数。</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>无法调用方法。此提供程序不支持内容 Seek 方法。</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>无法执行 ClearContent 操作。此提供程序不支持 ClearContent 操作。</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>提供程序不支持使用凭据。请在不指定凭据的情况下再次执行该操作。</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>FileSystem 提供程序仅在 New-PSDrive cmdlet 上支持凭据。请在不指定凭据的情况下再次执行该操作。</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>提供程序不支持事务。请在不使用 -UseTransaction 参数的情况下再次执行该操作。</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>无法调用方法。提供程序不支持使用筛选器。</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>无法创建驱动器。提供程序不支持使用凭据。</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>路径“{0}”处的项已存在。</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>无法复制项。路径 '{0}' 处的项不存在。</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>路径“{0}”处的项不存在。</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>包含存储在会话状态中的别名视图的驱动器</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>包含进程环境变量视图的驱动器</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>包含存储在会话状态中的函数视图的驱动器</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>包含存储在会话状态中的这些变量视图的驱动器</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>映射到当前用户临时目录路径的驱动器</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>无法创建链接 '{0}'，因为未指定目标值。</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>对 null 变量的引用始终返回 null 值。赋值没有效果。</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>会话中保留的最大历史记录对象数</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>无法重命名函数，因为函数 {0} 是只读的或常量。</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>无法重命名别名，因为别名 {0} 是只读的或常量。</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>无法重命名变量，因为变量 {0} 是只读的或常量。</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>无法在局部变量 {0}上设置选项。请使用 New-Variable 创建允许设置选项的变量。</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>Cmdlet {0} 无法修改，因为它是只读的。</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>无法删除变量 {0} ，因为该变量已优化且不可删除。请尝试使用 Remove-Variable cmdlet(不要使用任何别名)，或对用于删除变量的命令进行点源。</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>无法覆盖变量 {0} ，因为该变量已优化。请尝试使用 New-Variable 或 Set-Variable cmdlet(不要使用任何别名)，或者对用于设置变量的命令进行点源。</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>参数 {0} 和 {1} 不能一起使用。请仅指定一个参数。</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>目前仅 FileSystem 提供程序支持 Tail 参数。</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>不允许使用该别名，因为名为 '{0}' 且命令类型为 '{1}' 的命令已存在。</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>无法运行软件。权限被拒绝。</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>“-{0}”和“-{1}”是互斥的，不能同时指定。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>路径 '{0}' 无效。远程复制操作仅支持绝对路径。</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>无法验证远程路径“{0}”。</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>无法执行操作，因为会话 {0} 设置为 {1}。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>'{0}' 参数不能为 null 或为空。</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>会话状态变量</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式下，更改或创建变量 '{0}' 的作用域为 AllScope 将被阻止。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hans/TransactionStrings.zh-Hans.resx
+++ b/src/System.Management.Automation/resources/zh-Hans/TransactionStrings.zh-Hans.resx
@@ -118,57 +118,57 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="NoTransactionActive" xml:space="preserve">
-    <value>Cannot use transaction. No transaction is active.</value>
+    <value>无法使用事务。没有活动的事务。</value>
   </data>
   <data name="NoTransactionActiveForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. No transaction is active.</value>
+    <value>无法提交事务。没有活动的事务。</value>
   </data>
   <data name="NoTransactionActiveForRollback" xml:space="preserve">
-    <value>Cannot roll back the transaction, because there is no active transaction.</value>
+    <value>由于没有活动事务，因此无法回滚事务。</value>
   </data>
   <data name="CommittedTransactionForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been committed.</value>
+    <value>无法回滚事务。事务已提交。</value>
   </data>
   <data name="CommittedTransactionForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has already been committed.</value>
+    <value>无法提交事务。事务已提交。</value>
   </data>
   <data name="TransactionRolledBackForCommit" xml:space="preserve">
-    <value>Cannot commit transaction. The transaction has been rolled back or has timed out.</value>
+    <value>无法提交事务。事务已回滚或已超时。</value>
   </data>
   <data name="TransactionRolledBackForRollback" xml:space="preserve">
-    <value>Cannot roll back transaction. The transaction has already been rolled back or has timed out.</value>
+    <value>无法回滚事务。事务已回滚或超时。</value>
   </data>
   <data name="NoTransactionForActivation" xml:space="preserve">
-    <value>Cannot set active transaction. No transaction has been created.</value>
+    <value>无法设置活动事务。尚未创建任何事务。</value>
   </data>
   <data name="NoTransactionForActivationBecauseRollback" xml:space="preserve">
-    <value>Cannot set active transaction. The active transaction has been rolled back or has timed out.</value>
+    <value>无法设置活动事务。活动事务已回滚或已超时。</value>
   </data>
   <data name="NoTransactionAvailable" xml:space="preserve">
-    <value>This cmdlet requires an active transaction. The current transaction has already been committed or rolled back.</value>
+    <value>此 cmdlet 需要一个活动事务。当前事务已提交或已回滚。</value>
   </data>
   <data name="CmdletRequiresUseTx" xml:space="preserve">
-    <value>This cmdlet requires a transaction. Run the command again with the -UseTransaction parameter.</value>
+    <value>此 cmdlet 需要一个事务。使用 -UseTransaction 参数再次运行该命令。</value>
   </data>
   <data name="NoTransactionStarted" xml:space="preserve">
-    <value>Cannot use transaction. No transaction has been started.</value>
+    <value>无法使用事务。尚未启动任何事务。</value>
   </data>
   <data name="NoTransactionStartedFromCommit" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been committed.</value>
+    <value>无法使用事务。事务已提交。</value>
   </data>
   <data name="NoTransactionStartedFromRollback" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has been rolled back or has timed out.</value>
+    <value>无法使用事务。事务已回滚或已超时。</value>
   </data>
   <data name="TransactionTimedOut" xml:space="preserve">
-    <value>Cannot use transaction. The transaction has timed out.</value>
+    <value>无法使用事务。事务已超时。</value>
   </data>
   <data name="BaseTransactionNotSet" xml:space="preserve">
-    <value>The base transaction has not been set.</value>
+    <value>尚未设置基本事务。</value>
   </data>
   <data name="BaseTransactionNotActive" xml:space="preserve">
-    <value>The base transaction is not active.</value>
+    <value>基本事务未处于活动状态。</value>
   </data>
   <data name="BaseTransactionMustBeFirst" xml:space="preserve">
-    <value>The base transaction cannot be set after other transactions have been created.</value>
+    <value>创建其他事务后，无法设置基本事务。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/CredUI.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/CredUI.zh-Hant.resx
@@ -118,21 +118,21 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="PromptForCredential_DefaultCaption" xml:space="preserve">
-    <value>PowerShell credential request </value>
+    <value>PowerShell 認證要求 </value>
   </data>
   <data name="PromptForCredential_DefaultMessage" xml:space="preserve">
-    <value>Enter your credentials. </value>
+    <value>請輸入您的認證。</value>
   </data>
   <data name="PromptForCredential_DefaultTarget" xml:space="preserve">
-    <value>Enter your credentials.</value>
+    <value>請輸入您的認證。</value>
   </data>
   <data name="PromptForCredential_InvalidCaption" xml:space="preserve">
-    <value>The maximum length of the caption is {0} characters.</value>
+    <value>標題的長度上限為 {0} 個字元。</value>
   </data>
   <data name="PromptForCredential_InvalidMessage" xml:space="preserve">
-    <value>The maximum length of the message is {0} characters.</value>
+    <value>訊息的長度上限為 {0} 個字元。</value>
   </data>
   <data name="PromptForCredential_InvalidUserName" xml:space="preserve">
-    <value>The maximum length of the UserName value is {0} characters.</value>
+    <value>UserName 值的長度上限為 {0} 個字元。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/ErrorCategoryStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/ErrorCategoryStrings.zh-Hant.resx
@@ -127,7 +127,7 @@
     <value>DeviceError: ({1}:{2}) [{0}], {3}</value>
   </data>
   <data name="InvalidArgument" xml:space="preserve">
-    <value>InvalidArgument: ({1}:{2}) [{0}], {3}</value>
+    <value>InvalidArgument: ({1}:{2}) [{0}], {3}I</value>
   </data>
   <data name="InvalidData" xml:space="preserve">
     <value>InvalidData: ({1}:{2}) [{0}], {3}</value>

--- a/src/System.Management.Automation/resources/zh-Hant/ExtendedTypeSystem.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/ExtendedTypeSystem.zh-Hant.resx
@@ -118,289 +118,289 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MemberAlreadyPresent" xml:space="preserve">
-    <value>The member "{0}" is already present.</value>
+    <value>成員 "{0}" 已經存在。</value>
   </data>
   <data name="MemberAlreadyPresentFromTypesXml" xml:space="preserve">
-    <value>The member "{0}" is already present from the extended type data file.</value>
+    <value>延伸類型資料檔案中已經有成員 "{0}"。</value>
   </data>
   <data name="MemberNotPresent" xml:space="preserve">
-    <value>The member "{0}" is not present.</value>
+    <value>成員 "{0}" 不存在。</value>
   </data>
   <data name="ExceptionWhenSetting" xml:space="preserve">
-    <value>Exception setting "{0}": "{1}"</value>
+    <value>例外狀況設定 "{0}": "{1}"</value>
   </data>
   <data name="ExceptionWhenGetting" xml:space="preserve">
-    <value>Exception getting "{0}": "{1}"</value>
+    <value>取得 "{0}" 時發生例外狀況: "{1}"</value>
   </data>
   <data name="EnumerationException" xml:space="preserve">
-    <value>The following exception occurred while trying to enumerate the collection: "{0}".</value>
+    <value>嘗試列舉集合時發生下列例外狀況: “{0}”。</value>
   </data>
   <data name="AccessMemberOutsidePSObject" xml:space="preserve">
-    <value>Cannot access member "{0}" outside of a PSObject.</value>
+    <value>無法存取 PSObject 之外的成員 "{0}"。</value>
   </data>
   <data name="ChangeStaticMember" xml:space="preserve">
-    <value>Cannot change the member created from the type configuration: "{0}".</value>
+    <value>無法變更從類型設定建立的成員:“{0}”。</value>
   </data>
   <data name="ReservedMemberName" xml:space="preserve">
-    <value>The member name "{0}" is reserved.</value>
+    <value>已保留成員名稱 “{0}”。</value>
   </data>
   <data name="CannotChangeReservedMember" xml:space="preserve">
-    <value>"{0}" cannot be changed.</value>
+    <value>無法變更 "{0}"。</value>
   </data>
   <data name="MethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" with "{1}" argument(s): "{2}"</value>
+    <value>使用 "{1}" 引數: "{2}" 呼叫 “{0}” 時發生例外狀況</value>
   </data>
   <data name="CopyToInvocationException" xml:space="preserve">
-    <value>An exception was thrown when trying to call "{0}" to extract the contents of an object of type "{1}": "{2}"</value>
+    <value>嘗試呼叫 “{0}” 以擷取 “{1}” 類型的物件內容時擲回例外狀況: "{2}"</value>
   </data>
   <data name="MethodArgumentCountException" xml:space="preserve">
-    <value>Cannot find an overload for "{0}" and the argument count: "{1}".</value>
+    <value>找不到適用於 "{0}" 的多載且引數計數為 "{1}"。</value>
   </data>
   <data name="MethodGenericArgumentCountException" xml:space="preserve">
-    <value>Could not find a suitable generic method overload for "{0}" with "{1}" type parameters, and the argument count: "{2}".</value>
+    <value>對於具 "{1}" 類型參數的 "{0}"，找不到合適的泛型方法多載，且引數計數為 "{2}"。</value>
   </data>
   <data name="MethodAmbiguousException" xml:space="preserve">
-    <value>Multiple ambiguous overloads found for "{0}" and the argument count: "{1}".</value>
+    <value>找到適用於 “{0}” 的多個不明確多載，且引數計數為 “{1}”。</value>
   </data>
   <data name="MethodArgumentConversionException" xml:space="preserve">
-    <value>Cannot convert argument "{0}", with value: "{1}", for "{2}" to type "{3}": "{4}"</value>
+    <value>無法將適用於 “{2}” 的引數 "{0}" (值為 "{1}") 轉換為 "{3}" 類型: "{4}"</value>
   </data>
   <data name="GetWithoutGetterException" xml:space="preserve">
-    <value>Get accessor for property "{0}" is unavailable.</value>
+    <value>無法取得屬性 “{0}” 的存取子。</value>
   </data>
   <data name="SetWithoutSetterException" xml:space="preserve">
-    <value>Set accessor for property "{0}" is unavailable.</value>
+    <value>無法設定屬性 “{0}” 的存取子。</value>
   </data>
   <data name="CodePropertySetterFormat" xml:space="preserve">
-    <value>The setter method should be public, void, static, and have two parameters. The first parameter should be of the type PSObject. A second parameter is required if a getter method is also available, and should have the same type as the return type for the getter method.</value>
+    <value>Setter 方法應為公用、無效、靜態，且具有兩個參數。第一個參數應為 PSObject 類型。如果 getter 方法也可用，則第二個參數為必要，且其類型應該與 getter 方法的傳回類型相同。</value>
   </data>
   <data name="CodePropertyGetterFormat" xml:space="preserve">
-    <value>The getter method should be public, not void, static, and have one parameter of the type PSObject.</value>
+    <value>Getter 方法應為公用，非無效、靜態，且具有一個 PSObject 類型的參數。</value>
   </data>
   <data name="CodePropertyGetterAndSetterNull" xml:space="preserve">
-    <value>CodeProperty should use a getter or setter method.</value>
+    <value>CodeProperty 應該使用 getter 或 setter 方法。</value>
   </data>
   <data name="CodeMethodMethodFormat" xml:space="preserve">
-    <value>Cannot create a code method because of the method format. The method should be public, static, and have one parameter of type PSObject.</value>
+    <value>因為方法格式，無法建立程式碼方法。此方法應為公用、靜態，且具有一個 PSObject 類型的參數。</value>
   </data>
   <data name="CycleInAlias" xml:space="preserve">
-    <value>The alias with name "{0}" contains a cycle.</value>
+    <value>名稱為 “{0}” 的別名包含循環。</value>
   </data>
   <data name="InvalidCastException" xml:space="preserve">
-    <value>Cannot convert the "{0}" value of type "{1}" to type "{2}".</value>
+    <value>無法將 "{1}" 類型的 "{0}" 值轉換為 "{2}" 類型。</value>
   </data>
   <data name="InvalidCastExceptionWithoutValue" xml:space="preserve">
-    <value>Cannot convert the value of type "{0}" to type "{1}".</value>
+    <value>無法將 "{0}" 類型的值轉換為 "{1}" 類型。</value>
   </data>
   <data name="InvalidCastExceptionWithInnerException" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Error: "{2}"</value>
+    <value>無法將值 "{0}" 轉換為 "{1}" 類型。錯誤: "{2}"</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoFlagAndComma" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because no commas are allowed for this enumeration.</value>
+    <value>無法將值 “{0}” 轉換為 “{1}” 類型，因為此列舉不允許使用逗號。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNoValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{2}".</value>
+    <value>由於列舉值無效，因此無法將值 "{0}" 轉換為 “{1}” 類型。指定下列其中一個列舉值，然後再試一次。可能的列舉值為 “{2}”。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}" due to enumeration values that are not valid. Specify one of the following enumeration values and try again. The possible enumeration values are "{1}".</value>
+    <value>由於列舉值無效，因此無法將 null 轉換為 “{0}” 類型。指定下列其中一個列舉值，然後再試一次。可能的列舉值為 “{1}”。</value>
   </data>
   <data name="InvalidCastFromNull" xml:space="preserve">
-    <value>Cannot convert null to type "{0}".</value>
+    <value>無法將 null 轉換為 "{0}" 類型。</value>
   </data>
   <data name="InvalidCastExceptionNoStringForConversion" xml:space="preserve">
-    <value>Cannot convert value to type "{0}".  Error: "{1}"</value>
+    <value>無法將值轉換為 "{0}" 類型。 錯誤: "{1}"</value>
   </data>
   <data name="InvalidCastCannotRetrieveString" xml:space="preserve">
-    <value>Cannot convert value to type System.String.</value>
+    <value>無法將值轉換為 System.String 類型。</value>
   </data>
   <data name="ReferenceTypeExpected" xml:space="preserve">
-    <value>Reference type is expected in argument.</value>
+    <value>引數中預期有參考類型。</value>
   </data>
   <data name="NotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" because it is not IComparable.</value>
+    <value>無法比較 “{0}”，因為它不是 IComparable。</value>
   </data>
   <data name="ComparisonFailure" xml:space="preserve">
-    <value>Could not compare "{0}" to "{1}". Error: "{2}"</value>
+    <value>無法比較 "{0}" 與 "{1}"。錯誤: "{2}"</value>
   </data>
   <data name="NotTheSameTypeOrNotIcomparable" xml:space="preserve">
-    <value>Cannot compare "{0}" to "{1}" because the objects are not the same type or the object "{0}" does not implement "{2}".</value>
+    <value>無法比較 “{0}” 與 “{1}”，因為物件不是相同的類型或物件 “{0}” 未實作 “{2}“。</value>
   </data>
   <data name="InvalidCastExceptionEnumerationMoreThanOneValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}" because at least two matches were found ({2}, {3}) and only one match is allowed for this enumeration.</value>
+    <value>無法將值 “{0}” 轉換為 “{1}”類型，因為找到至少兩個相符項目 ({2}、{3})，而且此列舉只允許一個相符項目。</value>
   </data>
   <data name="InvalidCastExceptionForBooleanArgumentValue" xml:space="preserve">
-    <value>Cannot convert value "{0}" to type "{1}". Boolean parameters accept only Boolean values and numbers, such as $True, $False, 1 or 0.</value>
+    <value>無法將值 "{0}" 轉換為 "{1}" 類型。布林值參數只接受布林值和數字，例如 $True、$False、1 或 0。</value>
   </data>
   <data name="WriteOnlyProperty" xml:space="preserve">
-    <value>Cannot get property value because "{0}" is a write-only property.</value>
+    <value>無法取得屬性值，因為 “{0}” 是僅限寫入的屬性。</value>
   </data>
   <data name="ReadOnlyProperty" xml:space="preserve">
-    <value>"{0}" is a ReadOnly property.</value>
+    <value>"{0}" 是唯讀屬性。</value>
   </data>
   <data name="XmlNodeSetShouldBeAString" xml:space="preserve">
-    <value>Cannot set "{0}" because only strings can be used as values to set XmlNode properties.</value>
+    <value>無法設定 "{0}"，因為只能使用字串做為值來設定 XmlNode 屬性。</value>
   </data>
   <data name="XmlNodeSetRestrictions" xml:space="preserve">
-    <value>Cannot set "{0}" because only unique attributes or unique non-attributed leaf nodes can be set.</value>
+    <value>無法設定“{0}”，因為只能設定唯一屬性或唯一非屬性分頁節點。</value>
   </data>
   <data name="CannotAddPropertyOrMethod" xml:space="preserve">
-    <value>A PSProperty or PSMethod object cannot be added to this collection.</value>
+    <value>PSProperty 或 PSMethod 物件無法新增到此集合。</value>
   </data>
   <data name="TypesXmlError" xml:space="preserve">
-    <value>The following error occurred while loading the extended type data file: {0}</value>
+    <value>載入延伸類型資料檔案時發生下列錯誤: {0}</value>
   </data>
   <data name="ToStringException" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string: "{0}"</value>
+    <value>在擷取字串時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="NotAClsCompliantFieldProperty" xml:space="preserve">
-    <value>The field or property: "{0}" for type: "{1}" differs only in letter casing from the field or property: "{2}". The type must be Common Language Specification (CLS) compliant.</value>
+    <value>類型 “{1}” 的欄位或屬性 “{0}” 只與欄位或屬性 “{2}” 的字母大小寫不同。此類型必須符合通用語言規格 (CLS) 規範。</value>
   </data>
   <data name="ExceptionRetrievingTypeNameHierarchy" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type name hierarchy: "{0}".</value>
+    <value>擷取類型名稱階層時發生下列例外狀況: "{0}"。</value>
   </data>
   <data name="ExceptionGettingMember" xml:space="preserve">
-    <value>The following exception occurred while retrieving member "{1}": "{0}"</value>
+    <value>在擷取成員 "{1}" 時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionGettingMembers" xml:space="preserve">
-    <value>The following exception occurred while retrieving members: "{0}"</value>
+    <value>在擷取成員時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for property "{1}": "{0}"</value>
+    <value>擷取屬性 "{1}" 的讀取狀態時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for property "{1}": "{0}"</value>
+    <value>擷取屬性 "{1}" 的寫入狀態時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyType" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for property "{1}": "{0}"</value>
+    <value>擷取屬性 "{1}" 的類型時發生下列例外狀況: "{0}"。</value>
   </data>
   <data name="ExceptionRetrievingPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for property "{1}" : "{0}"</value>
+    <value>擷取屬性 "{1}" 的字串表示法時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingPropertyAttributes" xml:space="preserve">
-    <value>The following exception occurred while retrieving the attributes for property "{1}": "{0}"</value>
+    <value>針對屬性 (Property) "{1}" 擷取屬性 (Attribute) 時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingMethodDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for method "{1}": "{0}"</value>
+    <value>擷取方法 "{1}" 的定義時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingMethodString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for method "{1}": "{0}"</value>
+    <value>擷取方法 "{1}" 的字串表示法時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertytype" xml:space="preserve">
-    <value>The following exception occurred while retrieving the type for parameterized property "{1}": "{0}"</value>
+    <value>擷取參數化屬性 "{1}" 的類型時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyReadState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the read state for parameterized property "{1}": "{0}"</value>
+    <value>擷取參數化屬性 "{1}" 的讀取狀態時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyWriteState" xml:space="preserve">
-    <value>The following exception occurred while retrieving the write state for parameterized property "{1}": "{0}"</value>
+    <value>擷取參數化屬性 "{1}" 的寫入狀態時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyDefinitions" xml:space="preserve">
-    <value>The following exception occurred while retrieving the definitions for parameterized property "{1}": "{0}"</value>
+    <value>擷取參數化屬性 "{1}" 的定義時發生下列例外狀況: “{0}”</value>
   </data>
   <data name="ExceptionRetrievingParameterizedPropertyString" xml:space="preserve">
-    <value>The following exception occurred while retrieving the string representation for parameterized property "{1}": "{0}"</value>
+    <value>擷取參數化屬性 "{1}" 的字串表示法時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="CannotSetValueForMemberType" xml:space="preserve">
-    <value>Cannot set the Value property for PSMemberInfo object of type "{0}".</value>
+    <value>無法為 "{0}" 類型的 PSMemberInfo 物件設定 Value 屬性。</value>
   </data>
   <data name="NonRefArgumentToRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should be a {1}. Use {2}.</value>
+    <value>引數 '{0}' 應為 {1}。使用 {2}。</value>
   </data>
   <data name="RefArgumentToNonRefParameter" xml:space="preserve">
-    <value>Argument: '{0}' should not be a {1}. Do not use {2}.</value>
+    <value>引數 '{0}' 不應該是 {1}。請勿使用 {2}。</value>
   </data>
   <data name="PropertyNotFoundInTypeDescriptor" xml:space="preserve">
     <value>找不到屬性 "{0}"。</value>
   </data>
   <data name="InvalidComponent" xml:space="preserve">
-    <value>Cannot get or set the property value. The "{0}" argument should be of type "{1}" or "{2}".</value>
+    <value>無法取得或設定屬性值。"{0}" 引數的類型應為 "{1}" 或 "{2}"。</value>
   </data>
   <data name="CannotSetNonManagementObject" xml:space="preserve">
-    <value>Cannot set the value for property "{0}" because the object has type "{1}" instead of "{2}".</value>
+    <value>無法設定屬性 “{0}”的值，因為物件的類型是 “{1}” 而不是 “{2}”。</value>
   </data>
   <data name="WMIMethodInvocationException" xml:space="preserve">
-    <value>Exception calling "{0}" : "{1}"</value>
+    <value>呼叫 “{0}” 時發生例外狀況: “{1}”</value>
   </data>
   <data name="InvalidWMIClassPath" xml:space="preserve">
-    <value>{0} is not a valid class path.</value>
+    <value>{0} 不是有效的類別路徑。</value>
   </data>
   <data name="InvalidWMIPath" xml:space="preserve">
     <value>{0} 不是有效的路徑。</value>
   </data>
   <data name="PropertyIsSettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" can be changed.</value>
+    <value>配接器無法判斷是否可變更屬性 “{0}”。</value>
   </data>
   <data name="PropertyIsGettableError" xml:space="preserve">
-    <value>The adapter cannot determine whether property "{0}" is gettable.</value>
+    <value>配接器無法判斷是否可取得屬性 “{0}”。</value>
   </data>
   <data name="PropertyGetError" xml:space="preserve">
-    <value>The adapter cannot get the value of property "{0}".</value>
+    <value>配接器無法取得屬性 “{0}” 的值。</value>
   </data>
   <data name="PropertySetError" xml:space="preserve">
-    <value>The adapter cannot set the value of property "{0}".</value>
+    <value>配接器無法設定屬性 “{0}” 的值。</value>
   </data>
   <data name="PropertyTypeError" xml:space="preserve">
-    <value>The adapter cannot get the type of property "{0}".</value>
+    <value>配接器無法取得屬性 “{0}” 的類型。</value>
   </data>
   <data name="GetTypeNameHierarchyError" xml:space="preserve">
-    <value>The adapter cannot get the type hierarchy of "{0}".</value>
+    <value>配接器無法取得 “{0}” 的類型階層。</value>
   </data>
   <data name="GetProperties" xml:space="preserve">
-    <value>The adapter cannot get the properties of "{0}".</value>
+    <value>配接器無法取得 “{0}” 的屬性。</value>
   </data>
   <data name="GetProperty" xml:space="preserve">
-    <value>The adapter cannot get property "{0}" for "{1}".</value>
+    <value>配接器無法取得 “{1}” 的屬性 “{0}”。</value>
   </data>
   <data name="NullReturnValueError" xml:space="preserve">
-    <value>"{0}" returned a null value.</value>
+    <value>"{0}" 傳回了 Null 值。</value>
   </data>
   <data name="PropertyNotFound" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. The settable properties are: {2}.</value>
+    <value>找不到 '{1}' 物件的屬性 '{0}'。可設定的屬性為: {2}。</value>
   </data>
   <data name="NoSettableProperty" xml:space="preserve">
-    <value>The property '{0}' was not found for the '{1}' object. There is no settable property available.</value>
+    <value>找不到 '{1}' 物件的屬性 '{0}'。沒有可設定的屬性可用。</value>
   </data>
   <data name="ObjectCreationError" xml:space="preserve">
-    <value>Cannot create object of type "{0}". {1}</value>
+    <value>無法建立 "{0}" 類型的物件。{1}</value>
   </data>
   <data name="CannotInvokeStaticMethodOnUninstantiatedGenericType" xml:space="preserve">
-    <value>Cannot invoke static methods or access static properties on the open generic type {0}.  Specify the type parameters and retry.  For example, instead of [System.Collections.Generic.HashSet``1]::CreateSetComparer() use [System.Collections.Generic.HashSet[int]]::CreateSetComparer().</value>
+    <value>無法叫用靜態方法或存取開放泛型類型 {0} 上的靜態屬性。 指定類型參數，然後重試。 例如，不使用 [System.Collections.Generic.HashSet``1]::CreateSetComparer()，而使用 [System.Collections.Generic.HashSet[int]]::CreateSetComparer()。</value>
     <comment>Error message shown when somebody tries to access a property or invoke a static method on an uninstantiated generic type:
 PS&gt; [System.Collections.Generic.Comparer``1]::get_Default()
 
 {0} is a placeholder for a type name (for example: System.Collections.Generic.Comparer`1)</comment>
   </data>
   <data name="ExceptionConstructingAttribute" xml:space="preserve">
-    <value>The following exception occurred while constructing the attribute "{1}": "{0}"</value>
+    <value>建構屬性 “{1}” 時發生下列例外狀況: "{0}"</value>
   </data>
   <data name="CannotConvertValueToStringArray" xml:space="preserve">
-    <value>The value "{0}" cannot be converted to a string array.</value>
+    <value>值 "{0}" 無法轉換為字串陣列。</value>
   </data>
   <data name="InvalidCastExceptionNonCoreType" xml:space="preserve">
-    <value>Cannot convert value to type "{0}". Only core types are supported in this language mode.</value>
+    <value>無法將值轉換為 "{0}" 類型。此語言模式只支援核心類型。</value>
   </data>
   <data name="InvalidCastToByRefLikeType" xml:space="preserve">
-    <value>Cannot convert to the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>無法轉換為類似 ByRef 的類型 “{0}”。PowerShell 不支援 ByRef 類型。</value>
   </data>
   <data name="CannotAccessByRefLikePropertyOrField" xml:space="preserve">
-    <value>Cannot get or set the property or field "{0}" of the ByRef-like type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>無法取得或設定類似 ByRef 類型 “{1}” 的屬性或欄位 “{0}”。PowerShell 不支援 ByRef 類型。</value>
   </data>
   <data name="CannotCallMethodWithByRefLikeReturnType" xml:space="preserve">
-    <value>Cannot invoke the method "{0}" of the ByRef-like return type "{1}". ByRef-like types are not supported in PowerShell.</value>
+    <value>無法叫用類似 ByRef 傳回類型 "{1}" 的方法 "{0}"。PowerShell 不支援 ByRef 類型。</value>
   </data>
   <data name="CannotInstantiateBoxedByRefLikeType" xml:space="preserve">
-    <value>Cannot create an instance of the ByRef-like type "{0}". ByRef-like types are not supported in PowerShell.</value>
+    <value>無法建立類似 ByRef 類型 “{0}” 的執行個體。PowerShell 不支援 ByRef 類型。</value>
   </data>
   <data name="WDACHashTypeLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>延伸類型系統雜湊表轉換</value>
   </data>
   <data name="WDACHashTypeLogMessage" xml:space="preserve">
-    <value>Type conversion from HashTable to '{0}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 模式不允許類型從 HashTable 轉換為 '{0}'。</value>
   </data>
   <data name="WDACTypeConversionLogTitle" xml:space="preserve">
-    <value>Extended Type System Hashtable Conversion</value>
+    <value>延伸類型系統雜湊表轉換</value>
   </data>
   <data name="WDACTypeConversionLogMessage" xml:space="preserve">
-    <value>Type conversion from '{0}' to '{1}' will not be allowed in ConstrainedLanguage mode.</value>
+    <value>ConstrainedLanguage 模式不允許類型從 '{0}' 轉換為 '{1}'。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/Metadata.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/Metadata.zh-Hant.resx
@@ -118,150 +118,150 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="MetadataMemberInitialization" xml:space="preserve">
-    <value>Cannot initialize attributes for "{0}": "{1}"</value>
+    <value>無法初始化 "{0}" 的屬性: "{1}"</value>
   </data>
   <data name="ValidateRangeElementType" xml:space="preserve">
-    <value>The argument cannot be validated because its type "{0}" is not the same type ({1}) as the maximum and minimum limits of the parameter. Make sure the argument is of type {1} and then try the command again.</value>
+    <value>無法驗證引數，因為其型別 "{0}" 與參數上限和下限的型別 ({1}) 不同。請確定引數的型別為 {1}，然後再試一次命令。</value>
   </data>
   <data name="ValidateRangePositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than zero.</value>
+    <value>無法驗證引數 "{0}"，因為其值不是大於零。</value>
   </data>
   <data name="ValidateRangeNonNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not greater than or equal to zero.</value>
+    <value>無法驗證引數 "{0}"，因為其值不是大於或等於零。</value>
   </data>
   <data name="ValidateRangeNegativeFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than zero.</value>
+    <value>無法驗證引數 "{0}"，因為其值不是小於零。</value>
   </data>
   <data name="ValidateRangeNonPositiveFailure" xml:space="preserve">
-    <value>The argument "{0}" cannot be validated because its value is not less than or equal to zero.</value>
+    <value>無法驗證引數 "{0}"，因為其值不是小於或等於零。</value>
   </data>
   <data name="ValidateRangeMinRangeMaxRangeType" xml:space="preserve">
-    <value>The specified minimum range ({0}) cannot be accepted because it is not the same type as the specified maximum range ({1}). Update the ValidateRange attribute for the parameter.</value>
+    <value>無法接受指定的最小範圍 ({0})，因為其型別與指定的最大範圍 ({1}) 不同。請更新該參數的 ValidateRange 屬性。</value>
   </data>
   <data name="ValidateRangeNotIComparable" xml:space="preserve">
-    <value>Cannot accept the MaxRange and MinRange parameter types. Both parameters must be objects that implement an IComparable interface.</value>
+    <value>無法接受 MaxRange 和 MinRange 參數型別。這兩個參數都必須是實作 IComparable 介面的物件。</value>
   </data>
   <data name="ValidateRangeMaxRangeSmallerThanMinRange" xml:space="preserve">
-    <value>The specified maximum range cannot be accepted because it is less than the specified minimum range. Update the ValidateRange attribute for the parameter.</value>
+    <value>無法接受指定的最大範圍，因為它小於指定的最小範圍。請更新該參數的 ValidateRange 屬性。</value>
   </data>
   <data name="ValidateRangeGreaterThanMaxRangeFailure" xml:space="preserve">
-    <value>The {0} argument is greater than the maximum allowed range of {1}. Supply an argument that is less than or equal to {1} and then try the command again.</value>
+    <value>{0} 引數大於允許範圍的上限 {1}。請提供小於或等於 {1} 的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateRangeSmallerThanMinRangeFailure" xml:space="preserve">
-    <value>The {0} argument is less than the minimum allowed range of {1}. Supply an argument that is greater than or equal to {1} and then try the command again.</value>
+    <value>{0} 引數小於允許範圍的下限 {1}。請提供大於或等於 {1} 的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidatePatternFailure" xml:space="preserve">
-    <value>The argument "{0}" does not match the "{1}" pattern. Supply an argument that matches "{1}" and try the command again.</value>
+    <value>引數 "{0}" 不符合 "{1}" 模式。請提供符合 "{1}" 的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateCountNotInArray" xml:space="preserve">
-    <value>The ValidateCount attribute cannot be applied to a non-array parameter. Either remove the attribute from the parameter or make the parameter an array parameter.</value>
+    <value>ValidateCount 屬性無法套用至非陣列參數。請從參數移除該屬性，或將參數設為陣列參數。</value>
   </data>
   <data name="ValidateCountExactFailure" xml:space="preserve">
-    <value>The parameter requires exactly {0} value(s) - {1} value(s) were provided.</value>
+    <value>參數需要剛好 {0} 個值 - 提供了 {1} 個值。</value>
   </data>
   <data name="ValidateCountMinMaxFailure" xml:space="preserve">
-    <value>The parameter requires at least {0} value(s) and no more than {1} value(s) - {2} value(s) were provided.</value>
+    <value>參數需要至少 {0} 個值且不超過 {1} 個值 - 提供了 {2} 個值。</value>
   </data>
   <data name="ValidateCountMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum number of arguments for a parameter is fewer than the specified minimum number of arguments. Update the ValidateCount attribute for the parameter.</value>
+    <value>指定的參數引數數目上限少於指定的引數數目下限。請更新參數的 ValidateCount 屬性。</value>
   </data>
   <data name="ValidateLengthMaxLengthSmallerThanMinLength" xml:space="preserve">
-    <value>The specified maximum character length of the argument is shorter than the specified minimum argument character length. Update the ValidateLength attribute for the parameter.</value>
+    <value>指定的引數字元長度上限短於指定的引數字元長度下限。請更新參數的 ValidateLength 屬性。</value>
   </data>
   <data name="ValidateLengthNotString" xml:space="preserve">
-    <value>The ValidateLength attribute cannot be applied to a parameter that is not a string or string[] parameter. Make the parameter a string or string[] parameter.</value>
+    <value>ValidateLength 屬性無法套用至不是 string 或 string[] 的參數。請將參數設為 string 或 string[] 參數。</value>
   </data>
   <data name="ValidateLengthMinLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too short. Specify an argument with a length that is greater than or equal to "{0}", and then try the command again.</value>
+    <value>引數的字元長度 ({1}) 太短。請指定長度大於或等於 "{0}" 的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateLengthMaxLengthFailure" xml:space="preserve">
-    <value>The character length ({1}) of the argument is too long. Specify an argument with a length that is shorter than or equal to "{0}", and then try the command again.</value>
+    <value>引數的字元長度 ({1}) 太長。請指定長度小於或等於 "{0}" 的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateSetFailure" xml:space="preserve">
-    <value>The argument "{0}" does not belong to the set "{1}" specified by the ValidateSet attribute. Supply an argument that is in the set and then try the command again.</value>
+    <value>引數 "{0}" 不屬於 ValidateSet 屬性指定的集合 "{1}"。請提供該集合中的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateSetGeneratedValidValuesListIsNull" xml:space="preserve">
-    <value>Valid values generator return a null value.</value>
+    <value>有效值產生器傳回 null 值。</value>
   </data>
   <data name="ValidateFailureResult" xml:space="preserve">
-    <value>"{0}" failed on property "{1}" {2}</value>
+    <value>"{0}" 在屬性 "{1}" 上失敗 {2}</value>
   </data>
   <data name="ParsingTooManyParameterSets" xml:space="preserve">
-    <value>Cannot get or run the command. The maximum number of parameter sets for this command has been exceeded.</value>
+    <value>無法取得或執行命令。已超過此命令的參數集數目上限。</value>
   </data>
   <data name="ArgumentTransformationArgumentsShouldBeStrings" xml:space="preserve">
-    <value>Cannot process the argument because the argument value is not a string. The values of parameter arguments that have the ArgumentTransformationAttribute specified should be strings.</value>
+    <value>無法處理引數，因為引數值不是字串。已指定 ArgumentTransformationAttribute 的參數引數值應為字串。</value>
   </data>
   <data name="InvalidValueFailure" xml:space="preserve">
-    <value>The variable cannot be validated because the value {1} is not a valid value for the {0} variable.</value>
+    <value>無法驗證變數，因為值 {1} 不是 {0} 變數的有效值。</value>
   </data>
   <data name="InvalidMetadataForCurrentValue" xml:space="preserve">
-    <value>The attribute cannot be added because variable {0} with value {1} would no longer be valid.</value>
+    <value>無法新增屬性，因為值為 {1} 的變數 {0} 將不再有效。</value>
   </data>
   <data name="ValidateNotNullFailure" xml:space="preserve">
-    <value>The argument is null. Provide a valid value for the argument, and then try running the command again.</value>
+    <value>引數為 null。請提供有效的引數值，然後再嘗試執行命令。</value>
   </data>
   <data name="ValidateNotNullCollectionFailure" xml:space="preserve">
-    <value>The argument has a null value, or an element of the argument collection contains a null value. Provide a collection that does not contain any null values, and then try the command again.</value>
+    <value>引數具有 null 值，或引數集合中的某個元素包含 null 值。請提供不包含任何 null 值的集合，然後再試一次命令。</value>
   </data>
   <data name="ValidateNotNullOrEmptyFailure" xml:space="preserve">
-    <value>The argument is null or empty. Provide an argument that is not null or empty, and then try the command again.</value>
+    <value>引數為 null 或空白。請提供非 null 且非空白的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateNotNullOrEmptyCollectionFailure" xml:space="preserve">
-    <value>The argument is null, empty, or an element of the argument collection contains a null value. Supply a collection that does not contain any null values and then try the command again.</value>
+    <value>引數為 null、空白，或引數集合中的某個元素包含 null 值。請提供不包含任何 null 值的集合，然後再試一次命令。</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceFailure" xml:space="preserve">
-    <value>The argument is null, empty, or consists of only white-space characters. Provide an argument that contains non white-space characters, and then try the command again.</value>
+    <value>引數為 null、空白，或僅包含空白字元。請提供包含非空白字元的引數，然後再試一次命令。</value>
   </data>
   <data name="ValidateNotNullOrWhiteSpaceCollectionFailure" xml:space="preserve">
-    <value>An element of the argument collection is null, empty, or consists of only white-space characters. Supply a collection that does not contain any those values and then try the command again.</value>
+    <value>引數集合中的某個元素為 null、空白，或僅包含空白字元。請提供不包含任何這些值的集合，然後再試一次命令。</value>
   </data>
   <data name="ParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>A parameter with the name '{0}' was defined multiple times for the command.</value>
+    <value>已為該命令多次定義名稱為 '{0}' 的參數。</value>
   </data>
   <data name="AliasParameterNameAlreadyExistsForCommand" xml:space="preserve">
-    <value>The parameter alias cannot be specified because an alias with the name '{0}' was already defined multiple times for the command.</value>
+    <value>無法指定參數別名，因為已為該命令多次定義名稱為 '{0}' 的別名。</value>
   </data>
   <data name="ParameterNameConflictsWithAlias" xml:space="preserve">
-    <value>The parameter '{0}' cannot be specified because it conflicts with the parameter alias of the same name for parameter '{1}'.</value>
+    <value>無法指定參數 '{0}'，因為它與參數 '{1}' 的同名參數別名衝突。</value>
   </data>
   <data name="ValidateScriptFailure" xml:space="preserve">
-    <value>The "{1}" validation script for the argument with value "{0}" did not return a result of True. Determine why the validation script failed, and then try the command again.</value>
+    <value>用於值為 "{0}" 之引數的 "{1}" 驗證指令碼未傳回 True 結果。請判斷驗證指令碼失敗的原因，然後再試一次命令。</value>
   </data>
   <data name="ValidateVersionFailure" xml:space="preserve">
-    <value>The "{0}" argument does not contain a valid PowerShell version. Supply a valid version number and then try the command again.</value>
+    <value>"{0}" 引數不包含有效的 PowerShell 版本。請提供有效的版本號碼，然後再試一次命令。</value>
   </data>
   <data name="ValidateVariableName" xml:space="preserve">
-    <value>Cannot validate argument '{0}' because it is not a valid variable name.</value>
+    <value>無法驗證引數 '{0}'，因為它不是有效的變數名稱。</value>
   </data>
   <data name="JobDefinitionMustDeriveFromIJobConverter" xml:space="preserve">
-    <value>The job conversion type must derive from IAstToScriptBlockConverter.</value>
+    <value>作業轉換型別必須衍生自 IAstToScriptBlockConverter。</value>
   </data>
   <data name="ValidateDrivePathArgNotString" xml:space="preserve">
-    <value>The path argument is invalid. Supply a path argument that is a string type.</value>
+    <value>路徑引數無效。請提供字串型別的路徑引數。</value>
   </data>
   <data name="ValidateDrivePathFailure" xml:space="preserve">
-    <value>The path argument drive {0} does not belong to the set of approved drives: {1}. Supply a path argument with an approved drive.</value>
+    <value>路徑引數的磁碟機 {0} 不屬於核准的磁碟機集合: {1}。請提供具有核准磁碟機的路徑引數。</value>
   </data>
   <data name="ValidateDrivePathInvalidChar" xml:space="preserve">
-    <value>The path argument contains invalid characters.</value>
+    <value>路徑引數包含無效字元。</value>
   </data>
   <data name="ValidateDrivePathNoRoot" xml:space="preserve">
-    <value>The path argument has no root drive.  Supply a full path argument with a root drive.</value>
+    <value>路徑引數沒有根磁碟機。 請提供具有根磁碟機的完整路徑引數。</value>
   </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
-    <value>The argument value for the parameter '{0}' cannot be null or an empty string.</value>
+    <value>參數 '{0}' 的引數值不能為 null 或空字串。</value>
   </data>
   <data name="InvalidEnumArgument" xml:space="preserve">
-    <value>The Enum member '{0}' is not a valid value for the parameter '{1}'. Specify one of the following members and try again: {2}.</value>
+    <value>列舉成員 '{0}' 不是參數 '{1}' 的有效值。請指定下列其中一個成員，然後再試一次: {2}。</value>
   </data>
   <data name="ValidateTrustedDataFailure" xml:space="preserve">
-    <value>Cannot process input. The argument "{0}" is not trusted.</value>
+    <value>無法處理輸入。引數 "{0}" 不受信任。</value>
   </data>
   <data name="WDACParameterArgNotTrustedLogTitle" xml:space="preserve">
-    <value>ValidateTrustedData Attribute Check Failure</value>
+    <value>ValidateTrustedData 屬性檢查失敗</value>
   </data>
   <data name="WDACParameterArgNotTrustedMessage" xml:space="preserve">
-    <value>The parameter argument '{0}' is not trusted and will fail the ValidateTrustedData parameter attribute check in Constrained Language mode.</value>
+    <value>參數引數 '{0}' 不受信任，且在限制語言模式下將無法通過 ValidateTrustedData 參數屬性檢查。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/Modules.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/Modules.zh-Hant.resx
@@ -118,570 +118,570 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ModuleNotFound" xml:space="preserve">
-    <value>The specified module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入指定的模組 '{0}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="ModuleWithVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with version '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入版本為 '{0}' 的指定模組 '{1}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="MaximumVersionFormatIncorrect" xml:space="preserve">
-    <value>The specified MaximumVersion '{0}' was incorrect. If you are using '*', MaximumVersion only supports one '*' and should always be placed at the end of MaximumVersion.</value>
+    <value>指定的 MaximumVersion '{0}' 不正確。如果您使用 '*'，MaximumVersion 只支援一個 '*'，而且一律應放在 MaximumVersion 的結尾。</value>
   </data>
   <data name="MaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MaximumVersion '{1}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入 MaximumVersion '{1}' 的指定模組 '{0}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionNotFound" xml:space="preserve">
-    <value>The specified module '{0}' with MinimumVersion '{1}' and MaximumVersion '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入具有 MinimumVersion '{1}' 和 MaximumVersion '{2}' 的指定模組 '{0}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="MinimumVersionAndMaximumVersionInvalidRange" xml:space="preserve">
-    <value>The MinimumVersion '{0}' should not be greater than MaximumVersion '{1}'.</value>
+    <value>MinimumVersion '{0}' 不應大於 MaximumVersion '{1}'。</value>
   </data>
   <data name="ModuleAssemblyFound" xml:space="preserve">
-    <value>The assembly '{0}' was not loaded because no assembly with that name was found. Verify the assembly name, and then try again.</value>
+    <value>未載入組件 '{0}'，因為找不到該名稱的組件。請確認組件名稱，然後再試一次。</value>
   </data>
   <data name="ManifestMemberNotFound" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed because no valid module was found in any module directory.</value>
+    <value>模組資訊清單 '{2}' 的欄位 '{1}' 中列出的待處理模組 '{0}' 未處理，因為在任何模組目錄中都找不到有效的模組。</value>
   </data>
   <data name="CantUseAsCustomObjectWithBinaryModule" xml:space="preserve">
-    <value>No custom object was returned for module '{0}' because the -AsCustomObject parameter can only be used with script modules.</value>
+    <value>沒有傳回模組 '{0}' 的自訂物件，因為 -AsCustomObject 參數只能與指令碼模組搭配使用。</value>
   </data>
   <data name="InvalidModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' could not be processed because it is not a valid PowerShell module manifest file. Remove the elements that are not permitted: {1}</value>
+    <value>無法處理模組資訊清單 '{0}'，因為它不是有效的 PowerShell 模組資訊清單檔。請移除不允許的元素: {1}</value>
   </data>
   <data name="EmptyModuleManifest" xml:space="preserve">
-    <value>Processing the module manifest file '{0}' did not result in a valid manifest object. Update the file to contain a valid PowerShell module manifest. A valid manifest can be created using the New-ModuleManifest cmdlet.</value>
+    <value>處理模組資訊清單檔 '{0}' 時，未產生有效的資訊清單物件。請更新檔案，使其包含有效的 PowerShell 模組資訊清單。您可以使用 New-ModuleManifest Cmdlet 建立有效的資訊清單。</value>
   </data>
   <data name="InvalidModuleManifestMember" xml:space="preserve">
-    <value>The '{0}' module cannot be imported because its manifest contains one or more members that are not valid. The valid manifest members are ({1}). Remove the members that are not valid ({2}), then try to import the module again.</value>
+    <value>無法匯入 '{0}' 模組，因為其資訊清單包含一或多個無效的成員。有效的資訊清單成員為 ({1})。請移除無效的成員 ({2})，然後再次嘗試匯入模組。</value>
   </data>
   <data name="InvalidModuleSpecificationMember" xml:space="preserve">
-    <value>The hashtable describing a module contains one or more members that are not valid. The valid members are ({0}). Remove the members that are not valid ({1}), then try again.</value>
+    <value>描述模組的雜湊表包含一或多個無效的成員。有效的成員為 ({0})。請移除無效的成員 ({1})，然後再試一次。</value>
   </data>
   <data name="ModuleTooDeeplyNested" xml:space="preserve">
-    <value>Cannot load the module '{0}' because the module nesting limit has been exceeded. Modules can only be nested to {1} levels. Evaluate and change the order in which you are loading modules to prevent exceeding the nesting limit, and then try running your script again.</value>
+    <value>無法載入模組 '{0}'，因為已超過模組巢狀限制。模組最多只能巢狀到 {1} 層。請評估並變更載入模組的順序，以避免超過巢狀限制，然後再次嘗試執行您的指令碼。</value>
   </data>
   <data name="ModuleManifestMissingModuleVersion" xml:space="preserve">
-    <value>The member 'ModuleVersion' is not present in the module manifest. This member must exist and be assigned a version number of the form 'n.n.n.n'. Add the missing member to the file '{0}'.</value>
+    <value>模組資訊清單中沒有成員 'ModuleVersion'。此成員必須存在，且值必須是格式為 'n.n.n.n' 的版本號碼。請將遺漏的成員新增至檔案 '{0}'。</value>
   </data>
   <data name="ModuleManifestInvalidValue" xml:space="preserve">
-    <value>The '{0}' member is not valid in the module manifest file '{2}': {1}</value>
+    <value>模組資訊清單檔 '{2}' 中的 '{0}' 成員無效: {1}</value>
   </data>
   <data name="ModuleManifestInsufficientModuleVersion" xml:space="preserve">
-    <value>The version '{0}' of module '{1}' does not meet the required minimum version '{2}'. Verify that the version number is supported, and then try loading the module again.</value>
+    <value>模組 '{1}' 的版本 '{0}' 不符合所需的最低版本 '{2}'。請確認版本號碼受支援，然後再次嘗試載入模組。</value>
   </data>
   <data name="ModuleManifestInsufficientPowerShellVersion" xml:space="preserve">
-    <value>The version of PowerShell on this computer is '{0}'. The module '{1}' requires a minimum PowerShell version of '{2}' to run. Verify that you have the minimum required version of PowerShell installed, and then try again.</value>
+    <value>此電腦上的 PowerShell 版本為 '{0}'。模組 '{1}' 需要至少 PowerShell 版本 '{2}' 才能執行。請確認您已安裝所需的最低版本 PowerShell，然後再試一次。</value>
   </data>
   <data name="ModuleManifestNestedModulesCantGoWithModuleToProcess" xml:space="preserve">
-    <value>The module manifest member 'NestedModules' cannot be used if the 'ModuleToProcess' member is a binary module. Edit the module manifest file at '{0}', and then try again.</value>
+    <value>如果 'ModuleToProcess' 成員是二進位模組，則無法使用模組資訊清單成員 'NestedModules'。請編輯位於 '{0}' 的模組資訊清單檔，然後再試一次。</value>
   </data>
   <data name="ModuleManifestInvalidManifestMember" xml:space="preserve">
-    <value>The member '{0}' in the module manifest is not valid: {1}. Verify that a valid value is specified for this field in the '{2}' file.</value>
+    <value>模組資訊清單中的成員 '{0}' 無效: {1}。請確認已在 '{2}' 檔案中為此欄位指定有效值。</value>
   </data>
   <data name="InvalidModuleManifestPath" xml:space="preserve">
-    <value>The module manifest path '{0}' is not valid. The value of the Path argument must resolve to a single file that has a '.psd1' extension. Change the value of the Path argument to point to a valid psd1 file, and then try again.</value>
+    <value>模組資訊清單路徑 '{0}' 無效。Path 引數的值必須解析為副檔名為 '.psd1' 的單一檔案。請將 Path 引數的值變更為指向有效的 psd1 檔案，然後再試一次。</value>
   </data>
   <data name="InvalidModuleManifestVersion" xml:space="preserve">
-    <value>The ModuleVersion key in module manifest '{0}' specifies module version '{1}' which does not match its version folder name at '{2}'. Change the value of the ModuleVersion key to match the version folder name.</value>
+    <value>模組資訊清單 '{0}' 中的 ModuleVersion 索引鍵指定了模組版本 '{1}'，但這與 '{2}' 的版本資料夾名稱不符。請變更 ModuleVersion 索引鍵的值，使其與版本資料夾名稱一致。</value>
   </data>
   <data name="InvalidNestedModuleinModuleManifest" xml:space="preserve">
-    <value>The specified NestedModule entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模組資訊清單 '{1}' 中指定的 NestedModule 項目 '{0}' 無效。請使用有效值更新此項目，然後再試一次。</value>
   </data>
   <data name="InvalidRequiredAssembliesInModuleManifest" xml:space="preserve">
-    <value>The specified RequiredAssemblies entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模組資訊清單 '{1}' 中指定的 RequiredAssemblies 項目 '{0}' 無效。請使用有效值更新此項目，然後再試一次。</value>
   </data>
   <data name="InvalidFilePathinModuleManifest" xml:space="preserve">
-    <value>The specified FileList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模組資訊清單 '{1}' 中指定的 FileList 項目 '{0}' 無效。請使用有效值更新此項目，然後再試一次。</value>
   </data>
   <data name="InvalidRequiredModulesinModuleManifest" xml:space="preserve">
-    <value>The specified RequiredModules entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模組資訊清單 '{1}' 中指定的 RequiredModules 項目 '{0}' 無效。請使用有效值更新此項目，然後再試一次。</value>
   </data>
   <data name="InvalidModuleListinModuleManifest" xml:space="preserve">
-    <value>The specified ModuleList entry '{0}' in the module manifest '{1}' is invalid. Try again after updating this entry with valid values.</value>
+    <value>模組資訊清單 '{1}' 中指定的 ModuleList 項目 '{0}' 無效。請使用有效值更新此項目，然後再試一次。</value>
   </data>
   <data name="InvalidPowerShellVersionInModuleManifest" xml:space="preserve">
-    <value>The module manifest '{0}' is specified with the CompatiblePSEditions key which is supported only on PowerShell version '5.1' or higher. Update the value of the PowerShellVersion key to '5.1' or higher, and try again.</value>
+    <value>模組資訊清單 '{0}' 使用了 CompatiblePSEditions 索引鍵，但此索引鍵只支援 PowerShell '5.1' 或更新版本。請將 PowerShellVersion 索引鍵的值更新為 '5.1' 或更新版本，然後再試一次。</value>
   </data>
   <data name="DuplicateEntriesInCompatiblePSEditions" xml:space="preserve">
-    <value>The specified value '{0}' for CompatiblePSEditions contains duplicate PowerShell Edition names. Try again after removing the duplicate PowerShell Edition names.</value>
+    <value>CompatiblePSEditions 的指定值 '{0}' 包含重複的 PowerShell 版本名稱。請移除重複的 PowerShell 版本名稱，然後再試一次。</value>
   </data>
   <data name="ModuleVersionEqualsToVersionFolder" xml:space="preserve">
-    <value>Version specified in ModuleVersion key is equal to version folder name.</value>
+    <value>ModuleVersion 索引鍵中指定的版本等於版本資料夾名稱。</value>
   </data>
   <data name="SkippingInvalidModuleVersionFolder" xml:space="preserve">
-    <value>Skipping the Version folder {0} under Module {1} as it does not have a valid module manifest file.</value>
+    <value>正在略過模組 {1} 下的版本資料夾 {0}，因為其中沒有有效的模組資訊清單檔。</value>
   </data>
   <data name="RequiredModuleMissingModuleName" xml:space="preserve">
-    <value>The 'ModuleName' member does not exist in the hashtable that describes this module.</value>
+    <value>描述此模組的雜湊表中不存在 'ModuleName' 成員。</value>
   </data>
   <data name="RequiredModuleMissingModuleVersion" xml:space="preserve">
-    <value>The 'ModuleVersion', 'MaximumVersion' and 'RequiredVersion' members do not exist in the hashtable that describes this module. One of these three members must exist, and be assigned a version number in the format 'n.n.n.n'.</value>
+    <value>描述此模組的雜湊表中沒有 'ModuleVersion'、'MaximumVersion' 和 'RequiredVersion' 成員。這三個成員中必須有一個存在，並以 'n.n.n.n' 格式指派版本號碼。</value>
   </data>
   <data name="RequiredModuleNotLoaded" xml:space="preserve">
-    <value>The required module '{1}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未載入必要模組 '{1}'。請載入該模組，或從檔案 '{0}' 中的 'RequiredModules' 移除該模組。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongGuid" xml:space="preserve">
-    <value>The required module '{1}' with GUID '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未載入具有 GUID '{1}' 的必要模組 '{2}'。請載入該模組，或從檔案 '{0}' 中的 'RequiredModules' 移除該模組。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongVersion" xml:space="preserve">
-    <value>The required module '{1}' with version '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未載入版本為 '{2}' 的必要模組 '{1}'。請載入該模組，或從檔案 '{0}' 中的 'RequiredModules' 移除該模組。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MaximumVersion '{2}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未載入具有 MaximumVersion '{2}' 的必要模組 '{1}'。請載入該模組，或從檔案 '{0}' 中的 'RequiredModules' 移除該模組。</value>
   </data>
   <data name="RequiredModuleNotLoadedWrongMinimumVersionAndMaximumVersion" xml:space="preserve">
-    <value>The required module '{1}' with MinimumVersion '{2}' and MaximumVersion '{3}' is not loaded. Load the module or remove the module from 'RequiredModules' in the file '{0}'.</value>
+    <value>未載入具有 MaximumVersion '{2}' 和 MaximumVersion '{3}' 的必要模組 '{1}'。請載入該模組，或從檔案 '{0}' 中的 'RequiredModules' 移除該模組。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}'.</value>
+    <value>找不到符合 ModuleVersion '{1}' 的模組 '{0}。</value>
   </data>
   <data name="RequiredModuleNotFoundRequiredVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with RequiredVersion '{1}'.</value>
+    <value>找不到符合 RequiredVersion '{1}' 的模組 '{0}'。</value>
   </data>
   <data name="RequiredModuleNotFoundMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with MaximumVersion '{1}'.</value>
+    <value>找不到符合 MaximumVersion '{1}' 的模組 '{0}'。</value>
   </data>
   <data name="RequiredModuleNotFoundModuleAndMaximumVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found with ModuleVersion '{1}' and MaximumVersion '{2}'.</value>
+    <value>找不到符合 ModuleVersion '{1}' 和 MaximumVersion '{2}' 的模組 '{0}。</value>
   </data>
   <data name="RequiredModuleNotFoundWithoutVersion" xml:space="preserve">
-    <value>The module '{0}' cannot be found.</value>
+    <value>找不到模組 '{0}'。</value>
   </data>
   <data name="NoModulesRemoved" xml:space="preserve">
-    <value>No modules were removed. Verify that the specification of modules to remove is correct and those modules exist in the runspace.</value>
+    <value>未移除任何模組。請確認要移除的模組規格正確，且這些模組存在於 Runspace 中。</value>
   </data>
   <data name="UnableToRemoveModuleMember" xml:space="preserve">
-    <value>The '{0}' member, which was imported from module '{1}', cannot be removed for the following reason: {2}</value>
+    <value>無法移除從模組 '{1}' 匯入的 '{0}' 成員，原因如下: {2}</value>
   </data>
   <data name="ModuleIsReadOnly" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is read-only. Add the Force parameter to your command to remove read-only modules.</value>
+    <value>無法移除模組 '{0}'，因為它是唯讀的。若要移除唯讀模組，請在命令中加入 Force 參數。</value>
   </data>
   <data name="ModuleIsConstant" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is marked as 'constant.' A module cannot be removed if it is marked 'constant.'</value>
+    <value>無法移除模組 '{0}'，因為它標記為 'constant'。標記為 'constant' 的模組無法移除。</value>
   </data>
   <data name="ModuleIsRequired" xml:space="preserve">
-    <value>Unable to remove the module '{0}' because it is required by '{1}'. Add the Force parameter to your command to remove the module.</value>
+    <value>無法移除模組 '{0}'，因為 '{1}' 需要它。若要移除該模組，請在命令中加入 Force 參數。</value>
   </data>
   <data name="CanOnlyBeUsedFromWithinAModule" xml:space="preserve">
-    <value>The Export-ModuleMember cmdlet can only be called from inside a module.</value>
+    <value>只能從模組內部呼叫 Export-ModuleMember Cmdlet。</value>
   </data>
   <data name="InvalidModuleExtension" xml:space="preserve">
-    <value>The extension '{0}' is not a valid module extension. The supported module extensions are '.dll', '.ps1', '.psm1', '.psd1' and '.cdxml'. Correct the extension then try adding the file '{1}' again.</value>
+    <value>副檔名 '{0}' 不是有效的模組副檔名。支援的模組副檔名為 '.dll'、'.ps1'、'.psm1'、'.psd1' 和 '.cdxml'。請更正副檔名，然後再次嘗試新增檔案 '{1}'。</value>
   </data>
   <data name="InvalidOperationOnBinaryModule" xml:space="preserve">
-    <value>This operation cannot be performed on a binary module. It can only be performed on a script module.</value>
+    <value>無法在二進位模組上執行此作業。它只能在指令碼模組上執行。</value>
   </data>
   <data name="ScriptsToProcessIncorrectExtension" xml:space="preserve">
-    <value>The file '{0}' is not allowed because it does not have the extension '.ps1'.</value>
+    <value>不允許檔案 '{0}'，因為它沒有副檔名 '.ps1'。</value>
   </data>
   <data name="DefaultCompanyName" xml:space="preserve">
-    <value>Unknown</value>
+    <value>未知</value>
   </data>
   <data name="DefaultCopyrightMessage" xml:space="preserve">
-    <value>(c) {0}. All rights reserved.</value>
+    <value>(c) {0}。著作權所有，並保留一切權利。</value>
   </data>
   <data name="RemovingImportedFunction" xml:space="preserve">
-    <value>Removing the imported "{0}" function.</value>
+    <value>正在移除已匯入的 "{0}" 函式。</value>
   </data>
   <data name="RemovingImportedAlias" xml:space="preserve">
-    <value>Removing the imported "{0}" alias.</value>
+    <value>正在移除已匯入的 "{0}" 別名。</value>
   </data>
   <data name="RemovingImportedVariable" xml:space="preserve">
-    <value>Removing the imported "{0}" variable.</value>
+    <value>正在移除已匯入的 "{0}" 變數。</value>
   </data>
   <data name="LoadingModule" xml:space="preserve">
-    <value>Loading module from path '{0}'.</value>
+    <value>正在從路徑 '{0}' 載入模組。</value>
   </data>
   <data name="LoadingFile" xml:space="preserve">
-    <value>Loading '{0}' from path '{1}'.</value>
+    <value>正在從路徑 '{1}' 載入 '{0}'。</value>
   </data>
   <data name="DottingScriptFile" xml:space="preserve">
-    <value>Dot-sourcing the script file '{0}'.</value>
+    <value>正在點執行指令檔 '{0}'。</value>
   </data>
   <data name="ImportingFunction" xml:space="preserve">
-    <value>Importing function '{0}'.</value>
+    <value>正在匯入函式 '{0}'。</value>
   </data>
   <data name="ImportingCmdlet" xml:space="preserve">
-    <value>Importing cmdlet '{0}'.</value>
+    <value>正在匯入 Cmdlet '{0}'。</value>
   </data>
   <data name="ImportingAlias" xml:space="preserve">
-    <value>Importing alias '{0}'.</value>
+    <value>正在匯入別名 '{0}'。</value>
   </data>
   <data name="ImportingVariable" xml:space="preserve">
-    <value>Importing variable '{0}'.</value>
+    <value>正在匯入變數 '{0}'。</value>
   </data>
   <data name="ExportingCmdlet" xml:space="preserve">
-    <value>Exporting cmdlet '{0}'.</value>
+    <value>正在匯出 Cmdlet '{0}'。</value>
   </data>
   <data name="ExportingFunction" xml:space="preserve">
-    <value>Exporting function '{0}'.</value>
+    <value>正在匯出函式 '{0}'。</value>
   </data>
   <data name="ExportingAlias" xml:space="preserve">
-    <value>Exporting alias '{0}'.</value>
+    <value>正在匯出別名 '{0}'。</value>
   </data>
   <data name="ExportingVariable" xml:space="preserve">
-    <value>Exporting variable '{0}'.</value>
+    <value>正在匯出變數 '{0}'。</value>
   </data>
   <data name="ImportingNonStandardVerb" xml:space="preserve">
-    <value>The names of some imported commands from the module '{0}' include unapproved verbs that might make them less discoverable. To find the commands with unapproved verbs, run the Import-Module command again with the Verbose parameter. For a list of approved verbs, type Get-Verb.</value>
+    <value>某些從模組 '{0}' 匯入的命令名稱包含未核准的動詞，這可能會降低命令的可探索性。若要找出使用未核准動詞的命令，請使用 Verbose 參數再次執行 Import-Module 命令。如需核准動詞的清單，請輸入 Get-Verb。</value>
   </data>
   <data name="ImportingNonStandardVerbVerbose" xml:space="preserve">
-    <value>The '{0}' command in the {1}' module was imported, but because its name does not include an approved verb, it might be difficult to find. For a list of approved verbs, type Get-Verb.</value>
+    <value>已匯入模組 '{1}' 中的 '{0}' 命令，但因為其名稱未包含核准的動詞，可能較難找到。如需核准動詞的清單，請輸入 Get-Verb。</value>
   </data>
   <data name="ImportingNonStandardVerbVerboseSuggestion" xml:space="preserve">
-    <value>The '{0}' command in the {2}' module was imported, but because its name does not include an approved verb, it might be difficult to find. The suggested alternative verbs are "{1}".</value>
+    <value>已匯入模組 '{2}' 中的 '{0}' 命令，但因為其名稱未包含核准的動詞，可能較難找到。建議的替代動詞為 "{1}"。</value>
   </data>
   <data name="ImportingNonStandardNoun" xml:space="preserve">
-    <value>Some imported command names contain one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>某些匯入的命令名稱包含下列一或多個限制字元: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="ImportingNonStandardNounVerbose" xml:space="preserve">
-    <value>The command name '{0}' from the module '{1}' contains one or more of the following restricted characters: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
+    <value>模組 '{1}' 中的命令名稱 '{0}' 包含下列一或多個限制字元: # , ( ) {{ }} [ ] &amp; - / \ $ ^ ; : " ' &lt; &gt; | ? @ ` * % + = ~</value>
   </data>
   <data name="CreatingModuleManifestFile" xml:space="preserve">
-    <value>Creating the "{0}" module manifest file.</value>
+    <value>正在建立 "{0}" 模組資訊清單檔。</value>
   </data>
   <data name="ConfirmRemoveModule" xml:space="preserve">
-    <value>{0} (Path: '{1}')</value>
+    <value>{0} (路徑: '{1}')</value>
   </data>
   <data name="InvalidProcessorArchitecture" xml:space="preserve">
-    <value>The current processor architecture is: {0}. The module '{1}' requires the following architecture: {2}.</value>
+    <value>目前的處理器結構為: {0}。模組 '{1}' 需要下列結構: {2}。</value>
   </data>
   <data name="InvalidPowerShellHostName" xml:space="preserve">
-    <value>The name of the current PowerShell host is: '{0}'. The module '{1}' requires the following PowerShell host: '{2}'.</value>
+    <value>目前 PowerShell 主機的名稱為: '{0}'。模組 '{1}' 需要下列 PowerShell 主機: '{2}'。</value>
   </data>
   <data name="InvalidPowerShellHostVersion" xml:space="preserve">
-    <value>The current PowerShell host is: '{0}' (version {1}). The module '{2}' requires a minimum PowerShell host version of '{3}' to run.</value>
+    <value>目前的 PowerShell 主機為: '{0}'（版本 {1}）。模組 '{2}' 需要至少 PowerShell 主機版本 '{3}' 才能執行。</value>
   </data>
   <data name="ManifestHeaderLine1" xml:space="preserve">
-    <value>Module manifest for module '{0}'</value>
+    <value>模組 '{0}' 的模組資訊清單</value>
   </data>
   <data name="ManifestHeaderLine2" xml:space="preserve">
-    <value>Generated by: {0}</value>
+    <value>產生者: {0}</value>
   </data>
   <data name="ManifestHeaderLine3" xml:space="preserve">
-    <value>Generated on: {0}</value>
+    <value>產生於: {0}</value>
   </data>
   <data name="RootModule" xml:space="preserve">
-    <value>Script module or binary module file associated with this manifest.</value>
+    <value>與此資訊清單相關聯的指令碼模組或二進位模組檔案。</value>
   </data>
   <data name="NestedModules" xml:space="preserve">
-    <value>Modules to import as nested modules of the module specified in RootModule/ModuleToProcess</value>
+    <value>要匯入為 RootModule/ModuleToProcess 中指定模組之巢狀模組的模組</value>
   </data>
   <data name="GUID" xml:space="preserve">
-    <value>ID used to uniquely identify this module</value>
+    <value>用於唯一識別此模組的識別碼</value>
   </data>
   <data name="Author" xml:space="preserve">
-    <value>Author of this module</value>
+    <value>此模組的作者</value>
   </data>
   <data name="CompanyName" xml:space="preserve">
-    <value>Company or vendor of this module</value>
+    <value>此模組的公司或廠商</value>
   </data>
   <data name="Copyright" xml:space="preserve">
-    <value>Copyright statement for this module</value>
+    <value>此模組的著作權聲明</value>
   </data>
   <data name="ModuleVersion" xml:space="preserve">
-    <value>Version number of this module.</value>
+    <value>此模組的版本號碼。</value>
   </data>
   <data name="Description" xml:space="preserve">
-    <value>Description of the functionality provided by this module</value>
+    <value>此模組所提供功能的描述</value>
   </data>
   <data name="PowerShellVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell engine required by this module</value>
+    <value>此模組所需的最低 PowerShell 引擎版本</value>
   </data>
   <data name="CLRVersion" xml:space="preserve">
-    <value>Minimum version of the common language runtime (CLR) required by this module. {0}</value>
+    <value>此模組所需的通用語言執行平台 (CLR) 最低版本。{0}</value>
   </data>
   <data name="RequiredModules" xml:space="preserve">
-    <value>Modules that must be imported into the global environment prior to importing this module</value>
+    <value>匯入此模組之前，必須先匯入全域環境的模組</value>
   </data>
   <data name="ScriptsToProcess" xml:space="preserve">
-    <value>Script files (.ps1) that are run in the caller's environment prior to importing this module.</value>
+    <value>匯入此模組之前，會在呼叫者環境中執行的指令碼檔案 (.ps1)。</value>
   </data>
   <data name="TypesToProcess" xml:space="preserve">
-    <value>Type files (.ps1xml) to be loaded when importing this module</value>
+    <value>匯入此模組時要載入的類型檔案 (.ps1xml)</value>
   </data>
   <data name="FormatsToProcess" xml:space="preserve">
-    <value>Format files (.ps1xml) to be loaded when importing this module</value>
+    <value>匯入此模組時要載入的格式檔案 (.ps1xml)</value>
   </data>
   <data name="RequiredAssemblies" xml:space="preserve">
-    <value>Assemblies that must be loaded prior to importing this module</value>
+    <value>匯入此模組前必須載入的組件</value>
   </data>
   <data name="FileList" xml:space="preserve">
-    <value>List of all files packaged with this module</value>
+    <value>此模組所封裝的所有檔案清單</value>
   </data>
   <data name="PrivateData" xml:space="preserve">
-    <value>Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.</value>
+    <value>要傳遞至 RootModule/ModuleToProcess 中指定模組的私人資料。這也可能包含 PSData 雜湊表，其中含有 PowerShell 使用的其他模組中繼資料。</value>
   </data>
   <data name="Tags" xml:space="preserve">
-    <value>Tags applied to this module. These help with module discovery in online galleries.</value>
+    <value>套用至此模組的標籤。這些項目有助於在線上資源庫中探索模組。</value>
   </data>
   <data name="ProjectUri" xml:space="preserve">
-    <value>A URL to the main website for this project.</value>
+    <value>此專案主要網站的 URL。</value>
   </data>
   <data name="LicenseUri" xml:space="preserve">
-    <value>A URL to the license for this module.</value>
+    <value>此模組授權的 URL。</value>
   </data>
   <data name="IconUri" xml:space="preserve">
-    <value>A URL to an icon representing this module.</value>
+    <value>代表此模組的圖示 URL。</value>
   </data>
   <data name="ReleaseNotes" xml:space="preserve">
-    <value>ReleaseNotes of this module</value>
+    <value>此模組的 ReleaseNotes</value>
   </data>
   <data name="Prerelease" xml:space="preserve">
-    <value>Prerelease string of this module</value>
+    <value>此模組的預先發行版字串</value>
   </data>
   <data name="RequireLicenseAcceptance" xml:space="preserve">
-    <value>Flag to indicate whether the module requires explicit user acceptance for install/update/save</value>
+    <value>表示此模組是否需要使用者明確接受才能安裝/更新/儲存的旗標</value>
   </data>
   <data name="ExternalModuleDependencies" xml:space="preserve">
-    <value>External dependent modules of this module</value>
+    <value>此模組的外部相依模組</value>
   </data>
   <data name="EndOfManifestHashTable" xml:space="preserve">
-    <value>End of {0} hashtable</value>
+    <value>{0} 雜湊表結尾</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableError" xml:space="preserve">
-    <value>The PrivateData parameter value must be a hash table to create the module manifest with the following parameter values Tags, ProjectUri, LicenseUri, IconUri or ReleaseNotes. Either remove the Tags, ProjectUri, LicenseUri, IconUri, or ReleaseNotes parameter values or wrap the contents of PrivateData in a hashtable.</value>
+    <value>PrivateData 參數值必須是雜湊表，才能使用下列參數值建立模組資訊清單: Tags、ProjectUri、LicenseUri、IconUri 或 ReleaseNotes。請移除 Tags、ProjectUri、LicenseUri、IconUri 或 ReleaseNotes 參數值，或將 PrivateData 的內容包裝在雜湊表中。</value>
   </data>
   <data name="PrivateDataValueTypeShouldBeHashTableWarning" xml:space="preserve">
-    <value>The PrivateData should be defined as a hashtable, but this module manifest defines it as an object. Please consider wrapping the contents of PrivateData in a hashtable. This will enable you to add the Tags, ProjectUri, LicenseUri, IconUri, and ReleaseNotes properties to the module manifest at a later time.</value>
+    <value>PrivateData 應定義為雜湊表，但這個模組資訊清單將其定義為物件。請考慮將 PrivateData 的內容包裝在雜湊表中。這樣您之後就能將 Tags、ProjectUri、LicenseUri、IconUri 和 ReleaseNotes 屬性新增到模組資訊清單中。</value>
   </data>
   <data name="InvalidParameterValue" xml:space="preserve">
-    <value>The specified value '{0}' is invalid, try again with a valid value.</value>
+    <value>指定的值 '{0}' 無效，請使用有效的值再試一次。</value>
   </data>
   <data name="FunctionsToExport" xml:space="preserve">
-    <value>Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.</value>
+    <value>若要從此模組匯出的函式，為了達到最佳效能，請勿使用萬用字元，也不要刪除該項目。如果沒有要匯出的函式，則請使用空陣列。</value>
   </data>
   <data name="AliasesToExport" xml:space="preserve">
-    <value>Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.</value>
+    <value>若要從此模組匯出的別名，為了達到最佳效能，請勿使用萬用字元，也不要刪除該項目。如果沒有要匯出的別名，則請使用空陣列。</value>
   </data>
   <data name="CmdletsToExport" xml:space="preserve">
-    <value>Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.</value>
+    <value>若要從此模組匯出的 Cmdlet，為了達到最佳效能，請勿使用萬用字元，也不要刪除該項目。如果沒有要匯出的 Cmdlet，則請使用空陣列。</value>
   </data>
   <data name="VariablesToExport" xml:space="preserve">
-    <value>Variables to export from this module</value>
+    <value>要從此模組匯出的變數</value>
   </data>
   <data name="DscResourcesToExport" xml:space="preserve">
-    <value>DSC resources to export from this module</value>
+    <value>要從此模組匯出的 DSC 資源</value>
   </data>
   <data name="CompatiblePSEditions" xml:space="preserve">
-    <value>Supported PSEditions</value>
+    <value>支援的 PSEditions</value>
   </data>
   <data name="ProcessorArchitecture" xml:space="preserve">
-    <value>Processor architecture (None, X86, Amd64) required by this module</value>
+    <value>此模組需要的處理器結構為 (None、X86、Amd64)</value>
   </data>
   <data name="ModuleList" xml:space="preserve">
-    <value>List of all modules packaged with this module</value>
+    <value>此模組所封裝的所有模組清單</value>
   </data>
   <data name="DotNetFrameworkVersion" xml:space="preserve">
-    <value>Minimum version of Microsoft .NET Framework required by this module. {0}</value>
+    <value>此模組所需的最低 Microsoft .NET Framework 版本。{0}</value>
   </data>
   <data name="PowerShellHostName" xml:space="preserve">
-    <value>Name of the PowerShell host required by this module</value>
+    <value>此模組所需的 PowerShell 主機名稱</value>
   </data>
   <data name="PowerShellHostVersion" xml:space="preserve">
-    <value>Minimum version of the PowerShell host required by this module</value>
+    <value>此模組所需的最低 PowerShell 主機版本</value>
   </data>
   <data name="HelpInfoURI" xml:space="preserve">
-    <value>HelpInfo URI of this module</value>
+    <value>此模組的 HelpInfo URI</value>
   </data>
   <data name="ModuleDriveInUse" xml:space="preserve">
-    <value>Because the {0} module is providing the PSDrive in the current PowerShell session, no modules were removed. Change the current PSDrive provider, and then try removing modules again.</value>
+    <value>因為 {0} 模組在目前的 PowerShell 工作階段中提供 PSDrive，所以沒有移除任何模組。請變更目前的 PSDrive 提供者，然後再次嘗試移除模組。</value>
   </data>
   <data name="ImportModuleNoClobberForCmdlet" xml:space="preserve">
-    <value>The cmdlet '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未匯入 Cmdlet '{0}'，因為目前範圍中有成員具有相同名稱。</value>
   </data>
   <data name="ImportModuleNoClobberForAlias" xml:space="preserve">
-    <value>The alias '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未匯入別名 '{0}'，因為目前範圍中有成員具有相同名稱。</value>
   </data>
   <data name="ImportModuleNoClobberForFunction" xml:space="preserve">
-    <value>The function '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未匯入函式 '{0}'，因為目前範圍中有成員具有相同名稱。</value>
   </data>
   <data name="ImportModuleNoClobberForVariable" xml:space="preserve">
-    <value>The variable '{0}' was not imported because there is a member with the same name in the current scope.</value>
+    <value>未匯入變數 '{0}'，因為目前範圍中有成員具有相同名稱。</value>
   </data>
   <data name="WildCardNotAllowedInModuleToProcessAndInNestedModules" xml:space="preserve">
-    <value>Wildcard characters are not allowed in members 'ModuleToProcess', 'RootModule', or 'NestedModules' in the module manifest '{0}'.</value>
+    <value>模組資訊清單 '{0}' 中的成員 'ModuleToProcess'、'RootModule' 或 'NestedModules' 不允許使用萬用字元。</value>
   </data>
   <data name="CoreModuleCannotBeRemoved" xml:space="preserve">
-    <value>The module '{0}' is a core module for PowerShell. Add the Force parameter to your command to remove core modules.</value>
+    <value>模組 '{0}' 是 PowerShell 的核心模組。若要移除核心模組，請在命令中加入 Force 參數。</value>
   </data>
   <data name="ModuleManifestCannotContainBothModuleToProcessAndRootModule" xml:space="preserve">
-    <value>The module manifest cannot contain both the 'ModuleToProcess' and 'RootModule' members. Change the module manifest file to remove one of these members at '{0}', and then try again.</value>
+    <value>模組資訊清單不能同時包含 'ModuleToProcess' 和 'RootModule' 成員。請變更模組資訊清單檔，移除位於 '{0}' 的其中一個成員，然後再試一次。</value>
   </data>
   <data name="ModuleToProcessFieldDeprecated" xml:space="preserve">
-    <value>The module manifest member 'ModuleToProcess' has been deprecated. Use the 'RootModule' member instead.</value>
+    <value>模組資訊清單成員 'ModuleToProcess' 已棄用。請改為使用 'RootModule' 成員。</value>
   </data>
   <data name="DefaultCommandPrefix" xml:space="preserve">
-    <value>Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.</value>
+    <value>從此模組匯出之命令的預設前置詞。您可以使用 Import-Module -Prefix 覆寫預設前置詞。</value>
   </data>
   <data name="GlobalAndScopeParameterCannotBeSpecifiedTogether" xml:space="preserve">
-    <value>The 'Global' and 'Scope' parameters cannot be specified together. Remove one of these parameters, and then try running the command again.</value>
+    <value>無法同時指定 'Global' 和 'Scope' 參數。請移除其中一個參數，然後嘗試再次執行該指令。</value>
   </data>
   <data name="RequiredModulesCyclicDependency" xml:space="preserve">
-    <value>The required module '{0}' is not loaded. The module '{0}' has a requiredModule '{1}' in its module manifest '{2}' that points to a cyclic dependency.</value>
+    <value>未載入必要模組 '{0}'。模組 '{0}' 在其模組資訊清單 '{2}' 中的 requiredModule '{1}' 指向循環相依性。</value>
   </data>
   <data name="RequiredModuleNotFound" xml:space="preserve">
-    <value>The required module '{0}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入必要的模組 '{0}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="MixedModuleOverCimSessionWarning" xml:space="preserve">
-    <value>Some commands from module {0} cannot be imported over a CimSession. To get all the commands, verify that the remote server has PowerShell remote management enabled, and then try adding the PSSession parameter to an Import-Module cmdlet.</value>
+    <value>無法透過 CimSession 匯入模組 {0} 中的某些命令。若要取得所有命令，請確認遠端伺服器已啟用 PowerShell 遠端管理，然後嘗試在 Import-Module Cmdlet 中加入 PSSession 參數。</value>
   </data>
   <data name="WinCompatModuleWarning" xml:space="preserve">
-    <value>Module {0} is loaded in Windows PowerShell using {1} remoting session; please note that all input and output of commands from this module will be deserialized objects. If you want to load this module into PowerShell please use 'Import-Module -SkipEditionCheck' syntax.</value>
+    <value>模組 {1} 已使用 {0} 遠端處理工作階段載入 Windows PowerShell; 請注意，此模組中所有命令的輸入和輸出都會是還原序列化的物件。如果您想將此模組載入 PowerShell，請使用 'Import-Module -SkipEditionCheck' 語法。</value>
   </data>
   <data name="WinCompatRequredVersionError" xml:space="preserve">
-    <value>Detected Windows PowerShell version {0}. Windows PowerShell 5.1 is required to load modules using Windows PowerShell compatibility feature. Install Windows Management Framework (WMF) 5.1 from https://aka.ms/WMF5Download to enable this feature.</value>
+    <value>偵測到 Windows PowerShell 版本 {0}。若要使用 Windows PowerShell 相容性功能載入模組，則需要 Windows PowerShell 5.1。請從 https://aka.ms/WMF5Download 安裝 Windows Management Framework (WMF) 5.1 以啟用此功能。</value>
   </data>
   <data name="WinCompatModuleInDenyList" xml:space="preserve">
-    <value>Module '{0}' is blocked from loading using Windows PowerShell compatibility feature by a 'WindowsPowerShellCompatibilityModuleDenyList' setting in PowerShell configuration file.</value>
+    <value>PowerShell 設定檔中的 'WindowsPowerShellCompatibilityModuleDenyList' 設定已封鎖使用 Windows PowerShell 相容性功能載入模組 '{0}'。</value>
   </data>
   <data name="PsModuleOverCimSessionError" xml:space="preserve">
-    <value>The module {0} cannot be imported over a CimSession. Try using the PSSession parameter of the Import-Module cmdlet.</value>
+    <value>無法透過 CimSession 匯入模組 {0}。請嘗試使用 Import-Module Cmdlet 的 PSSession 參數。</value>
   </data>
   <data name="InvalidProcessorArchitectureInManifest" xml:space="preserve">
-    <value>The processor architecture value of {0} is not supported. Run the New-ModuleManifest command again, specifying one of the following supported enumeration values for processor architecture: None, MSIL, X86, Amd64, Arm</value>
+    <value>不支援處理器結構值 {0}。請再次執行 New-ModuleManifest 命令，並指定下列其中一個支援的處理器結構列舉值: None、MSIL、X86、Amd64、Arm</value>
   </data>
   <data name="RemoteDiscoveryWorksOnlyInListAvailableMode" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only list available modules. Add the ListAvailable parameter to your command, and then try again.</value>
+    <value>在遠端電腦上執行 Get-Module Cmdlet 只能列出可用的模組。請將 ListAvailable 參數加入您的命令，然後再試一次。</value>
   </data>
   <data name="ModuleLoadedAsASnapin" xml:space="preserve">
-    <value>The '{0}' module was not imported because the '{0}' snap-in was already imported.</value>
+    <value>未匯入 '{0}' 模組，因為已先匯入 '{0}' 嵌入式管理單元。</value>
   </data>
   <data name="WildCardNotAllowedInRequiredAssemblies" xml:space="preserve">
-    <value>Wildcard characters are not allowed in the member 'RequiredAssemblies' in the module manifest '{0}'.</value>
+    <value>模組資訊清單 '{0}' 中的成員 'RequiredAssemblies' 不允許使用萬用字元。</value>
   </data>
   <data name="CmdletizationDoesSupportRexportingNestedModules" xml:space="preserve">
-    <value>The value of the {0} key in {1} is {2} and the module has nested modules. When a CDXML file is the root module, the Import-Module command fails because the commands in nested modules cannot be exported. Move the CDXML file to the NestedModules key and try the command again.</value>
+    <value>{1} 中 {0} 索引鍵的值為 {2}，且模組具有巢狀模組。當 CDXML 檔案是根模組時，Import-Module 命令會失敗，因為無法匯出巢狀模組中的命令。請將 CDXML 檔案移到 NestedModules 索引鍵，然後再次嘗試命令。</value>
     <comment>{0} is equal to either ModuleToProcess or RootModule
 {1} is a placeholder for a file path to psd1 file
 {2} is a placeholder for a file path to cdxml file</comment>
   </data>
   <data name="RemoteDiscoveryRemotePsrpCommandFailed" xml:space="preserve">
-    <value>Failure from remote command: {0}: {{0}}</value>
+    <value>遠端命令失敗: {0}: {{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToGenerateProxyForRemoteModule" xml:space="preserve">
-    <value>Failed to generate proxies for remote module '{0}'. {{0}}</value>
+    <value>無法為遠端模組 '{0}' 產生 Proxy。{{0}}</value>
   </data>
   <data name="RemoteDiscoveryFailedToProcessRemoteModule" xml:space="preserve">
-    <value>Failed to process the remote module {0}. {1}</value>
+    <value>無法處理遠端模組 {0}。{1}</value>
   </data>
   <data name="RemoteDiscoveryFailureFromDiscoveryProvider" xml:space="preserve">
-    <value>Failed to receive module data from the remote CimSession. {0}</value>
+    <value>無法從遠端 CimSession 接收模組資料。{0}</value>
   </data>
   <data name="RequiredModuleNotFoundWrongGuidVersion" xml:space="preserve">
-    <value>The required module '{0}' with GUID '{1}' and version '{2}' was not loaded because no valid module file was found in any module directory.</value>
+    <value>未載入具有 GUID '{1}' 及版本 '{2}' 的必要模組 '{0}'，因為在任何模組目錄中都找不到有效的模組檔案。</value>
   </data>
   <data name="RemoteDiscoveryProviderNotFound" xml:space="preserve">
-    <value>A CIM provider for module discovery was not found on the CIM server. {0}</value>
+    <value>在 CIM 伺服器上找不到用於模組探索的 CIM 提供者。{0}</value>
     <comment>{0} is a placeholder for a more detailed error message</comment>
   </data>
   <data name="CannotDetectNetFrameworkVersion" xml:space="preserve">
-    <value>Cannot verify the Microsoft .NET Framework version {0} because it is not included in the list of permitted versions.</value>
+    <value>無法驗證 Microsoft .NET Framework 版本 {0}，因為它不在允許的版本清單中。</value>
   </data>
   <data name="ScriptAnalysisModule" xml:space="preserve">
-    <value>Analyzing {0}.</value>
+    <value>正在分析 {0}。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="ScriptAnalysisPreparing" xml:space="preserve">
-    <value>Preparing modules for first use.</value>
+    <value>正在準備模組以供首次使用。</value>
   </data>
   <data name="DeterminingAvailableModules" xml:space="preserve">
-    <value>Searching for available modules</value>
+    <value>正在搜尋可用的模組</value>
   </data>
   <data name="SearchingUncShare" xml:space="preserve">
-    <value>Searching UNC share {0}.</value>
+    <value>正在搜尋 UNC 共用 {0}。</value>
     <comment>{0} should not be localized, is used to contain a file path.</comment>
   </data>
   <data name="RemoteDiscoveryWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet against a remote computer can only be done for module names that do not include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>對遠端電腦執行 Get-Module cmdlet 只能用於不包含路徑的模組名稱。Name 參數中的元素 '{0}' 會解析為路徑。請更新 Name 參數，移除路徑元素，然後再試一次。</value>
   </data>
   <data name="ModuleDiscoveryForLoadedModulesWorksOnlyForUnQualifiedNames" xml:space="preserve">
-    <value>Running the Get-Module cmdlet without ListAvailable parameter is not supported for module names that include a path. Name parameter has this element '{0}' which resolves to a path. Update the Name parameter to not have path elements, and then try again.</value>
+    <value>對於包含路徑的模組名稱，不支援在未使用 ListAvailable 參數的情況下執行 Get-Module Cmdlet。Name 參數中的元素 '{0}' 會解析為路徑。請更新 Name 參數，移除路徑元素，然後再試一次。</value>
   </data>
   <data name="ModuleNotFoundForGetModule" xml:space="preserve">
-    <value>The specified module '{0}' was not found. Update the Name parameter to point to a valid path, and then try again. </value>
+    <value>找不到指定的模組 '{0}'。請更新 Name 參數，使其指向有效路徑，然後再試一次。</value>
   </data>
   <data name="PopulatingRepositorySourceLocation" xml:space="preserve">
-    <value>Populating RepositorySourceLocation property for module {0}.</value>
+    <value>正在填入模組 {0} 的 RepositorySourceLocation 屬性。</value>
   </data>
   <data name="ManifestMemberNotValid" xml:space="preserve">
-    <value>The module to process '{0}', listed in field '{1}' of module manifest '{2}' was not processed. {3}</value>
+    <value>未處理模組資訊清單 '{0}' 的欄位 '{1}' 中列出的要處理模組 '{2}'。 {3}</value>
   </data>
   <data name="PrerequisiteForDesktopEditionOnly" xml:space="preserve">
-    <value>This prerequisite is valid for the PowerShell Desktop edition only.</value>
+    <value>此必要條件僅適用於 PowerShell Desktop 版本。</value>
   </data>
   <data name="PSEditionNotSupported" xml:space="preserve">
-    <value>Module '{0}' does not support current PowerShell edition '{1}'. Its supported editions are '{2}'. Use 'Import-Module -SkipEditionCheck' to ignore the compatibility of this module.</value>
+    <value>模組 '{0}' 不支援目前的 PowerShell 版本 '{1}'。其支援的版本為 '{2}'。請使用 'Import-Module -SkipEditionCheck' 忽略此模組的相容性。</value>
   </data>
   <data name="ImplicitWinCompatDisabled" xml:space="preserve">
-    <value>Module '{0}' supports PowerShell edition '{1}' and cannot be loaded implicitly using the Windows Compatibility feature because it is disabled in the settings file. Use 'Import-Module -UseWindowsPowerShell' to load this module with Windows PowerShell or 'Import-Module -SkipEditionCheck' to try to load the module with the current PowerShell.</value>
+    <value>模組 '{0}' 支援 PowerShell 版本 '{1}'，因為設定檔已停用 Windows 相容性功能，所以無法隱含載入。請使用 'Import-Module -UseWindowsPowerShell' 以 Windows PowerShell 載入此模組，或使用 'Import-Module -SkipEditionCheck' 嘗試以目前的 PowerShell 載入此模組。</value>
   </data>
   <data name="ExperimentalFeatureNameMissingOrEmpty" xml:space="preserve">
-    <value>A non-empty string value should be specified for an experimental feature declared in the module manifest.</value>
+    <value>應為模組資訊清單中宣告的實驗性功能指定非空白字串值。</value>
   </data>
   <data name="InvalidExperimentalFeatureName" xml:space="preserve">
-    <value>One or more invalid experimental feature names found: {0}. A module experimental feature name should follow this convention: 'ModuleName.FeatureName'.</value>
+    <value>找到一或多個無效的實驗性功能名稱: {0}。模組實驗性功能名稱應遵循此慣例: 'ModuleName.FeatureName'。</value>
   </data>
   <data name="SkipEditionCheckNotSupportedWithoutListAvailable" xml:space="preserve">
-    <value>The -SkipEditionCheck switch parameter cannot be used without the -ListAvailable switch parameter.</value>
+    <value>必須搭配 -ListAvailable 切換參數，才能使用 -SkipEditionCheck 切換參數。</value>
   </data>
   <data name="ImportPSFileNotAllowedInConstrainedLanguage" xml:space="preserve">
-    <value>Importing *.ps1 files as modules is not allowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式中，不允許將 *.ps1 檔案匯入為模組。</value>
   </data>
   <data name="MismatchedLanguageModes" xml:space="preserve">
-    <value>An error has occurred while loading script module {0} because it has a different language mode than the module manifest. The manifest language mode is {1} and the module language mode is {2}. Ensure all module files are signed or otherwise part of your application allow list configuration.</value>
+    <value>載入指令碼模組 {0} 時發生錯誤，因為其語言模式與模組資訊清單不同。資訊清單語言模式為 {1}，而模組語言模式為 {2}。請確定所有模組檔案都已簽署，或已納入應用程式允許清單設定中。</value>
   </data>
   <data name="CannotUseDotSourceWithWildCardFunctionExport" xml:space="preserve">
-    <value>This module uses the dot-source operator while exporting functions using wildcard characters, and this is disallowed when the system is under application verification enforcement.</value>
+    <value>此模組在使用萬用字元匯出函式時，會使用 dot-source 運算子，而在系統啟用應用程式驗證強制執行時，這是不允許的。</value>
   </data>
   <data name="CannotExportMembersAccrossLanguageBoundaries" xml:space="preserve">
-    <value>Cannot export module members from a module that has a different language mode from the running session.</value>
+    <value>無法從語言模式與執行中工作階段不同的模組匯出模組成員。</value>
   </data>
   <data name="CannotCreateModuleWithScriptBlock" xml:space="preserve">
-    <value>Cannot create new module while the session is in ConstrainedLanguage mode.</value>
+    <value>當工作階段處於 ConstrainedLanguage 模式時，無法建立新模組。</value>
   </data>
   <data name="CannotFindCoreCompatibleBuiltInModule" xml:space="preserve">
-    <value>Cannot find the built-in module '{0}' that is compatible with the 'Core' edition. Please make sure the PowerShell built-in modules are available. They usually come with the PowerShell package under the $PSHOME module path, and are required for PowerShell to function properly.</value>
+    <value>找不到與 'Core' 版本相容的內建模組 '{0}'。請確認 PowerShell 內建模組可供使用。它們通常隨 PowerShell 套件一起提供，位於 $PSHOME 模組路徑下，而且是 PowerShell 正常運作所需。</value>
   </data>
   <data name="WDACExportModuleCommandLogTitle" xml:space="preserve">
     <value>Export-ModuleMember Cmdlet</value>
   </data>
   <data name="WDACExportModuleCommandLogMessage" xml:space="preserve">
-    <value>Export of module members will fail in Constrained Language mode because module '{0}', has a language mode '{1}' that is different from the current session '{2}'.</value>
+    <value>在限制語言模式中匯出模組成員將會失敗，因為模組 '{0}' 的語言模式 '{1}' 與目前的工作階段 '{2}' 的語言模式不同。</value>
   </data>
   <data name="WDACImplicitFunctionExportLogTitle" xml:space="preserve">
-    <value>Module Implicit Function Export</value>
+    <value>模組隱含函式匯出</value>
   </data>
   <data name="WDACImplicitFunctionExportLogMessage" xml:space="preserve">
-    <value>Implicit function export for module '{0}' will be denied because it is trusted (runs in Full Language mode) but the session is not trusted (runs in Constrained Language mode). It is best practice to always export module functions individually by full name.</value>
+    <value>模組 '{0}' 的隱含函式匯出將會遭到拒絕，因為它是受信任的 (以完整語言模式執行)，但工作階段不是受信任的 (以限制語言模式執行)。最佳做法是一律以完整名稱個別匯出模組函式。</value>
   </data>
   <data name="WDACScriptFileImportLogTitle" xml:space="preserve">
-    <value>Importing Script File as Module</value>
+    <value>正在將指令檔匯入為模組</value>
   </data>
   <data name="WDACScriptFileImportLogMessage" xml:space="preserve">
-    <value>Importing the script file '{0}' as a module will be disallowed in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式中，不允許將指令碼檔案 '{0}' 匯入為模組。</value>
   </data>
   <data name="WDACModuleDotSourceLogTitle" xml:space="preserve">
-    <value>Module Contains Dot-Source Operator</value>
+    <value>模組包含 Dot-Source 運算子</value>
   </data>
   <data name="WDACModuleDotSourceLogMessage" xml:space="preserve">
-    <value>Module '{0}' import will in fail Constrained Language mode because it exports functions using wildcard characters while also using the dot-source operator.</value>
+    <value>模組 '{0}' 的匯入在限制語言模式中將會失敗，因為它使用萬用字元匯出函式，同時也使用 dot-source 運算子。</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogTitle" xml:space="preserve">
-    <value>"Module Exporting Functions</value>
+    <value>"模組匯出函式</value>
   </data>
   <data name="WDACModuleFnExportWithNestedModulesLogMessage" xml:space="preserve">
-    <value>Module '{0}' exports functions using name wildcard characters. Any nested module function names will be removed when running in Constrained Language mode.</value>
+    <value>模組 '{0}' 使用名稱萬用字元匯出函式。在限制語言模式下執行時，任何巢狀模組函式名稱都會移除。</value>
   </data>
   <data name="WDACNewModuleCommandLogTitle" xml:space="preserve">
     <value>"New-Module Cmdlet</value>
   </data>
   <data name="WDACNewModuleCommandLogMessage" xml:space="preserve">
-    <value>A new module from an untrusted Constrained Language session will be blocked from providing the FullLanguage script block.</value>
+    <value>來自未受信任的限制語言工作階段的新模組，將無法提供 FullLanguage 指令碼區塊。</value>
   </data>
   <data name="WDACMismatchedLanguageModesTitle" xml:space="preserve">
-    <value>"Module Mismatched Language Modes</value>
+    <value>"模組語言模式不相符</value>
   </data>
   <data name="WDACMismatchedLanguageModesMessage" xml:space="preserve">
-    <value>A dependent module is being loaded that has a different language mode than the parent. This will be disallowed when in Constrained Language mode.</value>
+    <value>正在載入的相依模組與父模組的語言模式不同。在限制語言模式中將不允許此動作。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/PSConfigurationStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/PSConfigurationStrings.zh-Hant.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CanNotConfigurationFile" xml:space="preserve">
-    <value>PowerShell has stopped working because of a security issue: Cannot read the configuration file: {0}</value>
+    <value>PowerShell 已因安全性問題而停止運作: 無法讀取設定檔: {0}</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/ParserStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/ParserStrings.zh-Hant.resx
@@ -127,7 +127,7 @@
     <value>字串語彙基元不完整。</value>
   </data>
   <data name="InvalidUnicodeEscapeSequence" xml:space="preserve">
-    <value>The Unicode escape sequence is not valid. A valid sequence is `u{ followed by one to six hex digits and a closing '}'.</value>
+    <value>Unicode 逸出序列無效。有效的序列是 `u{，後接一到六個十六進位數字，並以 '}' 結尾。</value>
   </data>
   <data name="InvalidUnicodeEscapeSequenceValue" xml:space="preserve">
     <value>Unicode 逸出序列值超出範圍。最大值為 0x10FFFF。</value>

--- a/src/System.Management.Automation/resources/zh-Hant/PathUtilsStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/PathUtilsStrings.zh-Hant.resx
@@ -118,31 +118,31 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Utf7EncodingObsolete" xml:space="preserve">
-    <value>Encoding 'UTF-7' is obsolete, please use UTF-8.</value>
+    <value>編碼 'UTF-7' 已過時，請使用 UTF-8。</value>
   </data>
   <data name="UtilityFileExistsNoClobber" xml:space="preserve">
-    <value>File {0} already exists and {1} was specified.</value>
+    <value>檔案 {0} 已經存在，且已指定 {1}。</value>
   </data>
   <data name="OutFile_ReadWriteFileNotFileSystemProvider" xml:space="preserve">
-    <value>Cannot open file because the current provider ({0}) cannot open a file.</value>
+    <value>無法開啟檔案，因為目前的提供者 ({0}) 無法開啟檔案。</value>
   </data>
   <data name="OutFile_MultipleFilesNotSupported" xml:space="preserve">
-    <value>Cannot perform operation because the path resolved to more than one file. This command cannot operate on multiple files.</value>
+    <value>無法執行作業，因為路徑已解析為多個檔案。此命令無法針對多個檔案執行。</value>
   </data>
   <data name="OutFile_DidNotResolveFile" xml:space="preserve">
-    <value>Cannot perform operation because the wildcard path {0} did not resolve to a file.</value>
+    <value>無法執行作業，因為萬用字元路徑 {0} 未解析為檔案。</value>
   </data>
   <data name="OutFile_WriteToFileEncodingUnknown" xml:space="preserve">
-    <value>Unknown encoding {0}; valid values are {1}.</value>
+    <value>未知的編碼 {0}; 有效值為 {1}。</value>
   </data>
   <data name="ExportPSSession_ErrorDirectoryExists" xml:space="preserve">
-    <value>The directory '{0}' already exists.  Use the -Force parameter if you want to overwrite the directory and files within the directory.</value>
+    <value>目錄 '{0}' 已經存在。 如果您想要覆寫此目錄及其中的檔案，請使用 -Force 參數。</value>
   </data>
   <data name="ExportPSSession_ErrorModuleNameOrPath" xml:space="preserve">
-    <value>The user module path does not exist, and hence a module folder cannot be created for the provided module name '{0}'.</value>
+    <value>使用者模組路徑不存在，因此無法為提供的模組名稱 '{0}' 建立模組資料夾。</value>
   </data>
   <data name="ExportPSSession_CannotCreateOutputDirectory" xml:space="preserve">
-    <value>Cannot create the module {0} due to the following: {1}. Use a different argument for the -OutputModule parameter and retry.</value>
+    <value>無法建立模組 {0}，原因如下: {1}。請針對 -OutputModule 參數使用不同的引數，然後重試。</value>
     <comment>{StrContains="OutputModule"}
 {0} is a placeholder for the name of a directory
 {1} is a placeholder for an error message from the inner exception
@@ -161,6 +161,6 @@ At line:1 char:1
     </comment>
   </data>
   <data name="ExportPSSession_ScriptGeneratorVersionMismatch" xml:space="preserve">
-    <value>The module cannot be loaded because it has been generated with an incompatible version of the {0} cmdlet. Generate the module with the {0} cmdlet from the current session, and try loading the module again.</value>
+    <value>無法載入模組，因為它是由不相容的 {0} Cmdlet 版本產生。請使用目前工作階段中的 {0} Cmdlet 產生模組，然後再次嘗試載入模組。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/ProgressRecordStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/ProgressRecordStrings.zh-Hant.resx
@@ -118,15 +118,15 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="ArgMayNotBeNegative" xml:space="preserve">
-    <value>Cannot process the argument because {0} cannot be a negative value.</value>
+    <value>無法處理引數，因為 {0} 不能為負值。</value>
   </data>
   <data name="ArgMayNotBeNullOrEmpty" xml:space="preserve">
-    <value>Cannot process the argument because the value of {0} cannot be null or empty.</value>
+    <value>無法處理引數，因為 {0} 的值不能為 null 或空白。</value>
   </data>
   <data name="PercentMayNotBeMoreThan100" xml:space="preserve">
-    <value>Cannot set percent because {0} cannot be greater than 100.</value>
+    <value>無法設定百分比，因為 {0} 不能大於 100。</value>
   </data>
   <data name="ParentActivityIdCantBeActivityId" xml:space="preserve">
-    <value>ParentActivityId cannot be the same as the ActivityId.</value>
+    <value>ParentActivityId 不能與 ActivityId 相同。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/RemotingErrorIdStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/RemotingErrorIdStrings.zh-Hant.resx
@@ -300,7 +300,7 @@
     <value>PowerShell 用戶端不支援伺服器所交涉的 {0} {1}。請確定伺服器與 PowerShell 的組建 {2} 和通訊協定版本 {3} 相容。</value>
   </data>
   <data name="ClientNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the server failed. Make sure the server is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>{0}。與伺服器的交涉失敗。請確定伺服器與 PowerShell 的組建 {1} 和通訊協定版本 {2} 相容。</value>
   </data>
   <data name="ServerRequestedToCloseSession" xml:space="preserve">
     <value>目的地伺服器已傳送關閉工作階段的要求。</value>
@@ -321,7 +321,7 @@
     <value>執行 PowerShell 的伺服器無法處理連線作業，因為伺服器 Runspace 集區屬性與用戶端電腦指定的屬性不符。</value>
   </data>
   <data name="ServerNotFoundCapabilityProperties" xml:space="preserve">
-    <value>{0}. Negotiation with the client failed. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>{0}。與用戶端的交涉失敗。請確定用戶端與 PowerShell 的組建 {1} 和通訊協定版本 {2} 相容。</value>
   </data>
   <data name="ServerNegotiationTimeout" xml:space="preserve">
     <value>伺服器交涉計時器已到期。交涉逾時間隔為 {0} 毫秒。</value>
@@ -549,7 +549,7 @@
     <value>當指定 {1} 時，無法指定 {0}。</value>
   </data>
   <data name="WildCardErrorFilePathParameter" xml:space="preserve">
-    <value>Wildcard characters are not supported for the FilePath parameter. Specify a path without wildcard characters.</value>
+    <value>FilePath 參數不支援萬用字元。請指定不含萬用字元的路徑。</value>
   </data>
   <data name="FilePathNotFromFileSystemProvider" xml:space="preserve">
     <value>指定為 FilePath 參數值的路徑不是來自 FileSystem 提供者。</value>
@@ -612,7 +612,7 @@
     <value>使用下列 Proxy 存取類型時，無法指定 Proxy 認證: {0}。請指定不同的存取類型，或不要指定 Proxy 認證。</value>
   </data>
   <data name="WrongSessionOptionValue" xml:space="preserve">
-    <value>A {0} value must be specified for session option {1}.</value>
+    <value>必須為工作階段選項 {1} 指定 {0} 值。</value>
   </data>
   <data name="PushedRunspaceMustBeOpen" xml:space="preserve">
     <value>工作階段必須開啟。</value>
@@ -636,7 +636,7 @@
     <value>您無法從巢狀提示執行 Enter-PSSession。</value>
   </data>
   <data name="WsmanMaxRedirectionCountVariableDescription" xml:space="preserve">
-    <value>The maximum number of WS-Man URI redirections to allow while connecting to a remote computer</value>
+    <value>連線至遠端電腦時允許的 WS-Man URI 重新導向數目上限</value>
   </data>
   <data name="PSDefaultSessionOptionDescription" xml:space="preserve">
     <value>新遠端工作階段的預設工作階段選項</value>
@@ -846,7 +846,7 @@
     <value>Wait 和 Keep 參數不能在同一個命令中同時使用。</value>
   </data>
   <data name="WriteEventsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The WriteEvents parameter cannot be used without the Wait parameter.</value>
+    <value>未使用 Wait 參數時，無法使用 WriteEvents 參數。</value>
   </data>
   <data name="PowerShellVersionNotSupported" xml:space="preserve">
     <value>PowerShell 7+ 不支援 PowerShell 遠端端點版本設定。</value>
@@ -933,17 +933,17 @@
     <value>命令找不到名稱為 "{0}" 的 PSSession。</value>
   </data>
   <data name="WinPERemotingNotSupported" xml:space="preserve">
-    <value>PowerShell remoting is not supported in the Windows Preinstallation Environment (WinPE).</value>
+    <value>Windows 預先安裝環境 (WinPE) 不支援 PowerShell 遠端處理。</value>
   </data>
   <data name="WinRMRequiresRestart" xml:space="preserve">
-    <value>Changes made by {0} cannot take effect until the WinRM service is restarted.</value>
+    <value>{0} 所做的變更必須等到 WinRM 服務重新啟動後才會生效。</value>
   </data>
   <data name="WinRMRestartWarning" xml:space="preserve">
-    <value>{0} may need to restart the WinRM service if a configuration using this name has recently been unregistered, certain system data structures may still be cached. In that case, a restart of WinRM may be required.
-All WinRM sessions connected to PowerShell session configurations, such as Microsoft.PowerShell and session configurations that are created with the Register-PSSessionConfiguration cmdlet, are disconnected.</value>
+    <value>{0} 如果最近已取消註冊使用此名稱的設定，可能需要重新啟動 WinRM 服務，因為某些系統資料結構可能仍在快取中。在那樣的情況下，可能需要重新啟動 WinRM。
+所有連線至 PowerShell 工作階段設定 (例如 Microsoft.PowerShell，以及使用 Register-PSSessionConfiguration Cmdlet 建立的工作階段設定) 的 WinRM 工作階段都會中斷連線。</value>
   </data>
   <data name="WinRMForceRestartWarning" xml:space="preserve">
-    <value>You are running in a remote session and have selected the Force option which means the WinRM service may restart.If the WinRM service restarts then this remote session will be terminated and you will need to create a new session to continue</value>
+    <value>您正在遠端工作階段中執行，且已選取 Force 選項，這表示 WinRM 服務可能會重新啟動。如果 WinRM 服務重新啟動，此遠端工作階段就會終止，而您需要建立新的工作階段才能繼續</value>
   </data>
   <data name="JobSourceAdapterCannotSaveNullJob" xml:space="preserve">
     <value>嘗試儲存識別碼時，工作為 null。請指定工作以儲存其識別碼。</value>
@@ -1145,7 +1145,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>剖析設定檔 {0} 時發生錯誤，訊息如下: {1}</value>
   </data>
   <data name="WriteJobInResultsCannotBeUsedWithoutWait" xml:space="preserve">
-    <value>The -WriteJobInResults parameter cannot be used without the -Wait parameter</value>
+    <value>未使用 -Wait 參數時，無法使用 -WriteJobInResults 參數</value>
   </data>
   <data name="DISCPathsMustBeAbsolute" xml:space="preserve">
     <value>成員 '{0}' 不是絕對路徑 {1}。請將成員變更為檔案 {2} 中的絕對路徑。</value>
@@ -1465,52 +1465,52 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>提供的輸入資料無效。僅支援類型為 {0} 的輸入資料。</value>
   </data>
   <data name="WSManPluginInvalidInputStream" xml:space="preserve">
-    <value>The supplied input stream is not valid. Only {0} is supported as input stream.</value>
+    <value>提供的輸入資料流無效。只支援 {0} 作為輸入資料流。</value>
   </data>
   <data name="WSManPluginInvalidOutputStream" xml:space="preserve">
-    <value>The supplied output stream set is not valid. Only {0} is supported as output stream.</value>
+    <value>提供的輸出資料流集合無效。只支援 {0} 作為輸出資料流。</value>
   </data>
   <data name="WSManPluginInvalidSenderDetails" xml:space="preserve">
     <value>提供的 WSMAN_SENDER_DETAILS 無效。無法處理 Null WSMAN_SENDER_DETAILS。</value>
   </data>
   <data name="WSManPluginInvalidShellContext" xml:space="preserve">
-    <value>The supplied shell context is not valid.</value>
+    <value>提供的殼層內容無效。</value>
   </data>
   <data name="WSManPluginManagedException" xml:space="preserve">
     <value>{0}</value>
   </data>
   <data name="WSManPluginNullInvalidInput" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>外掛程式方法 {1} 中的 {0} 不允許為 NULL 值。</value>
   </data>
   <data name="WSManPluginNullInvalidStreamSet" xml:space="preserve">
-    <value>NULL value is not allowed for input stream and output stream sets. {0} and {1} are the supported input and output streams.</value>
+    <value>輸入資料流與輸出資料流集合不允許為 NULL 值。{0} 和 {1} 是支援的輸入與輸出資料流。</value>
   </data>
   <data name="WSManPluginNullPluginContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>外掛程式方法 {1} 中的 {0} 不允許為 NULL 值。</value>
   </data>
   <data name="WSManPluginNullShellContext" xml:space="preserve">
-    <value>NULL value is not allowed for {0} with the plugin method {1}.</value>
+    <value>外掛程式方法 {1} 中的 {0} 不允許為 NULL 值。</value>
   </data>
   <data name="WSManPluginOperationClose" xml:space="preserve">
-    <value>PowerShell plugin operation is shutting down. This may happen if the hosting service or application is shutting down.</value>
+    <value>PowerShell 外掛程式作業正在關閉。如果主控服務或應用程式正在關閉，就可能發生此情況。</value>
   </data>
   <data name="WSManPluginOptionNotUnderstood" xml:space="preserve">
-    <value>PowerShell plugin does not understand the option {0}. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>PowerShell 外掛程式無法理解選項 {0}。請確定用戶端與 PowerShell 的組建 {1} 和通訊協定版本 {2} 相容。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotFound" xml:space="preserve">
-    <value>An option with name {0} is expected from the client. Make sure the client is compatible with the build {1} and the protocol version {2} of PowerShell.</value>
+    <value>用戶端必須提供名稱為 {0} 的選項。請確定用戶端與 PowerShell 的組建 {1} 和通訊協定版本 {2} 相容。</value>
   </data>
   <data name="WSManPluginProtocolVersionNotMatch" xml:space="preserve">
-    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;Powershell plugin does not support the protocol version {2} requested by client.&lt;/PSProtocolVersionError&gt;</value>
+    <value>&lt;PSProtocolVersionError ServerProtocolVersion="{0}" ServerBuildVersion="{1}"&gt;PowerShell 外掛程式不支援用戶端要求的通訊協定版本 {2}。&lt;/PSProtocolVersionError&gt;</value>
   </data>
   <data name="WSManPluginReportContextFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error while reporting context to WSMan service.</value>
+    <value>PowerShell 外掛程式向 WSMan 服務回報內容時發生嚴重錯誤。</value>
   </data>
   <data name="WSManPluginSessionCreationFailed" xml:space="preserve">
     <value>無法建立受控伺服器工作階段。</value>
   </data>
   <data name="WSManPluginShutdownRegistrationFailed" xml:space="preserve">
-    <value>Powershell plugin encountered a fatal error registering a wait handle for shutdown notification.</value>
+    <value>PowerShell 外掛程式在註冊用於關閉通知的等候控制代碼時發生嚴重錯誤。</value>
   </data>
   <data name="ServerDriverRemoteHostAlreadyPushed" xml:space="preserve">
     <value>無法進入 Runspace，因為此工作階段中已推入 Runspace。</value>
@@ -1591,7 +1591,7 @@ All WinRM sessions connected to PowerShell session configurations, such as Micro
     <value>RequiredGroups 屬性雜湊表只能包含一個索引鍵。</value>
   </data>
   <data name="RequiredGroupsNotHashTable" xml:space="preserve">
-    <value>The RequiredGroups property is not in a name/value pair hashtable format.  This must be a hashtable of the form (using PowerShell syntax): RequiredGroups = @{ Or = 'Administrators' }.</value>
+    <value>RequiredGroups 屬性不是名稱/值組雜湊表格式。 這必須是下列格式的雜湊表 (使用 PowerShell 語法): RequiredGroups = @{ Or = 'Administrators' }。</value>
   </data>
   <data name="UnknownGroupMembershipKey" xml:space="preserve">
     <value>必要群組設定中有未知的索引鍵。 必要群組雜湊表只能包含 'And' 和 'Or' 這類邏輯成員資格分組的雜湊鍵。</value>
@@ -1662,7 +1662,7 @@ SSH 用戶端處理序在建立連線之前就已終止。</value>
     <value>PowerShell 6+ 不支援 WOW64。二進位檔必須與處理器架構相符。</value>
   </data>
   <data name="WowComponentNotPresent" xml:space="preserve">
-    <value>The "{0}" executable file was not found. Verify that the WOW64 feature is installed.</value>
+    <value>找不到 "{0}" 可執行檔。請確認已安裝 WOW64 功能。</value>
   </data>
   <data name="UnableToInstallPlugin" xml:space="preserve">
     <value>無法將外掛程式 {0} 安裝到目錄 {1}。</value>
@@ -1703,7 +1703,7 @@ SSH 用戶端處理序在建立連線之前就已終止。</value>
     <value>遠端偵錯工具例外狀況: {0}，錯誤訊息: {1}</value>
   </data>
   <data name="WindowsPowerShellNotPresent" xml:space="preserve">
-    <value>Unable to create Windows PowerShell process because Windows PowerShell could not be found on this machine.</value>
+    <value>無法建立 Windows PowerShell 處理序，因為在此機器上找不到 Windows PowerShell。</value>
   </data>
   <data name="InvalidPSSessionArgument" xml:space="preserve">
     <value>Create 的 Runspace 引數必須是非 Null 的 RemoteRunspace 物件。</value>

--- a/src/System.Management.Automation/resources/zh-Hant/RunspaceStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/RunspaceStrings.zh-Hant.resx
@@ -118,126 +118,126 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidRunspaceStateGeneral" xml:space="preserve">
-    <value>The runspace state is not valid for this operation.</value>
+    <value>Runspace 狀態不適用於此作業。</value>
   </data>
   <data name="CannotOpenAgain" xml:space="preserve">
-    <value>Cannot open the runspace because the runspace is not in the BeforeOpen state. Current state of the runspace is '{0}'.</value>
+    <value>無法開啟 Runspace，因為 Runspace 不是 BeforeOpen 狀態。Runspace 目前的狀態為 '{0}'。</value>
   </data>
   <data name="RunspaceNotInOpenedState" xml:space="preserve">
-    <value>Cannot perform the operation because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>無法執行此作業，因為 Runspace 不是 Opened 狀態。Runspace 目前的狀態為 '{0}'。</value>
   </data>
   <data name="RunspaceNotOpenForPipeline" xml:space="preserve">
-    <value>Cannot invoke the pipeline because the runspace is not in the Opened state. Current state of the runspace is '{0}'.</value>
+    <value>無法叫用管道，因為 Runspace 不是 Opened 狀態。Runspace 目前的狀態為 '{0}'。</value>
   </data>
   <data name="InvalidPipelineStateStateGeneral" xml:space="preserve">
-    <value>The pipeline state is not valid for this operation.</value>
+    <value>管道狀態不適用於此作業。</value>
   </data>
   <data name="PipelineReInvokeNotAllowed" xml:space="preserve">
-    <value>Cannot invoke pipeline because it has already been invoked.</value>
+    <value>無法叫用管道，因為已叫用過該管道。</value>
   </data>
   <data name="InvalidValueToResultError" xml:space="preserve">
-    <value>The valid value for the parameter is PipelineResultTypes.Output.</value>
+    <value>此參數的有效值為 PipelineResultTypes.Output。</value>
   </data>
   <data name="NoCommandInPipeline" xml:space="preserve">
-    <value>The pipeline does not contain a command.</value>
+    <value>管道不包含命令。</value>
   </data>
   <data name="ConcurrentInvokeNotAllowed" xml:space="preserve">
-    <value>The pipeline was not run because a pipeline is already running. Pipelines cannot be run concurrently.</value>
+    <value>管道未執行，因為已有管道正在執行。無法同時執行多個管道。</value>
   </data>
   <data name="NestedPipelineInvokeAsync" xml:space="preserve">
-    <value>A nested pipeline cannot be invoked asynchronously. Use the Invoke method.</value>
+    <value>無法以非同步方式叫用巢狀管道。請使用 Invoke 方法。</value>
   </data>
   <data name="NestedPipelineNoParentPipeline" xml:space="preserve">
-    <value>You should only run a nested pipeline from within a running pipeline.</value>
+    <value>您只能從正在執行的管道內執行巢狀管道。</value>
   </data>
   <data name="RunspaceCloseInvalidWhileSessionStateProxy" xml:space="preserve">
-    <value>Runspace cannot be closed while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy 方法呼叫進行中時，無法關閉 Runspace。</value>
   </data>
   <data name="NoPipelineWhenSessionStateProxyInProgress" xml:space="preserve">
-    <value>Pipeline cannot be invoked while a SessionStateProxy method call is in progress.</value>
+    <value>SessionStateProxy 方法呼叫進行中時，無法叫用管道。</value>
   </data>
   <data name="AnotherSessionStateProxyInProgress" xml:space="preserve">
-    <value>A SessionStateProxy method call is in progress. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>SessionStateProxy 方法呼叫進行中。不允許同時進行多個 SessionStateProxy 方法呼叫。</value>
   </data>
   <data name="NoSessionStateProxyWhenPipelineInProgress" xml:space="preserve">
-    <value>A pipeline is already running. Concurrent SessionStateProxy method calls are not allowed.</value>
+    <value>已有管道正在執行。不允許同時進行多個 SessionStateProxy 方法呼叫。</value>
   </data>
   <data name="ChangePropertyAfterOpen" xml:space="preserve">
-    <value>This property cannot be changed after the runspace has been opened.</value>
+    <value>開啟 Runspace 之後，便無法變更此屬性。</value>
   </data>
   <data name="ErrorLoadingModulesOnRunspaceOpen" xml:space="preserve">
-    <value>One or more errors occurred processing the module '{0}' specified in the InitialSessionState object used to create this runspace. See the ErrorRecords property for a complete list of errors. The first error was: {1}</value>
+    <value>處理用於建立此 Runspace 之 InitialSessionState 物件中所指定的模組 '{0}' 時，發生一或多個錯誤。如需完整的錯誤清單，請參閱 ErrorRecords 屬性。第一個錯誤為: {1}</value>
   </data>
   <data name="InvalidThreadOptionsChange" xml:space="preserve">
-    <value>The thread options can only be changed if the apartment state is multithreaded apartment (MTA), the current options are UseNewThread or UseCurrentThread, and the new value is ReuseThread.</value>
+    <value>只有在 Apartment 狀態為多執行緒 Apartment (MTA)，目前的選項為 UseNewThread 或 UseCurrentThread，且新值為 ReuseThread 時，才能變更執行緒選項。</value>
   </data>
   <data name="UseLocalScopeNotAllowed" xml:space="preserve">
-    <value>{0} cannot be false when language mode is {1} or {2}.</value>
+    <value>當語言模式為 {1} 或 {2} 時，{0} 不能是 false。</value>
   </data>
   <data name="DisconnectNotSupported" xml:space="preserve">
-    <value>You cannot disconnect a local-only runspace.</value>
+    <value>您無法中斷僅限本機 Runspace 的連線。</value>
   </data>
   <data name="ConnectNotSupported" xml:space="preserve">
-    <value>The Connect operation is not supported on local runspaces.</value>
+    <value>本機 Runspace 不支援 Connect 作業。</value>
   </data>
   <data name="RunspaceNotReady" xml:space="preserve">
-    <value>The session is busy. You will be connected to the session as soon as it is available. To cancel the Enter-PSSession command, press Ctrl-C.</value>
+    <value>工作階段忙碌中。工作階段一旦可供使用，您就會連線至該工作階段。若要取消 Enter-PSSession 命令，請按 Ctrl-C。</value>
   </data>
   <data name="NotSupportedOnRestrictedRunspace" xml:space="preserve">
-    <value>The command cannot be completed. Script invocation is not supported in this session configuration. This can occur if the session configuration is in no-language mode.</value>
+    <value>無法完成命令。此工作階段設定不支援指令碼叫用。如果工作階段設定處於無語言模式，就可能發生此情況。</value>
   </data>
   <data name="DisconnectConnectNotSupported" xml:space="preserve">
-    <value>You cannot use Disconnect and Connect operations on local runspaces.</value>
+    <value>您無法在本機 Runspace 上使用 Disconnect 和 Connect 作業。</value>
   </data>
   <data name="RunspaceNotOpenForPipelineConnect" xml:space="preserve">
-    <value>Cannot connect the pipeline because the runspace is not in the Opened state.  Current state of runspace is '{0}'.</value>
+    <value>無法連線管道，因為 Runspace 不是 Opened 狀態。 Runspace 目前的狀態為 '{0}'。</value>
   </data>
   <data name="InvalidRunspacePool" xml:space="preserve">
-    <value>Cannot construct a RemoteRunspace. The provided RunspacePool object is not valid.</value>
+    <value>無法建構 RemoteRunspace。提供的 RunspacePool 物件無效。</value>
   </data>
   <data name="NoDisconnectedCommand" xml:space="preserve">
-    <value>There is no disconnected command associated with this runspace.</value>
+    <value>沒有與此 Runspace 相關聯的已中斷連線命令。</value>
   </data>
   <data name="DisconnectNotSupportedOnServer" xml:space="preserve">
-    <value>The disconnection operation is not supported on the remote computer. To support disconnecting, the remote computer must be running Windows PowerShell 3.0 or a later version of Windows PowerShell and using the WSMan transport.</value>
+    <value>遠端電腦不支援中斷連線作業。若要支援中斷連線，遠端電腦必須執行 Windows PowerShell 3.0 或更新版本的 Windows PowerShell，並使用 WSMan 傳輸。</value>
   </data>
   <data name="CannotConnect" xml:space="preserve">
-    <value>Cannot connect the PSSession because the session is not in the Disconnected state, or is not available for connection.</value>
+    <value>無法連線 PSSession，因為工作階段不是 Disconnected 狀態，或無法供連線使用。</value>
   </data>
   <data name="InvalidMyResultError" xml:space="preserve">
-    <value>Value for parameter cannot be PipelineResultTypes.None or PipelineResultTypes.Output.</value>
+    <value>參數值不能是 PipelineResultTypes.None 或 PipelineResultTypes.Output。</value>
   </data>
   <data name="InvalidValueToResult" xml:space="preserve">
-    <value>Valid values for the parameter are PipelineResultTypes.Output or PipelineResultTypes.Null.</value>
+    <value>此參數的有效值為 PipelineResultTypes.Output 或 PipelineResultTypes.Null。</value>
   </data>
   <data name="DebugRedirectionNotSupported" xml:space="preserve">
-    <value>Debug stream redirection is not supported on the targeted remote computer.</value>
+    <value>目標遠端電腦不支援偵錯資料流重新導向。</value>
   </data>
   <data name="VerboseRedirectionNotSupported" xml:space="preserve">
-    <value>Verbose stream redirection is not supported on the targeted remote computer.</value>
+    <value>目標遠端電腦不支援詳細資訊資料流重新導向。</value>
   </data>
   <data name="WarningRedirectionNotSupported" xml:space="preserve">
-    <value>Warning stream redirection is not supported on the targeted remote computer.</value>
+    <value>目標遠端電腦不支援警告資料流重新導向。</value>
   </data>
   <data name="InformationRedirectionNotSupported" xml:space="preserve">
-    <value>Information stream redirection is not supported on the targeted remote computer.</value>
+    <value>目標遠端電腦不支援資訊資料流重新導向。</value>
   </data>
   <data name="RunningCmdWithJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script.  Because output is routed to job "{0}", you will not see output in the console.  You can wait for the running command to finish, or cancel the command and get an input prompt by pressing Ctrl-C.
+    <value>您已進入正忙於執行命令或指令碼的工作階段。 因為輸出會路由至作業 "{0}"，所以您不會在主控台中看到輸出。 您可以等待正在執行的命令完成，或按 Ctrl-C 取消該命令並取得輸入提示。
 </value>
   </data>
   <data name="RunningCmdWithoutJob" xml:space="preserve">
-    <value>You have entered a session that is busy running a command or script and output will be displayed in the console.  You can wait for the running command to finish or cancel it and get an input prompt by pressing Ctrl-C.
+    <value>您已進入正忙於執行命令或指令碼的工作階段，輸出會顯示在主控台中。 您可以等待正在執行的命令完成，或按 Ctrl-C 取消該命令並取得輸入提示。
 </value>
   </data>
   <data name="RunningCmdDebugStop" xml:space="preserve">
-    <value>You have entered a session that is currently stopped at a debug breakpoint inside a running command or script.  Use the PowerShell command line debugger to continue debugging.
+    <value>您已進入目前在執行中命令或指令碼內停於偵錯中斷點的工作階段。 請使用 PowerShell 命令列偵錯工具繼續偵錯。
 </value>
   </data>
   <data name="RunspaceNotLocal" xml:space="preserve">
-    <value>DefaultRunspace must be a LocalRunspace</value>
+    <value>DefaultRunspace 必須是 LocalRunspace</value>
   </data>
   <data name="PrimaryRunspaceAlreadySet" xml:space="preserve">
-    <value>The static PrimaryRunspace property can only be set once, and has already been set.</value>
+    <value>靜態 PrimaryRunspace 屬性只能設定一次，且已設定。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/SessionStateStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/SessionStateStrings.zh-Hant.resx
@@ -118,540 +118,540 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="InvalidProviderInfo" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was for a different provider than the one passed.</value>
+    <value>無法處理所傳回的資訊，因為從提供者的 Start 方法傳回的資訊適用於與通過提供者不同的提供者。</value>
   </data>
   <data name="InvalidProviderInfoNull" xml:space="preserve">
-    <value>Cannot process the returned information because the information returned from the provider's Start method was null.</value>
+    <value>無法處理所傳回的資訊，因為從提供者的 Start 方法傳回的資訊為 Null。</value>
   </data>
   <data name="GetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetItem 作業失敗。{2}</value>
   </data>
   <data name="GetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 GetItem 作業的動態參數。{2}</value>
   </data>
   <data name="SetItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 SetItem 作業失敗。{2}</value>
   </data>
   <data name="SetItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 SetItem 作業的動態參數。{2}</value>
   </data>
   <data name="ClearItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 ClearItem 作業失敗。{2}</value>
   </data>
   <data name="InvokeDefaultActionProviderException" xml:space="preserve">
-    <value>Attempting to perform the InvokeDefaultAction operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 InvokeDefaultAction 作業失敗。{2}</value>
   </data>
   <data name="InvokeDefaultActionDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the InvokeDefaultAction operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 InvokeDefaultAction 作業的動態參數。{2}</value>
   </data>
   <data name="ItemExistsProviderException" xml:space="preserve">
-    <value>Attempting to perform the ItemExists operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 ItemExists 作業失敗。{2}</value>
   </data>
   <data name="ItemExistsDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ItemExists operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 ItemExists 作業的動態參數。{2}</value>
   </data>
   <data name="IsValidPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsValidPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 IsValidPath 作業失敗。{2}</value>
   </data>
   <data name="IsItemContainerProviderException" xml:space="preserve">
-    <value>Attempting to perform the IsItemContainer operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 IsItemContainer 作業失敗。{2}</value>
   </data>
   <data name="RemoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 RemoveItem 作業失敗。{2}</value>
   </data>
   <data name="GetChildrenProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildItems operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetChildItems 作業失敗。{2}</value>
   </data>
   <data name="GetChildrenDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildItems operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 GetChildItems 作業的動態參數。{2}</value>
   </data>
   <data name="GetChildNamesProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildNames operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetChildNames 作業失敗。{2}</value>
   </data>
   <data name="GetChildNamesDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetChildNames operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 GetChildNames 作業的動態參數。{2}</value>
   </data>
   <data name="RenameItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 RenameItem 作業失敗。{2}</value>
   </data>
   <data name="RenameItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RenameItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 RenameItem 作業的動態參數。{2}</value>
   </data>
   <data name="NewItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewItem operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 NewItem 作業失敗。{2}</value>
   </data>
   <data name="NewItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 NewItem 作業的動態參數。{2}</value>
   </data>
   <data name="HasChildItemsProviderException" xml:space="preserve">
-    <value>Attempting to perform the HasChildItems operation on the '{0}' provider failed for the path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 HasChildItems 作業失敗。{2}</value>
   </data>
   <data name="CopyItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 CopyItem 作業失敗。{2}</value>
   </data>
   <data name="CopyItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 CopyItem 作業的動態參數。{2}</value>
   </data>
   <data name="GetParentPathProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetParentPath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetParentPath 作業失敗。{2}</value>
   </data>
   <data name="NormalizeRelativePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the NormalizeRelativePath operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 NormalizeRelativePath 作業失敗。{2}</value>
   </data>
   <data name="MakePathProviderException" xml:space="preserve">
-    <value>Attempting to perform the MakePath operation operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 MakePath 作業失敗。{2}</value>
   </data>
   <data name="GetChildNameProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetChildName operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetChildName 作業失敗。{2}</value>
   </data>
   <data name="MoveItemProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveItem operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 MoveItem 作業失敗。{2}</value>
   </data>
   <data name="MoveItemDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveItem operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 MoveItem 作業的動態參數。{2}</value>
   </data>
   <data name="GetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetProperty 作業失敗。{2}</value>
   </data>
   <data name="GetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 GetProperty 作業的動態參數。{2}</value>
   </data>
   <data name="SetPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 SetProperty 作業失敗。{2}</value>
   </data>
   <data name="SetPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the SetProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 SetProperty 作業的動態參數。{2}</value>
   </data>
   <data name="ClearPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 ClearProperty 作業失敗。{2}</value>
   </data>
   <data name="ClearPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 ClearProperty 作業的動態參數。{2}</value>
   </data>
   <data name="NewPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 NewProperty 作業失敗。{2}</value>
   </data>
   <data name="NewPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the NewProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 NewProperty 作業的動態參數。{2}</value>
   </data>
   <data name="RemovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RemoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 RemoveProperty 作業失敗。{2}</value>
   </data>
   <data name="RemovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the RemoveProperty operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 RemoveProperty 作業的動態參數。{2}</value>
   </data>
   <data name="CopyPropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the CopyProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 CopyProperty 作業失敗。{2}</value>
   </data>
   <data name="CopyPropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the CopyProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取 CopyProperty 作業的動態參數。{2}</value>
   </data>
   <data name="MovePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the MoveProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 MoveProperty 作業失敗。{2}</value>
   </data>
   <data name="MovePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the MoveProperty operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取 MoveProperty 作業的動態參數。{2}</value>
   </data>
   <data name="RenamePropertyProviderException" xml:space="preserve">
-    <value>Attempting to perform the RenameProperty operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 RenameProperty 作業失敗。{2}</value>
   </data>
   <data name="RenamePropertyDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for RenameProperty cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取 RenameProperty 的參數。{2}</value>
   </data>
   <data name="GetContentReaderProviderException" xml:space="preserve">
-    <value>Content reader cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取內容讀取器。{2}</value>
   </data>
   <data name="GetContentReaderDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentReader operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取 GetContentReader 作業的動態參數。{2}</value>
   </data>
   <data name="GetContentWriterProviderException" xml:space="preserve">
-    <value>Content writer cannot be retrieved for the '{0}' provider for the path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取內容寫入器。{2}</value>
   </data>
   <data name="GetContentWriterDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the GetContentWriter operation cannot be retrieved for the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法針對路徑 '{1}' 的 '{0}' 提供者，擷取 GetContentWriter 作業的動態參數。{2}</value>
   </data>
   <data name="GetContainerContentException" xml:space="preserve">
-    <value>Unable to get content because it is a directory: '{0}'. Please use 'Get-ChildItem' instead.</value>
+    <value>無法取得內容，因為它是目錄: '{0}'。請改為使用 'Get-ChildItem'。</value>
   </data>
   <data name="WriteContainerContentException" xml:space="preserve">
-    <value>Unable to write content because it is a directory: '{0}'.</value>
+    <value>無法寫入內容，因為它是目錄: '{0}'。</value>
   </data>
   <data name="LocationUndoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate backwards.</value>
+    <value>沒有可供向後瀏覽的位置歷程記錄。</value>
   </data>
   <data name="LocationRedoStackIsEmpty" xml:space="preserve">
-    <value>There is no location history left to navigate forwards.</value>
+    <value>沒有可供向前瀏覽的位置歷程記錄。</value>
   </data>
   <data name="BoundedStackIsEmpty" xml:space="preserve">
-    <value>The BoundedStack is empty.</value>
+    <value>BoundedStack 是空的。</value>
   </data>
   <data name="ClearContentProviderException" xml:space="preserve">
-    <value>Attempting to perform the ClearContent operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 ClearContent 作業失敗。{2}</value>
   </data>
   <data name="ClearDirectoryContent" xml:space="preserve">
-    <value>Unable to clear content of '{0}' because it is a directory. Clear-Content is only supported on files.</value>
+    <value>無法清除 '{0}' 的內容，因為它是目錄。僅在檔案上支援 Clear-Content。</value>
   </data>
   <data name="ClearContentDynamicParametersProviderException" xml:space="preserve">
-    <value>The dynamic parameters for the ClearContent operation cannot be retrieved from the '{0}' provider for path '{1}'. {2}</value>
+    <value>無法從路徑 '{1}' 的 '{0}' 提供者，擷取 ClearContent 作業的動態參數。{2}</value>
   </data>
   <data name="GetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the GetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 GetSecurityDescriptor 作業失敗。{2}</value>
   </data>
   <data name="SetSecurityDescriptorProviderException" xml:space="preserve">
-    <value>Attempting to perform the SetSecurityDescriptor operation on the '{0}' provider failed for path '{1}'. {2}</value>
+    <value>嘗試針對路徑 '{1}' 在 '{0}' 提供者上執行 SetSecurityDescriptor 作業失敗。{2}</value>
   </data>
   <data name="ProviderStartException" xml:space="preserve">
-    <value>Attempting to perform the Start operation on the '{0}' provider failed. {1}</value>
+    <value>嘗試在 '{0}' 提供者上執行 Start 作業失敗。{1}</value>
   </data>
   <data name="InitializeDefaultDrivesException" xml:space="preserve">
-    <value>Attempting to perform the InitializeDefaultDrives operation on the '{0}' provider failed.</value>
+    <value>嘗試在 '{0}' 提供者上執行 InitializDefaultDrives 作業失敗。</value>
   </data>
   <data name="NewDriveProviderException" xml:space="preserve">
-    <value>Attempting to perform the NewDrive operation on the '{0}' provider failed for the drive with root '{1}'. {2}</value>
+    <value>嘗試針對根目錄為 '{1}' 的磁碟機在 '{0}' 提供者上執行 NewDrive 作業失敗。{2}</value>
   </data>
   <data name="NewDriveDynamicParametersProviderException" xml:space="preserve">
-    <value>Dynamic parameters for NewDrive cannot be retrieved for the '{0}' provider. {1}</value>
+    <value>無法為 '{0}' 提供者擷取 NewDrive 的動態參數。{1}</value>
   </data>
   <data name="RemoveDriveProviderException" xml:space="preserve">
-    <value>The invocation of RemoveDrive on the '{0}' provider failed. {1}</value>
+    <value>在 '{0}' 提供者上叫用 RemoveDrive 失敗。{1}</value>
   </data>
   <data name="DriveRemovalPreventedByProvider" xml:space="preserve">
-    <value>Drive '{0}' cannot be removed because the provider '{1}' prevented it.</value>
+    <value>無法移除磁碟機 '{0}'，因為提供者 '{1}' 防止這麼做。</value>
   </data>
   <data name="NormalizeRelativePathOutsideBase" xml:space="preserve">
-    <value>The path '{0}' referred to an item that was outside the base '{1}'.</value>
+    <value>路徑 '{0}' 是指基底 '{1}' 以外的項目。</value>
   </data>
   <data name="ProviderSeekError" xml:space="preserve">
-    <value>The invocation of Seek on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>針對 '{1}' 路徑在 '{0}' 提供者的內容寫入器上叫用 Seek 失敗。{2}</value>
   </data>
   <data name="ProviderContentCloseError" xml:space="preserve">
-    <value>The invocation of Close on the '{0}' provider's content reader or writer failed for path '{1}'. {2}</value>
+    <value>針對 '{1}' 路徑在 '{0}' 提供者的內容讀取器或寫入器上叫用 Close 失敗。{2}</value>
   </data>
   <data name="ProviderContentReadError" xml:space="preserve">
-    <value>The invocation of Read on the '{0}' provider's content reader failed for path '{1}'. {2}</value>
+    <value>針對 '{1}' 路徑在 '{0}' 提供者的內容讀取器上叫用 Read 失敗。{2}</value>
   </data>
   <data name="ProviderContentWriteError" xml:space="preserve">
-    <value>The invocation of Write on the '{0}' provider's content writer failed for path '{1}'. {2}</value>
+    <value>針對 '{1}' 路徑在 '{0}' 提供者的內容寫入器上叫用 Write 失敗。{2}</value>
   </data>
   <data name="ProviderCannotBeUsedAsVariable" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to get or set data using the variable syntax. {2}</value>
+    <value>提供者 '{0}' 無法使用變數語法來取得或設定資料。{2}</value>
   </data>
   <data name="ProviderVariableSyntaxInvalid" xml:space="preserve">
-    <value>The variable syntax cannot be used to get or set data in the provider. {2}</value>
+    <value>變數語法無法用於在提供者中取得或設定資料。{2}</value>
   </data>
   <data name="AliasNotWritable" xml:space="preserve">
-    <value>Alias is not writeable because alias {0} is read-only or constant and cannot be written to.</value>
+    <value>無法寫入別名，因為別名 {0} 是唯讀或常數，因此無法寫入其中。</value>
   </data>
   <data name="FunctionNotWritable" xml:space="preserve">
-    <value>Cannot write to function {0} because it is read-only or constant.</value>
+    <value>無法寫入至函式 {0}，因為它是唯讀或常數。</value>
   </data>
   <data name="VariableNotWritable" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because it is read-only or constant.</value>
+    <value>無法覆寫變數 {0}，因為它是唯讀或常數。</value>
   </data>
   <data name="VariableIsPrivate" xml:space="preserve">
-    <value>Cannot access the variable '${0}' because it is a private variable.</value>
+    <value>無法存取變數 '${0}'，因為它是私人變數。</value>
   </data>
   <data name="NamedCommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command '{0}' because it is a private command.</value>
+    <value>無法存取命令 '{0}'，因為它是私人命令。</value>
   </data>
   <data name="CommandIsPrivate" xml:space="preserve">
-    <value>Cannot access the command because it is a private command.</value>
+    <value>無法存取命令，因為它是私人命令。</value>
   </data>
   <data name="ResourceIsPrivate" xml:space="preserve">
-    <value>Cannot access the session state resource because it is a private resource. </value>
+    <value>無法存取工作階段狀態資源，因為它是私人資源。</value>
   </data>
   <data name="AliasNotRemovable" xml:space="preserve">
-    <value>Alias was not removed because alias {0} is constant or read-only.</value>
+    <value>未移除別名，因為別名 {0} 為常數或唯讀。</value>
   </data>
   <data name="FunctionNotRemovable" xml:space="preserve">
-    <value>Cannot remove function {0} because it is constant.</value>
+    <value>無法移除函式 {0}，因為它是常數。</value>
   </data>
   <data name="VariableNotRemovable" xml:space="preserve">
-    <value>Cannot remove variable {0} because it is constant or read-only. If the variable is read-only, try the operation again specifying the Force option.</value>
+    <value>無法移除變數 {0}，因為它是常數或唯讀。如果變數是唯讀，請再次嘗試指定 Force 選項的作業。</value>
   </data>
   <data name="AliasIsConstant" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is constant.</value>
+    <value>無法修改別名 {0}，因為它是常數。</value>
   </data>
   <data name="AliasIsReadOnly" xml:space="preserve">
-    <value>Alias {0} cannot be modified because it is read-only.</value>
+    <value>無法修改別名 {0}，因為它是唯讀。</value>
   </data>
   <data name="FunctionIsConstant" xml:space="preserve">
-    <value>Cannot modify function {0} because it is constant.</value>
+    <value>無法修改函式 {0}，因為它是常數。</value>
   </data>
   <data name="FunctionIsReadOnly" xml:space="preserve">
-    <value>Cannot modify function {0} because it is read-only.</value>
+    <value>無法修改函式 {0}，因為它是唯讀。</value>
   </data>
   <data name="AliasCannotBeMadeConstant" xml:space="preserve">
-    <value>Alias {0} cannot be made constant after it has been created. Aliases can only be made constant at creation time.</value>
+    <value>別名 {0} 在建立後就無法成為常數。別名只能在建立時成為常數。</value>
   </data>
   <data name="FunctionCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing function {0} cannot be made constant. Functions can be made constant only at creation time.</value>
+    <value>現有函式 {0} 不能成為常數。函式只能在建立時成為常數。</value>
   </data>
   <data name="VariableCannotBeMadeConstant" xml:space="preserve">
-    <value>Existing variable {0} cannot be made constant. Variables can be made constant only at creation time.</value>
+    <value>現有變數 {0} 不能成為常數。變數只能在建立時成為常數。</value>
   </data>
   <data name="AliasAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the alias '{0}'.</value>
+    <value>AllScope 選項無法從別名 '{0}' 移除。</value>
   </data>
   <data name="FunctionAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the function '{0}'.</value>
+    <value>AllScope 選項無法從函式 '{0}' 移除。</value>
   </data>
   <data name="VariableAllScopeOptionCannotBeRemoved" xml:space="preserve">
-    <value>The AllScope option cannot be removed from the variable '{0}'.</value>
+    <value>AllScope 選項無法從變數 '{0}' 移除。</value>
   </data>
   <data name="ScopedFunctionMustHaveName" xml:space="preserve">
-    <value>The function definition '{0}' contained a scope qualifier but no function name.</value>
+    <value>函式定義 '{0}' 包含範圍限定詞，但沒有函式名稱。</value>
   </data>
   <data name="RemoveDrivesBeforeRemovingProvider" xml:space="preserve">
-    <value>Cannot remove provider {0}. All drives associated with provider {0} must be removed before provider {0} can be removed.</value>
+    <value>無法移除提供者 {0}。必須先移除與提供者 {0} 相關聯的所有磁碟機，才能移除提供者 {0}。</value>
   </data>
   <data name="DriveNameIllegalCharacters" xml:space="preserve">
-    <value>Cannot process the drive name because the drive name contains one or more of the following characters that are not valid: ; ~ / \ . :</value>
+    <value>無法處理磁碟機名稱，因為磁碟機名稱包含下列一或多個無效字元: ; ~ / \ . :</value>
   </data>
   <data name="NewDriveProviderFailed" xml:space="preserve">
-    <value>New drive creation failed because the provider does not allow the creation of the new drive.</value>
+    <value>新磁碟機建立失敗，因為提供者不允許建立新磁碟機。</value>
   </data>
   <data name="StackNameResolvedToMultiple" xml:space="preserve">
-    <value>The provided value '{0}' resolved to more than one location stack.</value>
+    <value>提供的值 '{0}' 解析為多個位置堆疊。</value>
   </data>
   <data name="StackNotFound" xml:space="preserve">
-    <value>Cannot find location stack '{0}'. It does not exist or it is not a container.</value>
+    <value>找不到位置堆疊 '{0}'。它不存在或不是容器。</value>
   </data>
   <data name="PathNotFound" xml:space="preserve">
     <value>找不到路徑 '{0}'，因為它不存在。</value>
   </data>
   <data name="AliasNotFound" xml:space="preserve">
-    <value>Cannot find alias because alias '{0}' does not exist.</value>
+    <value>找不到別名，因為別名 '{0}' 不存在。</value>
   </data>
   <data name="PathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot set the location because path '{0}' resolved to multiple containers. You can only set the location to a single container at a time.</value>
+    <value>無法設定位置，因為路徑 '{0}' 解析為多個容器。您一次只能將位置設定為單一容器。</value>
   </data>
   <data name="VariablePathResolvedToMultiple" xml:space="preserve">
-    <value>Cannot process variable because variable path '{0}' resolved to multiple items. You can get or set the variable value only one item at a time.</value>
+    <value>無法處理變數，因為變數路徑 '{0}' 解析為多個項目。您一次只能取得或設定一個項目的變數值。</value>
   </data>
   <data name="DriveNotFound" xml:space="preserve">
-    <value>Cannot find drive. A drive with the name '{0}' does not exist.</value>
+    <value>找不到磁碟機。沒有名為 '{0}' 的磁碟機。</value>
   </data>
   <data name="ProviderNotFound" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'.</value>
+    <value>找不到名稱為 '{0}' 的提供者。</value>
   </data>
   <data name="ProviderNotFoundBadFormat" xml:space="preserve">
-    <value>Cannot find a provider with the name '{0}'. The name is not in the proper format. A provider name can only be alphanumeric characters, or a PowerShell snap-in name that is followed by a single '\', followed by alphanumeric characters.</value>
+    <value>找不到名稱為 '{0}' 的提供者。名稱的格式不正確。提供者名稱只能是英數字元，或後面依序接著單一 '\' 和英數字元的 PowerShell 嵌入式管理單元名稱。</value>
   </data>
   <data name="ProviderNameAmbiguous" xml:space="preserve">
-    <value>'{0}' resolved to more than one provider name. Possible matches include:{1}.</value>
+    <value>'{0}' 解析為多個提供者名稱。可能的相符項目包括: {1}。</value>
   </data>
   <data name="ProviderNotFoundInAssembly" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider. The provider type name of '{0}' could not be found in the assembly.</value>
+    <value>嘗試建立提供者的執行個體時發生錯誤。在組件中找不到 '{0}' 的提供者類型名稱。</value>
   </data>
   <data name="ProviderNameNotValid" xml:space="preserve">
-    <value>The specified provider name '{0}' cannot be used because it contains one or more of the following characters that are not valid: \ [ ] ? * :</value>
+    <value>無法使用指定的提供者名稱 '{0}'，因為它包含下列一或多個無效的字元: \ [ ] ? * :</value>
   </data>
   <data name="ProviderCtorException" xml:space="preserve">
-    <value>An error occurred attempting to create an instance of the provider '{0}'. {1} </value>
+    <value>嘗試建立提供者 '{0}' 的執行個體時發生錯誤。{1}</value>
   </data>
   <data name="VariableNotFound" xml:space="preserve">
-    <value>Cannot find a variable with the name '{0}'.</value>
+    <value>找不到名稱為 '{0}' 的變數。</value>
   </data>
   <data name="TraceSourceNotFound" xml:space="preserve">
-    <value>Cannot find a trace source with the name '{0}'.</value>
+    <value>找不到名稱為 '{0}' 的追蹤來源。</value>
   </data>
   <data name="DriveAlreadyExists" xml:space="preserve">
-    <value>A drive with the name '{0}' already exists.</value>
+    <value>名稱為 '{0}' 的磁碟機已經存在。</value>
   </data>
   <data name="VariableAlreadyExists" xml:space="preserve">
-    <value>A variable with name '{0}' already exists.</value>
+    <value>具有名稱 '{0}' 的變數已存在。</value>
   </data>
   <data name="AliasAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because an alias with the name '{0}' already exists.</value>
+    <value>不允許別名，因為名稱為 '{0}' 的別名已經存在。</value>
   </data>
   <data name="CmdletProviderAlreadyExists" xml:space="preserve">
-    <value>Cannot register the cmdlet provider because a cmdlet provider with the name '{0}' already exists.</value>
+    <value>無法登錄 Cmdlet 提供者，因為名稱為 '{0}' 的 Cmdlet 提供者已存在。</value>
   </data>
   <data name="MustBeFileSystemPath" xml:space="preserve">
-    <value>The path does not refer to a file system path.</value>
+    <value>路徑未參考檔案系統路徑。</value>
   </data>
   <data name="GlobalScopeCannotRemove" xml:space="preserve">
-    <value>Global scope cannot be removed.</value>
+    <value>無法移除全域範圍。</value>
   </data>
   <data name="ScopeIDExceedsAvailableScopes" xml:space="preserve">
-    <value>The scope number '{0}' exceeds the number of active scopes.</value>
+    <value>範圍編號 '{0}' 超過使用中範圍的數目。</value>
   </data>
   <data name="OnlyAbleToComparePSDriveInfo" xml:space="preserve">
-    <value>Cannot compare PSDriveInfo. A PSDriveInfo instance can be compared only to another PSDriveInfo instance.</value>
+    <value>無法比較 PSDriveInfo。PSDriveInfo 執行個體只能與另一個 PSDriveInfo 執行個體進行比較。</value>
   </data>
   <data name="OutputStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the output.</value>
+    <value>Cmdlet 提供者無法串流處理結果，因為未指定任何 Cmdlet 來串流處理輸出。</value>
   </data>
   <data name="ErrorStreamingNotEnabled" xml:space="preserve">
-    <value>The cmdlet provider cannot stream the results because no cmdlet was specified through which to stream the error.</value>
+    <value>Cmdlet 提供者無法串流處理結果，因為未指定任何 Cmdlet 來串流處理錯誤。</value>
   </data>
   <data name="HomePathNotSet" xml:space="preserve">
-    <value>Home location for this provider is not set. To set the home location, call "(get-psprovider '{0}').Home = 'path'".</value>
+    <value>未設定此提供者的首頁位置。若要設定首頁位置，請呼叫 "(get-psprovider '{0}').Home = 'path'”。</value>
   </data>
   <data name="NotProviderQualifiedPath" xml:space="preserve">
-    <value>The path is not in the correct format. Provider paths must contain a provider Id, followed by "::", followed by a provider specific path.</value>
+    <value>路徑的格式不正確。提供者路徑必須包含提供者識別碼，後面接著 "::"，再接著提供者特定路徑。</value>
   </data>
   <data name="MovePropertyDestinationResolveToSingle" xml:space="preserve">
-    <value>Cannot move the item because the destination path can resolve only to a single path.</value>
+    <value>無法移動項目，因為目的地路徑只能解析為單一路徑。</value>
   </data>
   <data name="MoveItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Cannot move the item because the source and destination paths did not resolve to the same provider.</value>
+    <value>無法移動項目，因為來源和目的地路徑未解析為相同的提供者。</value>
   </data>
   <data name="MoveItemPathMultipleDestinationNotContainer" xml:space="preserve">
-    <value>Cannot move the item because the source path points to one or more items and the destination path is not a container. Validate that the destination path is a container and try again.</value>
+    <value>無法移動項目，因為來源路徑指向一或多個項目，而且目的地路徑不是容器。驗證目的地路徑是否為容器，然後再試一次。</value>
   </data>
   <data name="MoveItemOneDestination" xml:space="preserve">
-    <value>Cannot move the item because the destination resolved to multiple paths. Specify a destination path that resolves to a single destination and try again.</value>
+    <value>無法移動項目，因為目的地解析為多個路徑。指定解析為單一目的地的目的地路徑，然後再試一次。</value>
   </data>
   <data name="CopyContainerItemToLeafError" xml:space="preserve">
-    <value>Container cannot be copied onto existing leaf item.</value>
+    <value>容器無法複製到現有的分葉項目。</value>
   </data>
   <data name="CopyContainerToContainerWithoutRecurseOrContainer" xml:space="preserve">
-    <value>Container cannot be copied to another container. The -Recurse or -Container parameter is not specified.</value>
+    <value>容器無法複製到另一個容器。未指定 -Recurse 或 -Container 參數。</value>
   </data>
   <data name="CopyItemSourceAndDestinationNotSameProvider" xml:space="preserve">
-    <value>Source and destination path did not resolve to the same provider.</value>
+    <value>來源和目的地路徑未解析為相同的提供者。</value>
   </data>
   <data name="RenameMultipleItemError" xml:space="preserve">
-    <value>Cannot rename item because the path resolved to multiple items. Only one item can be renamed at a time.</value>
+    <value>無法將項目重新命名，因為路徑解析為多個項目。一次只能重新命名一個項目。</value>
   </data>
   <data name="ProviderImplementationInconsistent" xml:space="preserve">
-    <value>The provider '{0}' cannot be used to resolve the path '{1}' because of an error in the provider.</value>
+    <value>提供者 '{0}' 無法用來解析 '{1}' 路徑，因為提供者發生錯誤。</value>
   </data>
   <data name="IContentCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IContentCmdletProvider interface is not implemented by this provider.</value>
+    <value>無法使用介面。此提供者未實作 IContentCmdletProvider 介面。</value>
   </data>
   <data name="IPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IPropertyCmdletProvider interface is not supported by this provider.</value>
+    <value>無法使用介面。此提供者不支援 IPropertyCmdletProvider 介面。</value>
   </data>
   <data name="IDynamicPropertyCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot use interface. The IDynamicPropertyCmdletProvider interface is not implemented by this provider.</value>
+    <value>無法使用介面。此提供者未實作 IDynamicPropertyCmdletProvider 介面。</value>
   </data>
   <data name="NavigationCmdletProvider_NotSupported" xml:space="preserve">
-    <value>The NavigationCmdletProvider methods are not supported by this provider.</value>
+    <value>此提供者不支援 NavigationCmdletProvider 方法。</value>
   </data>
   <data name="ContainerCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider methods not processed. The ContainerCmdletProvider methods are not supported by this provider.</value>
+    <value>未處理提供者方法。此提供者不支援 ContainerCmdletProvider 方法。</value>
   </data>
   <data name="ItemCmdletProvider_NotSupported" xml:space="preserve">
-    <value>Cannot call methods. The ItemCmdletProvider methods are not supported by this provider.</value>
+    <value>無法呼叫方法。此提供者不支援 ItemCmdletProvider 方法。</value>
   </data>
   <data name="DriveCmdletProvider_NotSupported" xml:space="preserve">
-    <value>DriveCmdletProvider methods are not supported by this provider.</value>
+    <value>此提供者不支援 DriveCmdletProvider 方法。</value>
   </data>
   <data name="CmdletProvider_NotSupported" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support this operation.</value>
+    <value>提供者作業已停止，因為提供者不支援此作業。</value>
   </data>
   <data name="CmdletProvider_NotSupportedRecursionDepth" xml:space="preserve">
-    <value>Provider operation stopped because the provider does not support the 'Depth' parameter.</value>
+    <value>提供者作業已停止，因為提供者不支援 'Depth' 參數。</value>
   </data>
   <data name="IContent_Seek_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The content Seek method is not supported by this provider.</value>
+    <value>無法呼叫方法。此提供者不支援內容 Seek 方法。</value>
   </data>
   <data name="IContent_Clear_NotSupported" xml:space="preserve">
-    <value>Cannot perform the ClearContent operation. The ClearContent operation is not supported by this provider.</value>
+    <value>無法執行 ClearContent 作業。此提供者不支援 ClearContent 作業。</value>
   </data>
   <data name="Credentials_NotSupported" xml:space="preserve">
-    <value>The provider does not support the use of credentials. Perform the operation again without specifying credentials.</value>
+    <value>提供者不支援使用認證。請再次執行作業，而不指定認證。</value>
   </data>
   <data name="FileSystemProviderCredentials_NotSupported" xml:space="preserve">
-    <value>The FileSystem provider supports credentials only on the New-PSDrive cmdlet. Perform the operation again without specifying credentials.</value>
+    <value>FileSystem 提供者僅在 New-PSDrive Cmdlet 上支援認證。請再次執行作業，而不指定認證。</value>
   </data>
   <data name="Transactions_NotSupported" xml:space="preserve">
-    <value>The provider does not support transactions. Perform the operation again without the -UseTransaction parameter.</value>
+    <value>提供者不支援交易。在沒有 UseTransaction 參數的情況下再次執行作業。</value>
   </data>
   <data name="Filter_NotSupported" xml:space="preserve">
-    <value>Cannot call method. The provider does not support the use of filters.</value>
+    <value>無法呼叫方法。提供者不支援使用篩選條件。</value>
   </data>
   <data name="NewDriveCredentials_NotSupported" xml:space="preserve">
-    <value>Cannot create drive. The provider does not support the use of credentials.</value>
+    <value>無法建立磁碟機。提供者不支援使用認證。</value>
   </data>
   <data name="NewItemAlreadyExists" xml:space="preserve">
-    <value>The item at path '{0}' already exists.</value>
+    <value>路徑 '{0}' 上已有此項目。</value>
   </data>
   <data name="CopyItemDoesntExist" xml:space="preserve">
-    <value>Cannot copy item. Item at the path '{0}' does not exist.</value>
+    <value>無法複製項目。位於 '{0}' 路徑的項目不存在。</value>
   </data>
   <data name="RenameItemDoesntExist" xml:space="preserve">
-    <value>The item at the path '{0}' does not exist.</value>
+    <value>位於 '{0}' 路徑的項目不存在。</value>
   </data>
   <data name="AliasDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the aliases stored in a session state</value>
+    <value>包含工作階段狀態中儲存之別名檢視的磁碟機</value>
   </data>
   <data name="EnvironmentDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the environment variables for the process</value>
+    <value>包含處理序環境變數檢視的磁碟機</value>
   </data>
   <data name="FunctionDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of the functions stored in a session state</value>
+    <value>包含工作階段狀態中儲存之函式檢視的磁碟機</value>
   </data>
   <data name="VariableDriveDescription" xml:space="preserve">
-    <value>Drive that contains a view of those variables stored in a session state</value>
+    <value>包含工作階段狀態中儲存之變數檢視的磁碟機</value>
   </data>
   <data name="TempDriveDescription" xml:space="preserve">
-    <value>Drive that maps to the temporary directory path for the current user</value>
+    <value>對應至目前使用者之暫存目錄路徑的磁碟機</value>
   </data>
   <data name="NewLinkTargetNotSpecified" xml:space="preserve">
-    <value>Link '{0}' cannot be created because the target Value was not specified.</value>
+    <value>因為未指定目標值，所以無法建立連結 '{0}'。</value>
   </data>
   <data name="DollarNullDescription" xml:space="preserve">
-    <value>References to the null variable always return the null value. Assignments have no effect.</value>
+    <value>null 變數的參考一律會傳回 null 值。指派沒有作用。</value>
   </data>
   <data name="MaxHistoryCountDescription" xml:space="preserve">
-    <value>Maximum number of history objects to retain in a session</value>
+    <value>工作階段中要保留的歷程記錄物件數目上限</value>
   </data>
   <data name="CannotRenameFunction" xml:space="preserve">
-    <value>Cannot rename function because function {0} is read-only or constant.</value>
+    <value>無法將函式重新命名，因為函式 {0} 是唯讀或常數。</value>
   </data>
   <data name="CannotRenameAlias" xml:space="preserve">
-    <value>Cannot rename alias because alias {0} is read-only or constant.</value>
+    <value>無法重新命名別名，因為別名 {0} 是唯讀或常數。</value>
   </data>
   <data name="CannotRenameVariable" xml:space="preserve">
-    <value>Cannot rename variable because variable {0} is read-only or constant.</value>
+    <value>無法將變數重新命名，因為變數 {0} 是唯讀或常數。</value>
   </data>
   <data name="VariableOptionsNotSettable" xml:space="preserve">
-    <value>Cannot set options on the local variable {0}. Use New-Variable to create a variable that allows options to be set.</value>
+    <value>無法在本機變數 {0} 上設定選項。使用 New-Variable 建立允許設定選項的變數。</value>
   </data>
   <data name="CmdletIsReadOnly" xml:space="preserve">
-    <value>Cmdlet {0} cannot be modified because it is read-only.</value>
+    <value>無法修改 Cmdlet {0}，因為它是唯讀。</value>
   </data>
   <data name="VariableNotRemovableRare" xml:space="preserve">
-    <value>Cannot remove variable {0} because the variable has been optimized and is not removable. Try using the Remove-Variable cmdlet (without any aliases), or dot-sourcing the command that you are using to remove the variable.</value>
+    <value>無法移除變數 {0}，因為變數已最佳化且不可移除。請嘗試使用 Remove-Variable Cmdlet (不含任何別名)，或對您用於移除變數的命令執行點號載入。</value>
   </data>
   <data name="VariableNotWritableRare" xml:space="preserve">
-    <value>Cannot overwrite variable {0} because the variable has been optimized. Try using the New-Variable or Set-Variable cmdlet (without any aliases), or dot-source the command that you are using to set the variable.</value>
+    <value>無法覆寫變數 {0}，因為變數已最佳化。請嘗試使用 New-Variable 或 Set-Variable Cmdlet (不含任何別名)，或對您用於設定變數的命令執行點號載入。</value>
   </data>
   <data name="GetContent_TailAndHeadCannotCoexist" xml:space="preserve">
-    <value>The parameters {0} and {1} cannot be used together. Please specify only one parameter.</value>
+    <value>無法同時使用 {0} 和 {1} 參數。請僅指定一個參數。</value>
   </data>
   <data name="GetContent_TailNotSupported" xml:space="preserve">
-    <value>The Tail parameter currently is supported only for the FileSystem provider.</value>
+    <value>目前只有 FileSystem 提供者支援 Tail 參數。</value>
   </data>
   <data name="AliasWithCommandNameAlreadyExists" xml:space="preserve">
-    <value>The alias is not allowed, because a command with the name '{0}' and command type '{1}' already exists.</value>
+    <value>不允許別名，因為名稱為 '{0}' 且命令類型為 '{1}' 的命令已經存在。</value>
   </data>
   <data name="CanNotRun" xml:space="preserve">
-    <value>Cannot run software. Permission is denied.</value>
+    <value>無法執行軟體。權限被拒; 目前的使用者沒有足夠的權限可執行此作業。</value>
   </data>
   <data name="CopyItemFromSessionToSession" xml:space="preserve">
-    <value>'-{0}' and '-{1}' are mutually exclusive and cannot be specified at the same time.</value>
+    <value>'-{0}' 和 '-{1}' 互斥，無法同時指定。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNotAbsolute" xml:space="preserve">
-    <value>The path '{0}' is not valid. Only absolute paths are supported on remote copy operations.</value>
+    <value>路徑 '{0}' 無效。遠端複製作業僅支援絕對路徑。</value>
   </data>
   <data name="CopyItemValidateRemotePath" xml:space="preserve">
-    <value>Cannot validate remote path '{0}'.</value>
+    <value>無法驗證遠端路徑 '{0}'。</value>
   </data>
   <data name="CopyItemSessionProperties" xml:space="preserve">
-    <value>Cannot perform operation because the session {0} is set to {1}.</value>
+    <value>無法執行作業，因為工作階段 {0} 設定為 {1}。</value>
   </data>
   <data name="CopyItemRemotelyPathIsNullOrEmpty" xml:space="preserve">
-    <value>'{0}' parameter cannot be null or empty.</value>
+    <value>'{0}' 參數不得為 null 或空白。</value>
   </data>
   <data name="WDACSessionStateVarLogTitle" xml:space="preserve">
-    <value>Session State Variables</value>
+    <value>工作階段狀態變數</value>
   </data>
   <data name="WDACSessionStateVarLogMessage" xml:space="preserve">
-    <value>Changing or creating the variable '{0}' scope to AllScope will be prevented in ConstrainedLanguage mode.</value>
+    <value>在 ConstrainedLanguage 模式中會防止建立變數 '{0}' 範圍或將其變更為 AllScope。</value>
   </data>
 </root>

--- a/src/System.Management.Automation/resources/zh-Hant/TabCompletionStrings.zh-Hant.resx
+++ b/src/System.Management.Automation/resources/zh-Hant/TabCompletionStrings.zh-Hant.resx
@@ -118,154 +118,154 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="CannotDeserializeTabCompletionResult" xml:space="preserve">
-    <value>The tab completion result cannot be properly deserialized because the remote runspace does not contain a TypeTable instance.</value>
+    <value>因為遠端 Runspace 未包含 TypeTable 執行個體，所以無法正確還原序列化索引標籤完成結果。</value>
   </data>
   <data name="NoAccessToProperties" xml:space="preserve">
-    <value>Cannot access properties on a null instance of the type CompletionResult.</value>
+    <value>無法存取 CompletionResult 類型之 null 執行個體上的屬性。</value>
   </data>
   <data name="bnotOperatorDescription" xml:space="preserve">
-    <value>Bitwise NOT</value>
+    <value>位元 NOT</value>
   </data>
   <data name="notOperatorDescription" xml:space="preserve">
-    <value>Logical not. Negates the statement that follows it.</value>
+    <value>邏輯 Not。否定其後的陳述式。</value>
   </data>
   <data name="eqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中等於右運算元的值，否則，如果左運算元等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ieqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case insensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中等於右運算元的值，否則，如果左運算元等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ceqOperatorDescription" xml:space="preserve">
-    <value>Equal to - case sensitive. When the left operand is a collection, returns values from the collection that equal the right operand, otherwise returns TRUE if the left operand equals the right operand.</value>
+    <value>等於 - 區分大小寫。當左運算元是集合時，傳回該集合中等於右運算元的值，否則，如果左運算元等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="neOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>不等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中不等於右運算元的值，否則，如果左運算元不等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ineOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case insensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>不等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中不等於右運算元的值，否則，如果左運算元不等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cneOperatorDescription" xml:space="preserve">
-    <value>Not equal to - case sensitive. When the left operand is a collection, returns values from the collection that do not equal the right operand, otherwise returns TRUE if the left operand does not equal the right operand.</value>
+    <value>不等於 - 區分大小寫。當左運算元是集合時，傳回該集合中不等於右運算元的值，否則，如果左運算元不等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="geOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>大於或等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中大於或等於右運算元的值，否則，如果左運算元大於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="igeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>大於或等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中大於或等於右運算元的值，否則，如果左運算元大於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cgeOperatorDescription" xml:space="preserve">
-    <value>Greater than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are greater than or equal to the right operand, otherwise returns TRUE if the left operand is greater than or equal to the right operand.</value>
+    <value>大於或等於 - 區分大小寫。當左運算元是集合時，傳回該集合中大於或等於右運算元的值，否則，如果左運算元大於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="gtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>大於 - 不區分大小寫。當左運算元是集合時，傳回該集合中大於右運算元的值，否則，如果左運算元大於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="igtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case insensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>大於 - 不區分大小寫。當左運算元是集合時，傳回該集合中大於右運算元的值，否則，如果左運算元大於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cgtOperatorDescription" xml:space="preserve">
-    <value>Greater than - case sensitive. When the left operand is a collection, returns values from the collection that are greater than the right operand, otherwise returns TRUE if the left operand is greater than the right operand.</value>
+    <value>大於 - 區分大小寫。當左運算元是集合時，傳回該集合中大於右運算元的值，否則，如果左運算元大於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>小於 - 不區分大小寫。當左運算元是集合時，傳回該集合中小於右運算元的值，否則，如果左運算元小於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="iltOperatorDescription" xml:space="preserve">
-    <value>Less than - case insensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>小於 - 不區分大小寫。當左運算元是集合時，傳回該集合中小於右運算元的值，否則，如果左運算元小於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cltOperatorDescription" xml:space="preserve">
-    <value>Less than - case sensitive. When the left operand is a collection, returns values from the collection that are less than the right operand, otherwise returns TRUE if the left operand is less than the right operand.</value>
+    <value>小於 - 區分大小寫。當左運算元是集合時，傳回該集合中小於右運算元的值，否則，如果左運算元小於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="leOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>小於或等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中小於或等於右運算元的值，否則，如果左運算元小於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ileOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case insensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>小於或等於 - 不區分大小寫。當左運算元是集合時，傳回該集合中小於或等於右運算元的值，否則，如果左運算元小於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cleOperatorDescription" xml:space="preserve">
-    <value>Less than or equal to - case sensitive. When the left operand is a collection, returns values from the collection that are less than or equal to the right operand, otherwise returns TRUE if the left operand is less than or equal to the right operand.</value>
+    <value>小於或等於 - 區分大小寫。當左運算元是集合時，傳回該集合中小於或等於右運算元的值，否則，如果左運算元小於或等於右運算元，則傳回 TRUE。</value>
   </data>
   <data name="likeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>萬用字元比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="ilikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>萬用字元比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="clikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>萬用字元比對運算子 - 區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="notlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>萬用字元比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="inotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>萬用字元比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="cnotlikeOperatorDescription" xml:space="preserve">
-    <value>Wildcard matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>萬用字元比對運算子 - 區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="matchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>規則運算式比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="imatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>規則運算式比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="cmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that match the right hand operand, otherwise returns TRUE if the left operand matches the right operand.</value>
+    <value>規則運算式比對運算子 - 區分大小寫。當左運算元是集合時，傳回該集合中符合右運算元的值，否則，如果左運算元符合右運算元，則傳回 TRUE。</value>
   </data>
   <data name="notmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>規則運算式比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="inotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case insensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>規則運算式比對運算子 - 不區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="cnotmatchOperatorDescription" xml:space="preserve">
-    <value>Regular expression matching operator - case sensitive. When the left operand is a collection, returns values from the collection that do not match the right hand operand, otherwise returns TRUE if the left operand does not match the right operand.</value>
+    <value>規則運算式比對運算子 - 區分大小寫。當左運算元是集合時，傳回該集合中與右運算元不相符的值，否則，如果左運算元與右運算元不相符，則傳回 TRUE。</value>
   </data>
   <data name="replaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>取代運算子 - 不區分大小寫。變更左運算元。範例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="ireplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case insensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>取代運算子 - 不區分大小寫。變更左運算元。範例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="creplaceOperatorDescription" xml:space="preserve">
-    <value>Replace operator - case sensitive. Changes the left operand. Example: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
+    <value>取代運算子 - 區分大小寫。變更左運算元。範例: (dir *.ps1).FullName -replace '.ps1$','.ps1.bak'</value>
   </data>
   <data name="containsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (右運算元) 至少與右運算元中的其中一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="icontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (右運算元) 至少與右運算元中的其中一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="ccontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE only when the test value (right operand) exactly matches at least one of the values in the left operand.</value>
+    <value>內含項目運算子 - 區分大小寫。只有當測試值 (右運算元) 至少與左運算元中的其中一個值完全相符時，才傳回 TRUE。</value>
   </data>
   <data name="notcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (右運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="inotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (右運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="cnotcontainsOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (right operand) exactly matches none of the values in the left operand.</value>
+    <value>內含項目運算子 - 區分大小寫。當測試值 (右運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="inOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (左運算元) 至少與右運算元中的其中一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="iinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (左運算元) 至少與右運算元中的其中一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="cinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches at least one of the values in the right operand.</value>
+    <value>內含項目運算子 - 區分大小寫。當測試值 (左運算元) 至少與右運算元中的其中一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="notinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>內含項目運算子 - 區分大小寫。當測試值 (左運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="inotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case insensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>內含項目運算子 - 不區分大小寫。當測試值 (左運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="cnotinOperatorDescription" xml:space="preserve">
-    <value>Containment operator - case sensitive. Returns TRUE when the test value (left operand) exactly matches none of the values in the right operand.</value>
+    <value>內含項目運算子 - 區分大小寫。當測試值 (左運算元) 並未與右運算元中的任何一個值完全相符時，傳回 TRUE。</value>
   </data>
   <data name="splitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>分割 - 不區分大小寫。將一或多個字串分割成子字串。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -273,7 +273,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isplitOperatorDescription" xml:space="preserve">
-    <value>Split - case insensitive. Split one or more strings into substrings.
+    <value>分割 - 不區分大小寫。將一或多個字串分割成子字串。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -281,7 +281,7 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="csplitOperatorDescription" xml:space="preserve">
-    <value>Split - case sensitive. Split one or more strings into substrings.
+    <value>分割 - 區分大小寫。將一或多個字串分割成子字串。
 -Split &lt;String&gt;
 
 &lt;String&gt; -Split &lt;Delimiter&gt;[,&lt;Max-substrings&gt;[,"&lt;Options&gt;"]]
@@ -289,103 +289,103 @@
 &lt;String&gt; -Split {&lt;ScriptBlock&gt;} [,&lt;Max-substrings&gt;]</value>
   </data>
   <data name="isnotOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is not an instance of the specified .NET Framework type (right operand).</value>
+    <value>當左運算元不是指定 .NET Framework 類型 (右運算元) 的執行個體時，傳回 TRUE。</value>
   </data>
   <data name="isOperatorDescription" xml:space="preserve">
-    <value>Returns TRUE when the left operand is an instance of the specified .NET Framework type (right operand).</value>
+    <value>當左運算元是指定 .NET Framework 類型 (右運算元) 的執行個體時，傳回 TRUE。</value>
   </data>
   <data name="asOperatorDescription" xml:space="preserve">
-    <value>Converts the left operand to the specified .NET Framework type (right operand).</value>
+    <value>將左運算元轉換成指定的 .NET Framework 類型 (右運算元)。</value>
   </data>
   <data name="fOperatorDescription" xml:space="preserve">
-    <value>Formats strings by using the format method of string objects.</value>
+    <value>使用字串物件的格式方法來設定字串格式。</value>
   </data>
   <data name="andOperatorDescription" xml:space="preserve">
-    <value>Logical and. Returns TRUE when both statements are TRUE.</value>
+    <value>邏輯 AND。當兩個陳述式皆為 TRUE 時，傳回 TRUE。</value>
   </data>
   <data name="bandOperatorDescription" xml:space="preserve">
-    <value>Bitwise AND</value>
+    <value>位元 AND</value>
   </data>
   <data name="orOperatorDescription" xml:space="preserve">
-    <value>Logical or. TRUE when either or both statements are TRUE.</value>
+    <value>邏輯 OR。當其中一個或兩個陳述式皆為 TRUE 時，傳回 TRUE。</value>
   </data>
   <data name="borOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (inclusive)</value>
+    <value>位元 OR (包含)</value>
   </data>
   <data name="xorOperatorDescription" xml:space="preserve">
-    <value>Logical exclusive or. Returns TRUE when one of the statements is TRUE and the other is FALSE.</value>
+    <value>邏輯互斥 OR。當其中一個陳述式為 TRUE 而另一個陳述式為 FALSE 時，傳回 TRUE。</value>
   </data>
   <data name="bxorOperatorDescription" xml:space="preserve">
-    <value>Bitwise OR (exclusive)</value>
+    <value>位元 OR (排除)</value>
   </data>
   <data name="joinOperatorDescription" xml:space="preserve">
-    <value>Join - combine multiple strings into a single string.
+    <value>聯結 - 將多個字串結合成單一字串。
 -Join &lt;String[]&gt;
 &lt;String[]&gt; -Join &lt;Delimiter&gt;</value>
   </data>
   <data name="shlOperatorDescription" xml:space="preserve">
-    <value>Shift Left bit operator. Inserts zero in right-most bit position.</value>
+    <value>Shift Left 位元運算子。在最右邊的位元位置插入零。</value>
   </data>
   <data name="shrOperatorDescription" xml:space="preserve">
-    <value>Shift Right bit operator. Inserts zero in the left-most bit position. For signed values, sign bit is preserved.</value>
+    <value>Shift Right 位元運算子。在最左邊的位元位置插入零。對於帶正負號的值，會保留正負號位元。</value>
   </data>
   <data name="NameHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+指定正在建立的屬性名稱。</value>
   </data>
   <data name="LabelHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies the name of the property being created.</value>
+指定正在建立的屬性名稱。</value>
   </data>
   <data name="ExpressionHashtableKeyDescription" xml:space="preserve">
     <value>[scriptblock]
-A script block used to calculate the value of the new property.</value>
+用來計算新屬性值的指令碼區塊。</value>
   </data>
   <data name="AlignmentHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Define how the values are displayed in a column.
-Valid values are 'left', 'center', or 'right'.</value>
+定義值在資料行中的顯示方式。
+有效值為 'left'、'center' 或 'right'。</value>
   </data>
   <data name="FormatStringHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Specifies a format string that defines how the value is formatted for output.</value>
+指定格式字串，其定義輸出值的格式設定方式。</value>
   </data>
   <data name="WidthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-Specifies the maximum column width in a table when the value is displayed.
-The value must be greater than 0.</value>
+指定顯示值時，資料表中的最大資料行寬度。
+值必須大於 0。</value>
   </data>
   <data name="DepthHashtableKeyDescription" xml:space="preserve">
     <value>[int]
-The depth key specifies the depth of expansion per property.</value>
+深度索引鍵，指定每個屬性的展開深度。</value>
   </data>
   <data name="AscendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+指定一或多個屬性的排序順序。</value>
   </data>
   <data name="DescendingHashtableKeyDescription" xml:space="preserve">
     <value>[bool]
-Specifies the order of sorting for one or more properties.</value>
+指定一或多個屬性的排序順序。</value>
   </data>
   <data name="LogNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the log names to get events from.
-Supports wildcards.</value>
+指定要從中取得事件的記錄名稱。
+支援萬用字元。</value>
   </data>
   <data name="ProviderNameHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies the event log providers to get events from.
-Supports wildcards.</value>
+指定要從中取得事件的事件記錄檔提供者。
+支援萬用字元。</value>
   </data>
   <data name="PathHashtableKeyDescription" xml:space="preserve">
     <value>[String[]]
-Specifies file paths to log files to get events from.
-Valid file formats are: .etl, .evt, and .evtx</value>
+指定要從中取得事件的記錄檔案路徑。
+有效的檔案格式為: .etl、.evt 和 .evtx</value>
   </data>
   <data name="KeywordsHashtableKeyDescription" xml:space="preserve">
     <value>[Long[]]
-Selects events with the specified keyword bitmasks.
-The following are standard keywords:
+選取具有指定關鍵字位元遮罩的事件。
+以下是標準關鍵字:
 4503599627370496: AuditFailure
 9007199254740992: AuditSuccess
 4503599627370496: CorrelationHint
@@ -398,193 +398,193 @@ The following are standard keywords:
   </data>
   <data name="IDHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified event IDs.</value>
+選取具有指定記錄識別碼的事件。</value>
   </data>
   <data name="LevelHashtableKeyDescription" xml:space="preserve">
     <value>[int[]]
-Selects events with the specified log levels.
-The following log levels are valid:
-1: Critical
-2: Error
-3: Warning
-4: Informational
-5: Verbose</value>
+選取具有指定記錄層級的事件。
+下列記錄層級有效：
+1: 危急
+2: 錯誤
+3: 警告
+4: 資訊性
+5: 詳細資訊</value>
   </data>
   <data name="StartTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created after the specified date and time.</value>
+選取在指定日期和時間之後建立的事件。</value>
   </data>
   <data name="EndTimeHashtableKeyDescription" xml:space="preserve">
     <value>[datetime]
-Selects events created before the specified date and time.</value>
+選取在指定日期和時間之前建立的事件。</value>
   </data>
   <data name="UserIDHashtableKeyDescription" xml:space="preserve">
     <value>[string]
-Selects events generated by the specified user.
-This can either be a string representation of a SID or a domain and username in the format DOMAIN\USERNAME or USERNAME@DOMAIN</value>
+選取指定使用者產生的事件。
+這可以是 SID 的字串表示法，或是使用 DOMAIN\USERNAME 或 USERNAME@DOMAIN 格式的網域和使用者名稱</value>
   </data>
   <data name="DataHashtableKeyDescription" xml:space="preserve">
     <value>[string[]]
-Selects events with any of the specified values in the EventData section.</value>
+選取 EventData 區段中具有任何指定值的事件。</value>
   </data>
   <data name="SuppressHashFilterHashtableKeyDescription" xml:space="preserve">
     <value>[hashtable]
-Excludes events that match the values specified in the hashtable.</value>
+排除符合雜湊表中指定值的事件。</value>
   </data>
   <data name="RequiresModulesParameterDescription" xml:space="preserve">
-    <value>[string] or [hashtable]
-Specifies an array of PowerShell modules that the script requires.
-Each element can either be a string with the module name as value or a hashtable with the following keys:
-Name: Name of the module
-GUID: GUID of the module
-One of the following:
-ModuleVersion: Specifies a minimum acceptable version of the module.
-RequiredVersion: Specifies an exact, required version of the module.
-MaximumVersion: Specifies the maximum acceptable version of the module.</value>
+    <value>[string] 或 [hashtable]
+指定指令碼所需的 PowerShell 模組陣列。
+每個元素都可以是以模組名稱為值的字串，或具有下列索引鍵的雜湊表:
+Name: 模組的名稱
+GUID: 模組的 GUID
+下列其中一項:
+ModuleVersion: 指定模組的最小可接受版本。
+ModuleVersion: 指定模組所需的確切版本。
+MaximumVersion: 指定模組的最大可接受版本。</value>
   </data>
   <data name="RequiresPSEditionParameterDescription" xml:space="preserve">
     <value>[string]
-Specifies a PowerShell edition that the script requires.
-Valid values are "Core" and "Desktop"</value>
+指定指令碼所需的 PowerShell 版本。
+有效值為 "Core" 和 "Desktop"</value>
   </data>
   <data name="RequiresRunAsAdministratorParameterDescription" xml:space="preserve">
     <value>[switch]
-Specifies that PowerShell must be running as administrator on Windows.
-This must be the last parameter on the #requires statement line.</value>
+指定 PowerShell 必須在 Windows 上以系統管理員身分執行。
+這必須是 #requires 陳述式行的最後一個參數。</value>
   </data>
   <data name="RequiresVersionParameterDescription" xml:space="preserve">
     <value>[version]
-Specifies the minimum version of PowerShell that the script requires.</value>
+指定指令碼所需的最低 PowerShell 版本。</value>
   </data>
   <data name="RequiresPsEditionCoreDescription" xml:space="preserve">
-    <value>Specifies that the script requires PowerShell 7+ to run.</value>
+    <value>指定指令碼需要 PowerShell 7+ 才能執行。</value>
   </data>
   <data name="RequiresPsEditionDesktopDescription" xml:space="preserve">
-    <value>Specifies that the script requires Windows PowerShell 5.1 to run.</value>
+    <value>指定指令碼需要 Windows PowerShell 5.1 才能執行。</value>
   </data>
   <data name="RequiresModuleSpecModuleNameDescription" xml:space="preserve">
     <value>[string]
-Required. Specifies the module name.</value>
+必要項目。指定模組名稱。</value>
   </data>
   <data name="RequiresModuleSpecGUIDDescription" xml:space="preserve">
     <value>[string]
-Optional. Specifies the GUID of the module.</value>
+選用。指定模組的 GUID。</value>
   </data>
   <data name="RequiresModuleSpecModuleVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies a minimum acceptable version of the module.</value>
+指定模組的最小可接受版本。</value>
   </data>
   <data name="RequiresModuleSpecRequiredVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies an exact, required version of the module.</value>
+指定模組所需的確切版本。</value>
   </data>
   <data name="RequiresModuleSpecMaximumVersionDescription" xml:space="preserve">
     <value>[string]
-Specifies the maximum acceptable version of the module.</value>
+指定模組的最大可接受版本。</value>
   </data>
   <data name="CommentHelpSYNOPSISKeywordDescription" xml:space="preserve">
-    <value>A brief description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>函式或指令碼的簡短描述。
+此關鍵字在每個主題中只能使用一次。</value>
   </data>
   <data name="CommentHelpDESCRIPTIONKeywordDescription" xml:space="preserve">
-    <value>A detailed description of the function or script.
-This keyword can be used only once in each topic.</value>
+    <value>函式或指令碼的詳細描述。
+此關鍵字在每個主題中只能使用一次。</value>
   </data>
   <data name="CommentHelpPARAMETERKeywordDescription" xml:space="preserve">
     <value>.PARAMETER  &lt;Parameter-Name&gt;
-The description of a parameter.
-Add a .PARAMETER keyword for each parameter in the function or script syntax.</value>
+參數的描述。
+針對函式或指令碼語法中的每個參數新增 .PARAMETER 關鍵字。</value>
   </data>
   <data name="CommentHelpEXAMPLEKeywordDescription" xml:space="preserve">
-    <value>A sample command that uses the function or script, optionally followed by sample output and a description.
-Repeat this keyword for each example.</value>
+    <value>使用函式或指令碼的範例命令，後面可選擇性地接著範例輸出和描述。
+針對每個範例重複此關鍵字。</value>
   </data>
   <data name="CommentHelpINPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET types of objects that can be piped to the function or script.
-You can also include a description of the input objects.</value>
+    <value>可透過管道傳送到函式或指令碼的 .NET 物件類型。
+您也可以包含輸入物件的描述。</value>
   </data>
   <data name="CommentHelpOUTPUTSKeywordDescription" xml:space="preserve">
-    <value>The .NET type of the objects that the cmdlet returns.
-You can also include a description of the returned objects.</value>
+    <value>Cmdlet 傳回之物件的 .NET 類型。
+您也可以包含傳回物件的描述。</value>
   </data>
   <data name="CommentHelpNOTESKeywordDescription" xml:space="preserve">
-    <value>Additional information about the function or script.</value>
+    <value>函式或指令碼的其他資訊。</value>
   </data>
   <data name="CommentHelpLINKKeywordDescription" xml:space="preserve">
-    <value>The name of a related topic.
-Repeat the .LINK keyword for each related topic.
-The .Link keyword content can also include a URI to an online version of the same help topic.</value>
+    <value>相關主題的名稱。
+針對每個相關主題，重複使用 .LINK 關鍵字。
+.Link 關鍵字內容也可以包含相同說明主題線上版本的 URI。</value>
   </data>
   <data name="CommentHelpCOMPONENTKeywordDescription" xml:space="preserve">
-    <value>The name of the technology or feature that the function or script uses, or to which it is related.</value>
+    <value>函式或指令碼所使用或相關的技術或功能名稱。</value>
   </data>
   <data name="CommentHelpROLEKeywordDescription" xml:space="preserve">
-    <value>The name of the user role for the help topic.</value>
+    <value>說明主題的使用者角色名稱。</value>
   </data>
   <data name="CommentHelpFUNCTIONALITYKeywordDescription" xml:space="preserve">
-    <value>The keywords that describe the intended use of the function.</value>
+    <value>描述函式預期用途的關鍵字。</value>
   </data>
   <data name="CommentHelpFORWARDHELPTARGETNAMEKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPTARGETNAME &lt;Command-Name&gt;
-Redirects to the help topic for the specified command.</value>
+重新導向至指定命令的說明主題。</value>
   </data>
   <data name="CommentHelpFORWARDHELPCATEGORYKeywordDescription" xml:space="preserve">
     <value>.FORWARDHELPCATEGORY &lt;Category&gt;
-Specifies the help category of the item in .ForwardHelpTargetName</value>
+指定 .ForwardHelpTargetName 中項目的說明類別</value>
   </data>
   <data name="CommentHelpREMOTEHELPRUNSPACEKeywordDescription" xml:space="preserve">
     <value>.REMOTEHELPRUNSPACE &lt;PSSession-variable&gt;
-Specifies a session that contains the help topic.
-Enter a variable that contains a PSSession object.</value>
+指定包含說明主題的工作階段。
+輸入包含 PSSession 物件的變數。</value>
   </data>
   <data name="CommentHelpEXTERNALHELPKeywordDescription" xml:space="preserve">
     <value>.EXTERNALHELP &lt;XML Help File&gt;
-The .ExternalHelp keyword is required when a function or script is documented in XML files.</value>
+當函式或指令碼的文件為 XML 檔案中時，需要 .ExternalHelp 關鍵字。</value>
   </data>
   <data name="AssemblyKeywordDescription" xml:space="preserve">
-    <value>Specifies the path to a .NET assembly to load.
+    <value>指定要載入之 .NET 組件的路徑。
 
-using assembly &lt;.NET-assembly-path&gt;</value>
+使用組件 &lt;.NET-assembly-path&gt;</value>
   </data>
   <data name="ModuleKeywordDescription" xml:space="preserve">
-    <value>Specifies a PowerShell module to load classes from.
+    <value>指定要從中載入類別的 PowerShell 模組。
 
-using module &lt;ModuleName or Path&gt;
+使用模組 &lt;ModuleName 或 Path&gt;
 
-using module &lt;ModuleSpecification hashtable&gt;</value>
+使用模組 &lt;ModuleSpecification hashtable&gt;</value>
   </data>
   <data name="NamespaceKeywordDescription" xml:space="preserve">
-    <value>Specifies a .NET namespace to resolve types from or a namespace alias.
+    <value>指定要解析類型的 .NET 命名空間或命名空間別名。
 
-using namespace &lt;.NET-namespace&gt;
+使用命名空間 &lt;.NET-namespace&gt;
 
-using namespace &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
+使用命名空間 &lt;AliasName&gt; = &lt;.NET-namespace&gt;</value>
   </data>
   <data name="TypeKeywordDescription" xml:space="preserve">
-    <value>Specifies an alias for a .NET Type.
+    <value>指定 .NET 類型的別名。
 
-using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
+使用類型 &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
   </data>
   <data name="RegistryStringToolTip" xml:space="preserve">
-    <value>A normal string.</value>
+    <value>一般字串。</value>
   </data>
   <data name="RegistryExpandStringToolTip" xml:space="preserve">
-    <value>A string that contains unexpanded references to environment variables that are expanded when the value is retrieved.</value>
+    <value>包含環境變數的未展開參照的字串，且只有在擷取值時才會展開。</value>
   </data>
   <data name="RegistryBinaryToolTip" xml:space="preserve">
-    <value>Binary data in any form.</value>
+    <value>任何形式的二進位資料。</value>
   </data>
   <data name="RegistryDWordToolTip" xml:space="preserve">
-    <value>A 32-bit binary number.</value>
+    <value>32 位元二進位數字。</value>
   </data>
   <data name="RegistryMultiStringToolTip" xml:space="preserve">
-    <value>An array of strings.</value>
+    <value>字串的陣列。</value>
   </data>
   <data name="RegistryQWordToolTip" xml:space="preserve">
-    <value>A 64-bit binary number.</value>
+    <value>64 位元二進位數字。</value>
   </data>
   <data name="RegistryUnknownToolTip" xml:space="preserve">
-    <value>An unsupported registry data type.</value>
+    <value>不支援的登錄資料類型。</value>
   </data>
   <data name="SeparatorCommaToolTip" xml:space="preserve">
     <value>',' - Comma</value>
@@ -599,7 +599,7 @@ using type &lt;AliasName&gt; = &lt;.NET-type&gt;</value>
     <value>'; ' - Semi-Colon-Space</value>
   </data>
   <data name="SeparatorNewlineToolTip" xml:space="preserve">
-    <value>{0} - Newline</value>
+    <value>{0} - 新行</value>
   </data>
   <data name="SeparatorDashToolTip" xml:space="preserve">
     <value>'-' - Dash</value>


### PR DESCRIPTION
Backport of #27821 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27821$$$
-->

Triggered by @SeeminglyScience on behalf of @olprod

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Checks in localized resource files generated by the downstream localization pipeline (OneLocBuild), keeping the release branch's localized resources current.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Automated localization check-in; cherry-picked cleanly with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Automated localized resource file check-in from the OneLocBuild pipeline. No code behavior changes, only translated resource content.
