### PR TITLE
Support macOS signatures in nonofficial pipelines

### DIFF
--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -82,9 +82,9 @@ jobs:
       $signatureParameters = @{
         Path = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/drop_macos_sign_${{ parameters.buildArchitecture }}/Signed-${{ parameters.buildArchitecture }}"
         OfficialBuild = [System.Convert]::ToBoolean('${{ parameters.OfficialBuild }}')
-        EntitlementsPath = "$(Build.SourcesDirectory)/PowerShell/assets/macos-entitlements.plist"
+        EntitlementsPath = "$(Build.SourcesDirectory)/assets/macos-entitlements.plist"
       }
-      & "$(Build.SourcesDirectory)/PowerShell/tools/packaging/Update-MacOSCodeSignature.ps1" @signatureParameters
+      & "$(Build.SourcesDirectory)/tools/packaging/Update-MacOSCodeSignature.ps1" @signatureParameters
     displayName: 'Apply and verify Apple codesign on signed binaries'
 
   - pwsh: |

--- a/.pipelines/templates/mac-package-build.yml
+++ b/.pipelines/templates/mac-package-build.yml
@@ -1,6 +1,7 @@
 parameters:
   parentJob: ''
   buildArchitecture: x64
+  OfficialBuild: true
 
 jobs:
 - job: package_macOS_${{ parameters.buildArchitecture }}
@@ -78,12 +79,13 @@ jobs:
     continueOnError: true
 
   - pwsh: |
-      $signedDir = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/drop_macos_sign_${{ parameters.buildArchitecture }}/Signed-${{ parameters.buildArchitecture }}"
-      Get-ChildItem $signedDir -Recurse -Include 'pwsh', '*.dylib' | ForEach-Object {
-        codesign --verify --deep --strict --verbose=4 $_.FullName
-        if ($LASTEXITCODE -ne 0) { throw "codesign verification failed for $($_.FullName)" }
+      $signatureParameters = @{
+        Path = "$(Pipeline.Workspace)/CoOrdinatedBuildPipeline/drop_macos_sign_${{ parameters.buildArchitecture }}/Signed-${{ parameters.buildArchitecture }}"
+        OfficialBuild = [System.Convert]::ToBoolean('${{ parameters.OfficialBuild }}')
+        EntitlementsPath = "$(Build.SourcesDirectory)/PowerShell/assets/macos-entitlements.plist"
       }
-    displayName: 'Verify Apple codesign on signed binaries'
+      & "$(Build.SourcesDirectory)/PowerShell/tools/packaging/Update-MacOSCodeSignature.ps1" @signatureParameters
+    displayName: 'Apply and verify Apple codesign on signed binaries'
 
   - pwsh: |
       # Add -SkipReleaseChecks as a mitigation to unblock release.

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -190,21 +190,47 @@ jobs:
 
   - pwsh: |
       $signedDir = "$(ob_outputDirectory)/Signed-$(Runtime)"
-      $expected = 'Developer ID Application: Microsoft Corporation'
+      $officialBuild = [System.Convert]::ToBoolean('$(ps_official_build)')
+      $officialSignature = 'Developer ID Application: Microsoft Corporation'
+      $codeDirectoryMagic = [byte[]](0xfa, 0xde, 0x0c, 0x02)
       $missing = @()
       Get-ChildItem $signedDir -Recurse -Include 'pwsh', '*.dylib' | ForEach-Object {
         $bytes = [System.IO.File]::ReadAllBytes($_.FullName)
         $text = [System.Text.Encoding]::Latin1.GetString($bytes)
-        if (-not $text.Contains($expected)) {
+        $hasOfficialSignature = $text.Contains($officialSignature)
+        $hasAdHocSignature = $false
+
+        if (-not $officialBuild -and -not $hasOfficialSignature) {
+          # The package stage runs codesign --verify; here the Windows signing job
+          # verifies that unofficial output contains an ad-hoc CodeDirectory.
+          for ($offset = 0; $offset -le $bytes.Length - 16; $offset++) {
+            if ($bytes[$offset] -eq $codeDirectoryMagic[0] -and
+                $bytes[$offset + 1] -eq $codeDirectoryMagic[1] -and
+                $bytes[$offset + 2] -eq $codeDirectoryMagic[2] -and
+                $bytes[$offset + 3] -eq $codeDirectoryMagic[3] -and
+                ($bytes[$offset + 15] -band 0x02) -ne 0) {
+              $hasAdHocSignature = $true
+              break
+            }
+          }
+        }
+
+        if (-not $hasOfficialSignature -and ($officialBuild -or -not $hasAdHocSignature)) {
           $missing += $_.FullName
-          Write-Host "##[error]Missing '$expected' signature in $($_.FullName)"
+          $expectedSignature = if ($officialBuild) {
+            "'$officialSignature'"
+          } else {
+            'a Developer ID or ad-hoc'
+          }
+          Write-Host "##[error]Missing $expectedSignature signature in $($_.FullName)"
         } else {
-          Write-Host "OK: $($_.FullName)"
+          $signatureType = if ($hasOfficialSignature) { 'Developer ID' } else { 'ad-hoc' }
+          Write-Host "OK: $($_.FullName) has a $signatureType signature"
         }
       }
       if ($missing.Count -gt 0) {
-        throw "ESRP did not apply a Developer ID signature to $($missing.Count) file(s): $($missing -join ', ')"
+        throw "The expected Apple signature was not found in $($missing.Count) file(s): $($missing -join ', ')"
       }
-    displayName: 'Verify Developer ID signature on Mach-O binaries'
+    displayName: 'Verify Apple signature on Mach-O binaries'
 
   - template: /.pipelines/templates/step/finalize.yml@self

--- a/.pipelines/templates/mac.yml
+++ b/.pipelines/templates/mac.yml
@@ -220,12 +220,16 @@ jobs:
           $expectedSignature = if ($officialBuild) {
             "'$officialSignature'"
           } else {
-            'a Developer ID or ad-hoc'
+            'a Developer ID signature or ad-hoc CodeDirectory'
           }
-          Write-Host "##[error]Missing $expectedSignature signature in $($_.FullName)"
+          Write-Host "##[error]Missing $expectedSignature in $($_.FullName)"
         } else {
-          $signatureType = if ($hasOfficialSignature) { 'Developer ID' } else { 'ad-hoc' }
-          Write-Host "OK: $($_.FullName) has a $signatureType signature"
+          $signatureDescription = if ($hasOfficialSignature) {
+            'a Developer ID signature'
+          } else {
+            'an ad-hoc CodeDirectory'
+          }
+          Write-Host "OK: $($_.FullName) contains $signatureDescription"
         }
       }
       if ($missing.Count -gt 0) {

--- a/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
+++ b/.pipelines/templates/stages/PowerShell-Packages-Stages.yml
@@ -50,10 +50,12 @@ stages:
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
       buildArchitecture: x64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
   - template: /.pipelines/templates/mac-package-build.yml@self
     parameters:
       buildArchitecture: arm64
+      OfficialBuild: ${{ parameters.OfficialBuild }}
 
 - stage: windows_package_build
   displayName: 'Win Pkg (unsigned)'

--- a/tools/packaging/Update-MacOSCodeSignature.ps1
+++ b/tools/packaging/Update-MacOSCodeSignature.ps1
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Container })]
+    [string] $Path,
+
+    [Parameter(Mandatory)]
+    [bool] $OfficialBuild,
+
+    [Parameter(Mandatory)]
+    [ValidateScript({ Test-Path -LiteralPath $_ -PathType Leaf })]
+    [string] $EntitlementsPath
+)
+
+$binaries = @(
+    Get-ChildItem -LiteralPath $Path -Recurse -File |
+        Where-Object { $_.Name -eq 'pwsh' -or $_.Extension -eq '.dylib' }
+)
+
+if ($binaries.Count -eq 0) {
+    throw "No Mach-O binaries were found in '$Path'."
+}
+
+foreach ($binary in $binaries) {
+    & codesign --verify --deep --strict --verbose=4 $binary.FullName
+    if ($LASTEXITCODE -eq 0) {
+        continue
+    }
+
+    if ($OfficialBuild) {
+        throw "codesign verification failed for '$($binary.FullName)'."
+    }
+
+    # Nonofficial signing can leave only one slice of a universal binary signed.
+    # Re-signing on macOS applies an ad-hoc signature across every architecture.
+    Write-Verbose -Message "Applying an ad-hoc signature to '$($binary.FullName)' for the nonofficial package." -Verbose
+    $signArguments = @('--sign', '-', '--force', '--options', 'runtime')
+    if ($binary.Name -eq 'pwsh') {
+        $signArguments += @('--entitlements', $EntitlementsPath)
+    }
+    $signArguments += $binary.FullName
+
+    & codesign @signArguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Ad-hoc codesign failed for '$($binary.FullName)'."
+    }
+
+    & codesign --verify --deep --strict --verbose=4 $binary.FullName
+    if ($LASTEXITCODE -ne 0) {
+        throw "codesign verification failed for '$($binary.FullName)' after applying an ad-hoc signature."
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->

- Accept Microsoft Developer ID signatures or ad-hoc CodeDirectories when validating Mach-O output from nonofficial coordinated builds.
- Repair binaries that fail native verification with an ad-hoc signature on macOS package agents, then require strict `codesign` verification before packaging.
- Keep official builds verification-only and continue requiring the production Developer ID signature.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

The nonofficial signing service can return a universal `libpsl-native.dylib` with only one architecture slice signed. The coordinated Windows check found an ad-hoc CodeDirectory, but native macOS verification rejected the unsigned x86_64 slice. Nonofficial package jobs now repair only binaries that fail verification and then verify every Mach-O binary with `codesign --verify --deep --strict`.

Validation:

- [Coordinated nonofficial build 715578](https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=715578) succeeded for x64 and arm64 signature validation.
- [Packages nonofficial run 715615](https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=715615) passed both x64 and arm64 macOS package jobs, including native strict signature verification.
- The changed YAML and inline PowerShell parse successfully, PSScriptAnalyzer passes on the new helper, and local scenarios cover nonofficial repair and official verification-only behavior.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
