### PR TITLE
[release/v7.6.6] Fix the localization tests for Release Automation

### DIFF
--- a/test/powershell/engine/ResourceValidation/LocProject.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/LocProject.Tests.ps1
@@ -1,16 +1,22 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe "Localized resource files validation" -Tags "CI" {
+Describe "LocProject.json file validation" -Tags "CI" {
     BeforeAll {
-        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ../../../..)).Path
+        ## The 'LocProject.json' tests depend on running from a local PowerShell repo.
+        $skipTests = $env:PIPELINE_REPOSITORY_NAME -eq 'Release-Automation'
+        if ($skipTests) {
+            Write-Host "Skipping 'LocProject.json' tests in Release Automation." -ForegroundColor Yellow
+            return
+        }
 
+        $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot ../../../..)).Path
         $locProjectPath = Join-Path $repoRoot 'Localize' 'LocProject.json'
-        $content = Get-Content -Path $locProjectPath -Raw
-        $locProject = ConvertFrom-Json -InputObject $content
+        $content = Get-Content -Path $locProjectPath -Raw -ErrorAction Stop
+        $locProject = ConvertFrom-Json -InputObject $content -ErrorAction Stop
     }
 
-    It 'Validate LocItems in LocProject.json' {
+    It 'Validate LocItems in LocProject.json' -Skip:$skipTests {
         $locProject.Projects.Count | Should -Be 1
         $project = $locProject.Projects[0]
         $project.LanguageSet | Should -BeExactly 'VS_Main_Languages'
@@ -28,7 +34,7 @@ Describe "Localized resource files validation" -Tags "CI" {
             }
     }
 
-    It 'Validate total resource count' {
+    It 'Validate total resource count' -Skip:$skipTests {
         $srcDir = Join-Path $repoRoot 'src'
         $project = $locProject.Projects[0]
 

--- a/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
+++ b/test/powershell/engine/ResourceValidation/LocalizedResource.Tests.ps1
@@ -5,6 +5,12 @@ Describe "Localized resource files validation" -Tags "CI" {
 
     BeforeAll {
         $repoSrcDir = (Resolve-Path (Join-Path $PSScriptRoot ../../../../src)).Path
+        $skipSatelliteAssemblyTest = !$IsWindows
+        if (!$skipSatelliteAssemblyTest -and $env:PIPELINE_REPOSITORY_NAME -eq 'Release-Automation') {
+            ## Only MSIX packages include the localized satellite assemblies.
+            $isMSIXApp = Test-Path -Path (Join-Path $PSHOME 'AppxManifest.xml')
+            $skipSatelliteAssemblyTest = -not $isMSIXApp
+        }
 
         # Folders that exist in 'resources' folder but are not a localized resource directory.
         $excludeDirs = @('Graphics')
@@ -87,7 +93,7 @@ Describe "Localized resource files validation" -Tags "CI" {
         }
     }
 
-    It "Satellite assemblies should be produced for '<Language>'" -TestCases $testCases2 -Skip:(!$IsWindows) {
+    It "Satellite assemblies should be produced for '<Language>'" -TestCases $testCases2 -Skip:$skipSatelliteAssemblyTest {
         param($Language)
 
         $satDir = Join-Path $PSHOME $Language


### PR DESCRIPTION
Backport of #27944 to release/v7.6.6

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27944$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-Test

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Fixes LocProject.json and satellite-assembly Pester tests that fail in the Release Automation pipeline. LocProject.json tests now skip when running under Release Automation (file isn't available there), and satellite assembly tests now only run when the installed PowerShell is an MSIX package (which is the only package type that ships localized resource assemblies).

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Test-only change (Pester test files). Verified by running the updated tests both in a normal repo checkout (tests still execute/pass) and simulating the Release Automation environment variable (PIPELINE_REPOSITORY_NAME=Release-Automation) to confirm the tests are properly skipped.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Change is limited to test skip-logic in two Pester test files; no product/runtime code is touched. Narrow, well-scoped change with no customer-facing impact.
