### PR TITLE
[release/v7.6.6] Fix `FileOnlyEntry` crashing on older versions of Windows

### DIFF
--- a/src/System.Management.Automation/security/wldpNativeMethods.cs
+++ b/src/System.Management.Automation/security/wldpNativeMethods.cs
@@ -97,35 +97,52 @@ namespace System.Management.Automation.Security
 
         private static bool TestBooleanWldpSetting(string settingName)
         {
-            int hr = WldpNativeMethods.WldpGetApplicationSettingBoolean(
-                AppManifestId,
-                settingName,
-                out bool result);
+            bool result = SafeWldpGetApplicationSettingBoolean(settingName);
 
-            PSEtwLog.LogWDACQueryEvent(
-                "WldpGetApplicationSettingBoolean",
-                settingName,
-                hr,
-                result ? 1 : 0);
-
-            if (hr is not 0)
+            if (result)
             {
-                result = false;
+                return true;
             }
 
-            if (!result)
-            {
-                string debugValue = Environment.GetEnvironmentVariable(
-                    $"__PSLockdownPolicy_{settingName}",
-                    EnvironmentVariableTarget.Machine);
+            string debugValue = Environment.GetEnvironmentVariable(
+                $"__PSLockdownPolicy_{settingName}",
+                EnvironmentVariableTarget.Machine);
 
-                if (debugValue is "1")
-                {
-                    result = true;
-                }
+            if (debugValue is "1")
+            {
+                result = true;
             }
 
             return result;
+        }
+
+        private static bool SafeWldpGetApplicationSettingBoolean(string settingName)
+        {
+            try
+            {
+                int hr = WldpNativeMethods.WldpGetApplicationSettingBoolean(
+                    AppManifestId,
+                    settingName,
+                    out bool result);
+
+                PSEtwLog.LogWDACQueryEvent(
+                    "WldpGetApplicationSettingBoolean",
+                    settingName,
+                    hr,
+                    result ? 1 : 0);
+
+                return hr is 0 && result;
+            }
+            catch (Exception ex) when (ex is DllNotFoundException or EntryPointNotFoundException)
+            {
+                PSEtwLog.LogWDACQueryEvent(
+                    "WldpGetApplicationSettingBoolean_Failed",
+                    settingName,
+                    ex.HResult,
+                    0);
+
+                return false;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Backport of #27880 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27880$$$
-->

Triggered by @SeeminglyScience on behalf of @SeeminglyScience

Original CL Label: CL-Engine

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [ ] Required tooling change
- [ ] Optional tooling change (include reasoning)

### Customer Impact

- [ ] Customer reported
- [x] Found internally

Fixes a crash when the new EnableFileOnlyEntry WLDP setting check runs on older Windows versions that lack the corresponding API; EntryPointNotFoundException is now caught and treated as a false result instead of crashing.

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Introduced by #26752 (backported as #27922), which added the FileOnlyEntry WLDP setting check without accounting for older Windows versions missing the API.

## Testing

Cherry-picked cleanly with no conflicts, now that the prerequisite PR #26752 (backport #27922) is present in the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Fixes a crash on older Windows versions caused by the FileOnlyEntry WLDP check backported in #27922; catches EntryPointNotFoundException and treats it as a false result. Fix is narrowly scoped to the new opt-in setting's code path.
