### PR TITLE
fix(engine): unwrap scalar PSObject during collection binding

### DIFF
--- a/src/System.Management.Automation/engine/ParameterBinderBase.cs
+++ b/src/System.Management.Automation/engine/ParameterBinderBase.cs
@@ -1795,6 +1795,8 @@ namespace System.Management.Automation
                         "Argument type {0} is not IList, treating this as scalar",
                         currentValue.GetType().Name);
 
+                    object currentValueElement = PSObject.Base(currentValue);
+
                     if (collectionElementType != null)
                     {
                         if (coerceElementTypeIfNeeded)
@@ -1805,7 +1807,7 @@ namespace System.Management.Automation
 
                             // Coerce the scalar type into the collection
 
-                            currentValue =
+                            currentValueElement =
                                 CoerceTypeAsNeeded(
                                     argument,
                                     parameterName,
@@ -1813,9 +1815,9 @@ namespace System.Management.Automation
                                     null,
                                     currentValue);
                         }
-                        else
+                        else if (currentValueElement != null)
                         {
-                            Type currentValueElementType = currentValue.GetType();
+                            Type currentValueElementType = currentValueElement.GetType();
                             Type desiredElementType = collectionElementType;
 
                             if (currentValueElementType != desiredElementType &&
@@ -1840,23 +1842,23 @@ namespace System.Management.Automation
                         {
                             bindingTracer.WriteLine(
                                 "Adding scalar element of type {0} to array position {1}",
-                                (currentValue == null) ? "null" : currentValue.GetType().Name,
+                                (currentValueElement == null) ? "null" : currentValueElement.GetType().Name,
                                 0);
-                            resultAsIList[0] = currentValue;
+                            resultAsIList[0] = currentValueElement;
                         }
                         else if (collectionTypeInformation.ParameterCollectionType == ParameterCollectionType.IList)
                         {
                             bindingTracer.WriteLine(
                                 "Adding scalar element of type {0} via IList.Add",
-                                (currentValue == null) ? "null" : currentValue.GetType().Name);
-                            resultAsIList.Add(currentValue);
+                                (currentValueElement == null) ? "null" : currentValueElement.GetType().Name);
+                            resultAsIList.Add(currentValueElement);
                         }
                         else
                         {
                             bindingTracer.WriteLine(
                                 "Adding scalar element of type {0} via ICollection<T>::Add()",
-                                (currentValue == null) ? "null" : currentValue.GetType().Name);
-                            addMethod.Invoke(resultCollection, new object[1] { currentValue });
+                                (currentValueElement == null) ? "null" : currentValueElement.GetType().Name);
+                            addMethod.Invoke(resultCollection, new object[1] { currentValueElement });
                         }
                     }
                     catch (Exception error) // OK, we catch all here by design
@@ -1877,10 +1879,10 @@ namespace System.Management.Automation
                                 GetErrorExtent(argument),
                                 parameterName,
                                 toType,
-                                currentValue?.GetType(),
+                                currentValueElement?.GetType(),
                                 ParameterBinderStrings.CannotConvertArgument,
                                 "CannotConvertArgument",
-                                currentValue ?? "null",
+                                currentValueElement ?? "null",
                                 error.Message);
                         throw bindingException;
                     }

--- a/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
+++ b/test/powershell/Language/Parser/ParameterBinding.Tests.ps1
@@ -472,3 +472,59 @@ Describe 'Roundtrippable Conversions for Bare-string Numeric Literals passed to 
         Invoke-Expression "Test-AdvancedStringValue -Value $Argument" | Should -BeExactly $Argument
     }
 }
+
+Describe 'Scalar PSObject binding to non-generic IList parameters' -Tags 'CI' {
+    BeforeAll {
+        $typeDefinition = @'
+using System.Collections.Specialized;
+using System.Management.Automation;
+
+namespace ScalarPSObjectCollectionBinding
+{
+    [Cmdlet(VerbsDiagnostic.Test, "ScalarStringCollectionBinding")]
+    [OutputType(typeof(string))]
+    public sealed class TestScalarStringCollectionBindingCommand : PSCmdlet
+    {
+        [Parameter(Mandatory = true)]
+        public StringCollection Value { get; set; }
+
+        protected override void ProcessRecord()
+        {
+            WriteObject(Value[0]);
+        }
+    }
+}
+'@
+
+        $types = Add-Type -PassThru -TypeDefinition $typeDefinition
+        Import-Module $types[0].Assembly
+    }
+
+    It 'binds a scalar PSObject wrapping a string to StringCollection' {
+        $value = @('expected', 'expected') | Select-Object -Unique
+
+        # Confirm that this is the specific problematic input shape.
+        $value.GetType().FullName | Should -BeExactly 'System.String'
+        ($value -is [System.Management.Automation.PSObject]) |
+            Should -BeTrue
+
+        Test-ScalarStringCollectionBinding -Value $value |
+            Should -BeExactly 'expected'
+    }
+
+    It 'continues to bind a plain scalar string' {
+        Test-ScalarStringCollectionBinding -Value 'expected' |
+            Should -BeExactly 'expected'
+    }
+
+    It 'continues to bind multiple pipeline-produced strings' {
+        $value = @('first', 'second') | Select-Object -Unique
+
+        $result = @(
+            Test-ScalarStringCollectionBinding -Value $value
+        )
+
+        # The test cmdlet writes Value[0], proving binding succeeded.
+        $result | Should -BeExactly 'first'
+    }
+}


### PR DESCRIPTION
# PR Summary

Unwrap scalar values before adding them to collection parameters, matching the existing behavior for list elements. This prevents StringCollection parameters from attempting to cast a PSObject directly to a string.

Add regression coverage for a single pipeline-produced value.

## PR Context

fixes #27969 

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [] Issue filed: 
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [x] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
