### PR TITLE
[release/v7.5.11] Enable early .NET builds in APIScan

### DIFF
--- a/.pipelines/apiscan-gen-notice.yml
+++ b/.pipelines/apiscan-gen-notice.yml
@@ -4,6 +4,25 @@ name: apiscan-genNotice-$(BUILD.SOURCEBRANCHNAME)-$(Build.BuildId)
 trigger: none
 
 parameters:
+  - name: IsEarlyAccess
+    type: boolean
+    default: false
+  - name: EarlyAccessFeed
+    displayName: Early Access Feed
+    type: string
+    default: 'net10'
+    values:
+      - 'net8'
+      - 'net9'
+      - 'net10'
+  - name: DOTNET_RUNTIME_VERSION
+    displayName: Runtime version of early access build
+    type: string
+    default: ' '
+  - name: DOTNET_SDK_VERSION
+    displayName: SDK version of early access build
+    type: string
+    default: ' '
   - name: FORCE_CODEQL
     displayName: Debugging - Enable CodeQL and set cadence to 1 hour
     type: boolean
@@ -22,6 +41,12 @@ variables:
   # Defines the variables CgPat, CgOrganization, and CgProject
   - group: 'ComponentGovernance'
   - group: 'PoolNames'
+  - name: EARLY_ACCESS_FEED
+    value: ${{ parameters.EarlyAccessFeed }}
+  - name: IsEarlyAccess
+    value: ${{ parameters.IsEarlyAccess }}
+  - name: DOTNET_SDK_VERSION
+    value: ${{ parameters.DOTNET_SDK_VERSION }}
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/azurelinux/build:3.0
   - name: WindowsContainerImage
@@ -92,9 +117,32 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
+      - stage: prep
+        displayName: 'Prepare early access .NET'
+        dependsOn: []
+        jobs:
+          - ${{ if eq(parameters.IsEarlyAccess, true) }}:
+            - template: /.pipelines/templates/downloadDotnetEarlyAccess.yml@self
+              parameters:
+                DotnetRuntimeVersion: ${{ parameters.DOTNET_RUNTIME_VERSION }}
+                DotnetSdkVersion: ${{ parameters.DOTNET_SDK_VERSION }}
+          - ${{ else }}:
+            - job: skip_download_dotnet_early_access
+              displayName: 'Skip early access .NET download'
+              pool:
+                type: windows
+              variables:
+                - name: ob_outputDirectory
+                  value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
+                - name: ob_signing_setup_enabled
+                  value: false
+                - name: ob_sdl_codeSignValidation_enabled
+                  value: false
+              steps:
+                - pwsh: Write-Host 'IsEarlyAccess is false; skipping early access .NET download.'
       - stage: APIScan
         displayName: 'ApiScan'
-        dependsOn: []
+        dependsOn: [prep]
         jobs:
           - template: /.pipelines/templates/compliance/apiscan.yml@self
             parameters:

--- a/.pipelines/templates/compliance/apiscan.yml
+++ b/.pipelines/templates/compliance/apiscan.yml
@@ -54,12 +54,28 @@ jobs:
       parameters:
         repoRoot: '$(repoRoot)'
 
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core sdk'
-      inputs:
-        useGlobalJson: true
-        packageType: 'sdk'
-        workingDirectory: $(Build.SourcesDirectory)"
+    - template: ../install-dotnet.yml
+      parameters:
+        architecture: win-x64
+
+    - pwsh: |
+        $sdkVersion = $env:DOTNET_SDK_VERSION
+        if ([string]::IsNullOrWhiteSpace($sdkVersion)) {
+          throw 'DOTNET_SDK_VERSION must be specified for an early access build.'
+        }
+
+        $sdkVersion = $sdkVersion.Trim()
+        $globalJsonPath = Join-Path '$(repoRoot)' 'global.json'
+        $globalJson = Get-Content -Path $globalJsonPath -Raw | ConvertFrom-Json
+        $globalJson.sdk.version = $sdkVersion
+        $globalJson | ConvertTo-Json -Depth 10 | Set-Content -Path $globalJsonPath
+
+        Write-Verbose -Verbose "Updated global.json to use .NET SDK $sdkVersion."
+      displayName: Select early access .NET SDK
+      condition: eq(variables['ISEARLYACCESS'], 'true')
+      env:
+        DOTNET_SDK_VERSION: $(DOTNET_SDK_VERSION)
+        ob_restore_phase: true
 
     - pwsh: |
         Import-Module .\build.psm1 -force
@@ -70,12 +86,17 @@ jobs:
       displayName: Install dotnet-symbol
       workingDirectory: '$(repoRoot)'
       retryCountOnTaskFailure: 2
+      env:
+        ob_restore_phase: true
+        VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
     - task: CodeQL3000Init@0 # Add CodeQL Init task right before your 'Build' step.
       displayName: 🔏 CodeQL 3000 Init
       condition: eq(variables['CODEQL_ENABLED'], 'true')
       inputs:
         Language: csharp
+      env:
+        ob_restore_phase: true
 
     - pwsh: |
         Import-Module .\build.psm1 -force
@@ -98,6 +119,9 @@ jobs:
         Copy-Item -Path "$OutputFolder\*" -Destination $Destination -Recurse -Verbose
       workingDirectory: '$(repoRoot)'
       displayName: 'Build PowerShell Source'
+      env:
+        ob_restore_phase: true
+        VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
     - pwsh: |
         # Only keep windows runtimes
@@ -120,10 +144,14 @@ jobs:
         Write-Host
       workingDirectory: '$(repoRoot)'
       displayName: 'Remove unused runtimes'
+      env:
+        ob_restore_phase: true
 
     - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.
       displayName: 🔏 CodeQL 3000 Finalize
       condition: eq(variables['CODEQL_ENABLED'], 'true')
+      env:
+        ob_restore_phase: true
 
     - pwsh: |
         Get-ChildItem -Path env: | Out-String -width 9999 -Stream | write-Verbose -Verbose

--- a/.pipelines/templates/insert-nuget-config-azfeed.yml
+++ b/.pipelines/templates/insert-nuget-config-azfeed.yml
@@ -27,8 +27,8 @@ steps:
       }
       else
       {
-        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source EarlyAccess"
-        Switch-PSNugetConfig -Source EarlyAccess
+        Write-Verbose -Verbose "Running: Switch-PSNugetConfig -Source EarlyAccess (using Azure DevOps feed credentials from pipeline variables)"
+        Switch-PSNugetConfig -Source EarlyAccess -UserName '$(AzDevopsFeedUserNameKVPAT)' -ClearTextPAT '$(powershellPackageReadPat)'
       }
 
       if(-not (Test-Path $configPath))
@@ -70,7 +70,7 @@ steps:
             'net10' { 'https://pkgs.dev.azure.com/powershell-rel/PowerShell/_packaging/powershell-net-10-early-access/nuget/v3/index.json' }
             default { throw "Unknown early access feed URL: $earlyAccessFeed" }
         }
-      $galleryRepoUri = 'https://www.powershellgallery.com/api/v2'
+      $powerShellRepoUri = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json'
 
       Write-Verbose -Verbose "ADORepoUri == $ADORepoUri"
 
@@ -78,6 +78,11 @@ steps:
       {
         $endpointCredsObj = @{ endpointCredentials = @(
           @{ endpoint = $ADORepoUri; password = $azt }
+          @{
+            endpoint = $powerShellRepoUri
+            username = '$(AzDevopsFeedUserNameKVPAT)'
+            password = '$(powershellPackageReadPat)'
+          }
         )}
         $VSS_NUGET_EXTERNAL_FEED_ENDPOINTS = $endpointCredsObj | ConvertTo-Json -Compress
 

--- a/build.psm1
+++ b/build.psm1
@@ -931,10 +931,11 @@ function Switch-PSNugetConfig {
         Set-PipelineVariable -Name 'EARLY_ACCESS_FEED_URL' -Value $earlyAccessFeedUrl
 
         $earlyAccessFeed = [NugetPackageSource] @{Url = $earlyAccessFeedUrl; Name = 'earlyaccess' }
+        $powerShellPackages = [NugetPackageSource] @{Url = 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/PowerShell/nuget/v3/index.json'; Name = 'powershell' }
 
-        New-NugetConfigFile -NugetPackageSource $earlyAccessFeed -Destination "$PSScriptRoot/" @extraParams
-        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/src/Modules/" @extraParams
-        New-NugetConfigFile -NugetPackageSource $gallery -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $earlyAccessFeed -Destination "$PSScriptRoot/"
+        New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/src/Modules/" @extraParams
+        New-NugetConfigFile -NugetPackageSource $powerShellPackages -Destination "$PSScriptRoot/test/tools/Modules/" @extraParams
     } else {
         throw "Unknown source: $Source"
     }


### PR DESCRIPTION
Backport of #27952 to `release/v7.5.11`.

This enables early .NET SDK download, selection, authenticated feed setup, and restore-phase compilation for the APIScan pipeline.