### PR TITLE
[release/v7.5.11] Use Azure CLI for early-access feed token

### DIFF
--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -46,17 +46,19 @@ steps:
     NugetConfigDir: ${{ parameters.repoRoot }}/src/Modules
     ob_restore_phase: ${{ parameters.ob_restore_phase }}
 
-- task: AzurePowerShell@5
+- task: AzureCLI@2
   inputs:
     azureSubscription: powershell-net-early-access
-    azurePowerShellVersion: LatestVersion
-    ScriptType: InlineScript
-    pwsh: true
-    inline: |
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
       Write-Verbose -Verbose "Getting an Azure DevOps access token"
       # Microsoft's well-known Entra resource ID for the Azure DevOps token audience.
       $azureDevOpsResourceUrl = '499b84ac-1321-427f-aa17-267ca6975798'
-      $azt = (Get-AzAccessToken -ResourceUrl $azureDevOpsResourceUrl).Token | ConvertFrom-SecureString -AsPlainText
+      $azt = az account get-access-token --resource $azureDevOpsResourceUrl --query accessToken --output tsv
+      if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($azt)) {
+        throw "Failed to get an Azure DevOps access token."
+      }
 
       Write-Host "##vso[task.setsecret]$azt"
       Write-Verbose -Verbose "Setting up Azure Artifacts Credential Provider token"


### PR DESCRIPTION
Backport of #27849 to release/v7.5.11

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27849$$$
-->

Triggered by @adityapatwardhan on behalf of @jshigetomi

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Required pipeline fix for SDK validation: acquire the early-access Azure DevOps feed token with AzureCLI@2 so Linux agents do not depend on a preinstalled Az.Accounts module, and fail explicitly when token acquisition fails.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Original change was motivated by Linux SDK validation build 707180 failing before its inline script while equivalent Windows and macOS jobs succeeded. On release/v7.5.11, the merge commit cherry-picked without conflicts; the target-relative diff was reviewed to contain only the intended pipeline-template change, and git diff --check passed. End-to-end service-connection and token acquisition behavior requires backport PR CI.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because this changes the authenticated token-acquisition task used by SDK validation across platforms. The change is narrowly scoped to one pipeline template, preserves the existing service connection and token secret handling, adds explicit failure handling, and has already been merged and used on newer branches; PR CI remains required.
