### PR TITLE
[release/v7.6.6] Produce satellite assemblies in Windows release build and properly remove them when they are not required

### DIFF
--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -15,6 +15,9 @@ jobs:
     value: none
   - name: DOTNET_NOLOGO
     value: 1
+  # Allow .NET SDK to access cultural data on Windows build.
+  - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+    value: 0
   - group: DotNetPrivateBuildAccess
   - group: certificate_logical_to_actual
   - name: ob_outputDirectory

--- a/build.psm1
+++ b/build.psm1
@@ -565,9 +565,11 @@ Fix steps:
     # as well as .zip packages, we only support the default en-US culture.
     # Therefore, we only produce satellite assemblies for win7-x64, win7-x86, and win-arm64 by default (excluding min-size build),
     # unless the caller wants to force produce localized resources.
+    $RemovePowerShellSatelliteAssemblies = $false
     if (!$ForceProduceLocalizedResources -and ($Options.Runtime -notmatch '^(win7-x64|win7-x86|win-arm64)$' -or $ForMinimalSize)) {
-        # Disable satellite assemblies for other cultures.
+        # Disable satellite assemblies from package/runtime assets for other cultures.
         $Arguments += "/property:SatelliteResourceLanguages=en"
+        $RemovePowerShellSatelliteAssemblies = $true
     }
 
     if ($Output -or $SMAOnly) {
@@ -743,6 +745,21 @@ Fix steps:
     } finally {
         Pop-Location
     }
+
+    if ($RemovePowerShellSatelliteAssemblies) {
+        $smaResDll = 'System.Management.Automation.resources.dll'
+        $resDirs = Get-ChildItem -Path $publishPath -Filter $smaResDll -Recurse -Depth 1 | ForEach-Object DirectoryName
+
+        if ($resDirs) {
+            Write-Log -message "PowerShell satellite assemblies found under '$publishPath':"
+            $relatives = $resDirs | ForEach-Object { Resolve-Path $_ -Relative -RelativeBasePath $publishPath }
+            Write-Log -message ($relatives -join ", ")
+
+            $resDirs | Remove-Item -Recurse -Force -ErrorAction Stop
+            Write-Log -message "Removed PowerShell satellite assemblies under '$publishPath'."
+        }
+    }
+
     Write-LogGroupEnd -Title "Build PowerShell"
 
     # No extra post-building task will run if '-SMAOnly' is specified, because its purpose is for a quick update of S.M.A.dll after full build.


### PR DESCRIPTION
Backport of #27938 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27751$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

1. Setting `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT` to `0` in Windows builds allow .NET SDK to produce satellite assemblies for PowerShell.
2. Also updated the `build.psm1` to remove PowerShell satellite assemblies properly when they are not required.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Cherry-picked cleanly with no conflicts. Original PR added tests validating LocProject.json content stays in sync with actual resource files in the repo.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

