### PR TITLE
[release/v7.6.6] Remove the `<assembly>` element for from `CmdletizationCoreResources.resx`

### DIFF
--- a/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
+++ b/src/System.Management.Automation/resources/CmdletizationCoreResources.resx
@@ -121,7 +121,6 @@
     <value>Cmdlets over '{0}' class</value>
     <comment>{0} is a placeholder for a name of a CIM class.  Example: "ROOT\cimv2\Win32_Process"</comment>
   </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ScriptWriter_DuplicateQueryParameterName" xml:space="preserve">
     <value>Two cmdlet parameters defined within the {0} element have the same name: {1}.  Resolve the conflict in the Cmdlet Definition XML and retry.</value>
     <comment>{0} is a placeholder for a name of an XML element.  Example: &lt;GetCmdletParameters&gt;


### PR DESCRIPTION
Backport of #27900 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27900$$$
-->

Triggered by @SeeminglyScience on behalf of @daxian-dbw

Original CL Label: CL-General

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Removes a leftover `<assembly>` element in CmdletizationCoreResources.resx missed by the earlier #27869 cleanup, required for correct localization/resource validation.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly with no conflicts, since the prerequisite change from #27869 was already present in the release branch.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Removes a leftover unused `<assembly>` element from a resx file, a follow-up cleanup to already-present code in the release branch; no runtime behavior change.
