### PR TITLE
[release/v7.6.6] Update `AppxManifest.xml` to only declare `en-US` for the `<Resources>` element

### DIFF
--- a/assets/AppxManifest.xml
+++ b/assets/AppxManifest.xml
@@ -25,19 +25,6 @@
 
   <Resources>
     <Resource Language="en-US"/>
-    <Resource Language="cs"/>
-    <Resource Language="de"/>
-    <Resource Language="es"/>
-    <Resource Language="fr"/>
-    <Resource Language="it"/>
-    <Resource Language="ja"/>
-    <Resource Language="ko"/>
-    <Resource Language="pl"/>
-    <Resource Language="pt-BR"/>
-    <Resource Language="ru"/>
-    <Resource Language="tr"/>
-    <Resource Language="zh-Hans"/>
-    <Resource Language="zh-Hant"/>
   </Resources>
 
   <Applications>

--- a/build.psm1
+++ b/build.psm1
@@ -8,7 +8,6 @@ param(
 
 . "$PSScriptRoot\tools\buildCommon\startNativeExecution.ps1"
 
-# CI runs with PowerShell 5.0, so don't use features like ?: && ||
 Set-StrictMode -Version 3.0
 
 # On Unix paths is separated by colon.


### PR DESCRIPTION
Backport of #27939 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27751$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Update `AppxManifest.xml` to only declare `en-US` for the `<Resources>` element. We cannot add the other languages until the MS Store related texts are localized.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly with no conflicts. Original PR added tests validating LocProject.json content stays in sync with actual resource files in the repo.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

