### PR TITLE
[release/v7.4.20] Merged PR 41075: Map credential provider variable as it is a secret

### DIFF
--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -109,6 +109,7 @@ jobs:
     displayName: 'Build Linux - $(Runtime)'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -87,6 +87,7 @@ jobs:
     displayName: 'Build'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - template: /.pipelines/templates/step/finalize.yml@self
 

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -156,6 +156,7 @@ jobs:
     displayName: Build reference assemblies
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - task: onebranch.pipeline.signing@1
     displayName: Sign ref assemblies

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -143,6 +143,7 @@ jobs:
       displayName: Restore and execute tests
       env:
         __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+        VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
     - task: PublishTestResults@2
       displayName: 'Publish Test Results **\test-hosting.xml'

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -65,6 +65,7 @@ jobs:
     retryCountOnTaskFailure: 1
     env:
       ob_restore_phase: true
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - pwsh: |
       Write-Host "This doesn't do anything but make the build phase run."
@@ -132,6 +133,7 @@ jobs:
     retryCountOnTaskFailure: 1
     env:
       ob_restore_phase: true
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - pwsh: |
       Write-Host "This doesn't do anything but make the build phase run."

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -125,6 +125,7 @@ jobs:
     displayName: 'Build Windows Universal - $(Architecture)-$(BuildConfiguration) Symbols folder'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - pwsh: |
@@ -184,6 +185,7 @@ jobs:
     condition: and(succeeded(), eq(variables['Architecture'], 'fxdependent'))
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.


### PR DESCRIPTION
Backport of #27959 to release/v7.4.20

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27959$$$
-->

Triggered by @adityapatwardhan on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Maps the secret VSS_NUGET_EXTERNAL_FEED_ENDPOINTS pipeline variable into the build, restore, package, and test task environments so the NuGet credential provider can authenticate to external feeds consistently across Linux, macOS, and Windows release pipelines.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

The original change is pipeline configuration only and added no automated tests. The backport cherry-picked cleanly. Verified the resulting commit changes only the six intended pipeline templates with eight additive environment mappings, ran git diff --check against upstream/release/v7.4.20 successfully, and confirmed every expected VSS_NUGET_EXTERNAL_FEED_ENDPOINTS mapping with a targeted git grep. Azure Pipeline CI was not run locally and must validate template execution on the PR.

## Risk

**REQUIRED**: Check exactly one box.

- [x] High
- [ ] Medium
- [ ] Low

High risk because the change affects shared cross-platform build, restore, packaging, and test pipeline templates and credential handling. The implementation is narrowly scoped to additive secret environment mappings that mirror the existing runtime feed key pattern, with no product code changes.
