### PR TITLE
Fix the localization tests for Release Automation

### DIFF
--- a/test/powershell/engine/ResourceValidation/LocProject.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/LocProject.Tests.ps1
@@ -1,16 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe "Localized resource files validation" -Tags "CI" {
+Describe "LocProject.json file validation" -Tags "CI" {
     BeforeAll {
-        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ../../../..)).Path
+        ## The 'LocProject.json' tests depend on running from a local PowerShell repo.
+        $skipTests = $env:PIPELINE_REPOSITORY_NAME -eq 'Release-Automation'
+        if ($skipTests) {
+            Write-Host "Skipping 'LocProject.json' tests in Release Automation." -ForegroundColor Yellow
+            return
+        }
 
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ../../../..)).Path
         $locProjectPath = Join-Path $repoRoot 'Localize' 'LocProject.json'
-        $content = Get-Content -Path $locProjectPath -Raw
-        $locProject = ConvertFrom-Json -InputObject $content
+        $content = Get-Content -Path $locProjectPath -Raw -ErrorAction Stop
+        $locProject = ConvertFrom-Json -InputObject $content -ErrorAction Stop
     }
 
-    It 'Validate LocItems in LocProject.json' {
+    It 'Validate LocItems in LocProject.json' -Skip:$skipTests {
         $locProject.Projects.Count | Should -Be 1
         $project = $locProject.Projects[0]
         $project.LanguageSet | Should -BeExactly 'VS_Main_Languages'
@@ -28,7 +34,7 @@ Describe "Localized resource files validation" -Tags "CI" {
             }
     }
 
-    It 'Validate total resource count' {
+    It 'Validate total resource count' -Skip:$skipTests {
         $srcDir = Join-Path $repoRoot 'src'
         $project = $locProject.Projects[0]
 

--- a/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
@@ -5,6 +5,12 @@ Describe "Localized resource files validation" -Tags "CI" {
 
     BeforeAll {
         $repoSrcDir = (Resolve-Path (Join-Path $PSScriptRoot ../../../../src)).Path
+        $skipSatelliteAssemblyTest = !$IsWindows
+        if (!$skipSatelliteAssemblyTest -and $env:PIPELINE_REPOSITORY_NAME -eq 'Release-Automation') {
+            ## Only MSIX packages include the localized satellite assemblies.
+            $isMSIXApp = Test-Path -Path (Join-Path $PSHOME 'AppxManifest.xml')
+            $skipSatelliteAssemblyTest = -not $isMSIXApp
+        }
 
         # Folders that exist in 'resources' folder but are not a localized resource directory.
         $excludeDirs = @('Graphics')
@@ -87,7 +93,7 @@ Describe "Localized resource files validation" -Tags "CI" {
         }
     }
 
-    It "Satellite assemblies should be produced for '<Language>'" -TestCases $testCases2 -Skip:(!$IsWindows) {
+    It "Satellite assemblies should be produced for '<Language>'" -TestCases $testCases2 -Skip:$skipSatelliteAssemblyTest {
         param($Language)
 
         $satDir = Join-Path $PSHOME $Language


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix the localization tests for Release Automation. 
- `LocProject.json` tests depend on the `LocProject.json` file is available, which is not the case for Release Automation. So, they should be skipped for Release Automation.
- Satellite assembly tests depend on the running PowerShell has those resource assemblies. Since we only ship resource assemblies in MSIX package, we should only enable them for test runs with MSIX installed PowerShell.