### PR TITLE
[release/v7.5.11] Merged PR 41075: Map credential provider variable as it is a secret

### DIFF
--- a/.pipelines/templates/linux.yml
+++ b/.pipelines/templates/linux.yml
@@ -109,6 +109,7 @@ jobs:
     displayName: 'Build Linux - $(Runtime)'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -87,6 +87,7 @@ jobs:
     displayName: 'Build'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - template: /.pipelines/templates/step/finalize.yml@self
 

--- a/.pipelines/templates/nupkg.yml
+++ b/.pipelines/templates/nupkg.yml
@@ -156,6 +156,7 @@ jobs:
     displayName: Build reference assemblies
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - task: onebranch.pipeline.signing@1
     displayName: Sign ref assemblies

--- a/.pipelines/templates/release-validate-sdk.yml
+++ b/.pipelines/templates/release-validate-sdk.yml
@@ -142,6 +142,7 @@ jobs:
       displayName: Restore and execute tests
       env:
         __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+        VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
     - task: PublishTestResults@2
       displayName: 'Publish Test Results **\test-hosting.xml'

--- a/.pipelines/templates/testartifacts.yml
+++ b/.pipelines/templates/testartifacts.yml
@@ -65,6 +65,7 @@ jobs:
     retryCountOnTaskFailure: 1
     env:
       ob_restore_phase: true
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - pwsh: |
       Write-Host "This doesn't do anything but make the build phase run."
@@ -132,6 +133,7 @@ jobs:
     retryCountOnTaskFailure: 1
     env:
       ob_restore_phase: true
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
 
   - pwsh: |
       Write-Host "This doesn't do anything but make the build phase run."

--- a/.pipelines/templates/windows-hosted-build.yml
+++ b/.pipelines/templates/windows-hosted-build.yml
@@ -125,6 +125,7 @@ jobs:
     displayName: 'Build Windows Universal - $(Architecture)-$(BuildConfiguration) Symbols folder'
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - pwsh: |
@@ -184,6 +185,7 @@ jobs:
     condition: and(succeeded(), eq(variables['Architecture'], 'fxdependent'))
     env:
       __DOTNET_RUNTIME_FEED_KEY: $(RUNTIME_SOURCEFEED_KEY)
+      VSS_NUGET_EXTERNAL_FEED_ENDPOINTS: $(VSS_NUGET_EXTERNAL_FEED_ENDPOINTS)
       ob_restore_phase: true # Set ob_restore_phase to run this step before '🔒 Setup Signing' step.
 
   - task: CodeQL3000Finalize@0 # Add CodeQL Finalize task right after your 'Build' step.


### PR DESCRIPTION
Backport of #27959 to release/v7.5.11

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27959$$$
-->

Triggered by @daxian-dbw on behalf of @adityapatwardhan

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable mapping to build/restore steps in linux.yml, mac.yml, windows-hosted-build.yml, nupkg.yml, testartifacts.yml, and release-validate-sdk.yml, following the same secret-mapping pattern as __DOTNET_RUNTIME_FEED_KEY. Needed so NuGet external feed credentials are available during pipeline build/restore/test steps.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [ ] Yes
- [x] No

This is not a regression.

## Testing

Pipeline template change; verified original PR ran successfully in CI on master. Backport applied cleanly via cherry-pick with no conflicts.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [ ] Medium
- [x] Low

Change only adds an environment variable mapping following an existing, proven pattern; no product/runtime code affected.
