### PR TITLE
Cache the regex used by switch -regex

### DIFF
--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -2484,15 +2484,14 @@ namespace System.Management.Automation
                 else
                 {
                     pattern = PSObject.ToStringParser(context, condition);
-                    m = Regex.Match(str, pattern, options);
 
-                    if (m.Success && m.Groups.Count > 0)
-                    {
-                        // We used the static regex method for it's caching ability, but
-                        // we need the group names now.  Fortunately constructing another regex
-                        // isn't slow because it should be in the cache still.
-                        regex = new Regex(pattern, options);
-                    }
+                    // Use the engine's regex cache, the same one '-match', '-replace' and '-split'
+                    // use.  The static 'Regex.Match' helper caches only 'Regex.CacheSize' patterns
+                    // (15 by default), and the 'Regex' constructor never consults that cache at
+                    // all, so pairing the two recompiled the pattern on every successful match
+                    // just to get at the group names.
+                    regex = ParserOps.NewRegex(pattern, options);
+                    m = regex.Match(str);
                 }
 
                 if (m.Success)

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -33,7 +33,7 @@ namespace System.Management.Automation
                                                        CommandBaseAst commandBaseAst,
                                                        CommandRedirection[] redirections,
                                                        ExecutionContext context)
-        {
+        {   
             var commandAst = commandBaseAst as CommandAst;
             var invocationToken = commandAst != null ? commandAst.InvocationOperator : TokenKind.Unknown;
             bool dotSource = invocationToken == TokenKind.Dot;
@@ -2500,22 +2500,19 @@ namespace System.Management.Automation
 
                     if (groups.Count > 0)
                     {
-                        Diagnostics.Assert(regex != null, "Logic above ensures regex is not null.");
-
                         Hashtable h = new Hashtable(StringComparer.CurrentCultureIgnoreCase);
 
-                        foreach (string groupName in regex.GetGroupNames())
+                        foreach (Group g in groups)
                         {
-                            Group g = groups[groupName];
-                            if (g.Success)
+                            if (!g.Success)
                             {
-                                int keyInt;
-
-                                if (Int32.TryParse(groupName, out keyInt))
-                                    h.Add(keyInt, g.ToString());
-                                else
-                                    h.Add(groupName, g.ToString());
+                                continue;
                             }
+
+                            if (int.TryParse(g.Name, out int keyInt))
+                                h.Add(keyInt, g.Value);
+                            else
+                                h.Add(g.Name, g.Value);
                         }
 
                         context.SetVariable(SpecialVariables.MatchesVarPath, h);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -2485,11 +2485,6 @@ namespace System.Management.Automation
                 {
                     pattern = PSObject.ToStringParser(context, condition);
 
-                    // Use the engine's regex cache, the same one '-match', '-replace' and '-split'
-                    // use.  The static 'Regex.Match' helper caches only 'Regex.CacheSize' patterns
-                    // (15 by default), and the 'Regex' constructor never consults that cache at
-                    // all, so pairing the two recompiled the pattern on every successful match
-                    // just to get at the group names.
                     regex = ParserOps.NewRegex(pattern, options);
                     m = regex.Match(str);
                 }
@@ -2502,17 +2497,17 @@ namespace System.Management.Automation
                     {
                         Hashtable h = new Hashtable(StringComparer.CurrentCultureIgnoreCase);
 
-                        foreach (Group g in groups)
+                        foreach (string groupName in regex.GetGroupNames())
                         {
-                            if (!g.Success)
+                            Group g = groups[groupName];
+                            if (g.Success)
                             {
-                                continue;
+                                int keyInt;
+                                if (Int32.TryParse(groupName, out keyInt))
+                                    h.Add(keyInt, g.ToString());
+                                else
+                                    h.Add(groupName, g.ToString());
                             }
-
-                            if (int.TryParse(g.Name, out int keyInt))
-                                h.Add(keyInt, g.Value);
-                            else
-                                h.Add(g.Name, g.Value);
                         }
 
                         context.SetVariable(SpecialVariables.MatchesVarPath, h);

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -2495,6 +2495,8 @@ namespace System.Management.Automation
 
                     if (groups.Count > 0)
                     {
+                        Diagnostics.Assert(regex != null, "Logic above ensures regex is not null.");
+
                         Hashtable h = new Hashtable(StringComparer.CurrentCultureIgnoreCase);
 
                         foreach (string groupName in regex.GetGroupNames())
@@ -2503,6 +2505,7 @@ namespace System.Management.Automation
                             if (g.Success)
                             {
                                 int keyInt;
+
                                 if (Int32.TryParse(groupName, out keyInt))
                                     h.Add(keyInt, g.ToString());
                                 else

--- a/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
+++ b/src/System.Management.Automation/engine/runtime/Operations/MiscOps.cs
@@ -33,7 +33,7 @@ namespace System.Management.Automation
                                                        CommandBaseAst commandBaseAst,
                                                        CommandRedirection[] redirections,
                                                        ExecutionContext context)
-        {   
+        {
             var commandAst = commandBaseAst as CommandAst;
             var invocationToken = commandAst != null ? commandAst.InvocationOperator : TokenKind.Unknown;
             bool dotSource = invocationToken == TokenKind.Dot;

--- a/test/powershell/Language/Scripting/SwitchRegex.Tests.ps1
+++ b/test/powershell/Language/Scripting/SwitchRegex.Tests.ps1
@@ -1,0 +1,170 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'switch -regex' -Tags 'CI' {
+
+    Context 'Populates $matches' {
+
+        It 'Sets named groups' {
+            switch -regex ('2026-09-04 ERROR boom') {
+                '^(?<date>\S+) ERROR (?<msg>.*)$' {
+                    $matches['date'] | Should -BeExactly '2026-09-04'
+                    $matches['msg']  | Should -BeExactly 'boom'
+                }
+            }
+        }
+
+        It 'Sets numbered groups, including group 0' {
+            switch -regex ('2026-09-04 ERROR boom') {
+                '^(\S+) (ERROR) (.*)$' {
+                    $matches[0] | Should -BeExactly '2026-09-04 ERROR boom'
+                    $matches[1] | Should -BeExactly '2026-09-04'
+                    $matches[2] | Should -BeExactly 'ERROR'
+                    $matches[3] | Should -BeExactly 'boom'
+                }
+            }
+        }
+
+        It 'Exposes both named and numbered keys' {
+            # .NET numbers the unnamed groups first, so (\d+) is group 1 and the
+            # named group keeps its name -- keys are 0, 1 and 'letters'.
+            switch -regex ('abc123') {
+                '(?<letters>[a-z]+)(\d+)' {
+                    ($matches.Keys | Sort-Object { "$_" }) -join ',' |
+                        Should -BeExactly '0,1,letters'
+                }
+            }
+        }
+
+        It 'Leaves $matches from an earlier match untouched when nothing matches' {
+            switch -regex ('abc123') { '(?<first>abc)' { } }
+            $captured = $matches['first']
+
+            switch -regex ('zzz') {
+                'nomatch' { throw 'should not run' }
+                default { }
+            }
+
+            $matches['first'] | Should -BeExactly $captured
+        }
+    }
+
+    Context 'Case sensitivity' {
+
+        It 'Matches case-insensitively by default' {
+            $hit = $false
+            switch -regex ('HELLO') { 'hello' { $hit = $true } }
+            $hit | Should -BeTrue
+        }
+
+        It 'Honors -CaseSensitive' {
+            $hit = $false
+            switch -regex -casesensitive ('HELLO') { 'hello' { $hit = $true } }
+            $hit | Should -BeFalse
+        }
+    }
+
+    Context 'A [regex] instance as the clause condition' {
+        BeforeAll {
+            $re = [regex]::new('hello', [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+        }
+
+        It 'Is used as-is under a case-insensitive switch' {
+            $hit = $false
+            switch -regex ('HELLO') { $re { $hit = $true } }
+            $hit | Should -BeTrue
+        }
+
+        It 'Is rebuilt case-sensitively under -CaseSensitive' {
+            $hit = $false
+            switch -regex -casesensitive ('HELLO') { $re { $hit = $true } }
+            $hit | Should -BeFalse
+        }
+    }
+
+    Context 'Clause evaluation' {
+
+        It 'Falls through to later clauses without continue' {
+            $hits = @()
+            switch -regex ('abc123') {
+                '(?<letters>[a-z]+)' { $hits += "letters=$($matches.letters)" }
+                '(?<digits>\d+)'     { $hits += "digits=$($matches.digits)" }
+            }
+
+            $hits -join '|' | Should -BeExactly 'letters=abc|digits=123'
+        }
+
+        It 'Throws InvalidRegularExpression on a malformed pattern' {
+            { switch -regex ('x') { '[' { } } } |
+                Should -Throw -ErrorId 'InvalidRegularExpression'
+        }
+    }
+
+    Context 'More distinct clause patterns than the static regex cache holds' {
+        # The engine caches switch clause patterns itself rather than relying on
+        # [regex]::CacheSize, which defaults to 15. Exercise more distinct patterns
+        # than that, repeatedly, so a caching regression shows up as a wrong result
+        # rather than only as a slowdown.
+
+        It 'Matches the correct clause across repeated passes' {
+            $results = foreach ($i in 1..5) {
+                foreach ($n in 1..24) {
+                    $captured = $null
+                    switch -regex ("value-$n-end") {
+                        '^value-1-(?<tail>\w+)$'  { $captured = "01:$($matches.tail)"; continue }
+                        '^value-2-(?<tail>\w+)$'  { $captured = "02:$($matches.tail)"; continue }
+                        '^value-3-(?<tail>\w+)$'  { $captured = "03:$($matches.tail)"; continue }
+                        '^value-4-(?<tail>\w+)$'  { $captured = "04:$($matches.tail)"; continue }
+                        '^value-5-(?<tail>\w+)$'  { $captured = "05:$($matches.tail)"; continue }
+                        '^value-6-(?<tail>\w+)$'  { $captured = "06:$($matches.tail)"; continue }
+                        '^value-7-(?<tail>\w+)$'  { $captured = "07:$($matches.tail)"; continue }
+                        '^value-8-(?<tail>\w+)$'  { $captured = "08:$($matches.tail)"; continue }
+                        '^value-9-(?<tail>\w+)$'  { $captured = "09:$($matches.tail)"; continue }
+                        '^value-10-(?<tail>\w+)$' { $captured = "10:$($matches.tail)"; continue }
+                        '^value-11-(?<tail>\w+)$' { $captured = "11:$($matches.tail)"; continue }
+                        '^value-12-(?<tail>\w+)$' { $captured = "12:$($matches.tail)"; continue }
+                        '^value-13-(?<tail>\w+)$' { $captured = "13:$($matches.tail)"; continue }
+                        '^value-14-(?<tail>\w+)$' { $captured = "14:$($matches.tail)"; continue }
+                        '^value-15-(?<tail>\w+)$' { $captured = "15:$($matches.tail)"; continue }
+                        '^value-16-(?<tail>\w+)$' { $captured = "16:$($matches.tail)"; continue }
+                        '^value-17-(?<tail>\w+)$' { $captured = "17:$($matches.tail)"; continue }
+                        '^value-18-(?<tail>\w+)$' { $captured = "18:$($matches.tail)"; continue }
+                        '^value-19-(?<tail>\w+)$' { $captured = "19:$($matches.tail)"; continue }
+                        '^value-20-(?<tail>\w+)$' { $captured = "20:$($matches.tail)"; continue }
+                        '^value-21-(?<tail>\w+)$' { $captured = "21:$($matches.tail)"; continue }
+                        '^value-22-(?<tail>\w+)$' { $captured = "22:$($matches.tail)"; continue }
+                        '^value-23-(?<tail>\w+)$' { $captured = "23:$($matches.tail)"; continue }
+                        '^value-24-(?<tail>\w+)$' { $captured = "24:$($matches.tail)"; continue }
+                        default { $captured = 'none' }
+                    }
+
+                    $captured
+                }
+            }
+
+            $expected = foreach ($i in 1..5) {
+                foreach ($n in 1..24) { '{0:d2}:end' -f $n }
+            }
+
+            $results | Should -BeExactly $expected
+        }
+    }
+
+    Context 'switch -regex -file' {
+        BeforeAll {
+            $file = Join-Path $TestDrive 'switch-regex.txt'
+            Set-Content -Path $file -Value @('alpha 1', 'beta 2', 'gamma 3')
+        }
+
+        It 'Matches per line and populates $matches' {
+            $acc = @()
+            switch -regex -file $file {
+                '^alpha (?<n>\d)$' { $acc += "a$($matches.n)"; continue }
+                '^beta (?<n>\d)$'  { $acc += "b$($matches.n)"; continue }
+                default            { $acc += 'other' }
+            }
+
+            $acc -join ',' | Should -BeExactly 'a1,b2,other'
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`switch -regex` no longer rebuilds a `Regex` object for every line that matches, making
regex switch statements substantially faster and much lighter on allocation.

`SwitchOps.ConditionSatisfiedRegex` paired a static `Regex.Match` call with `new Regex(...)`
so it could read the group names, on the assumption — stated in the code comment — that the
constructor would hit .NET's regex cache. Only the static `Regex` methods consult that cache,
so every successful match paid a full pattern parse and matcher codegen. The guard did not
help either, since `m.Groups.Count` is at least 1 for any successful match.

This routes the branch through `ParserOps.NewRegex`, the cache that `-match`, `-replace` and
`-split` already use, and matches on that instance. The pattern and `RegexOptions` are
unchanged, so matching semantics are identical, and the existing `catch (ArgumentException)`
still fires for invalid patterns.

Also adds `test/powershell/Language/Scripting/SwitchRegex.Tests.ps1`. `switch -regex` had no
test coverage anywhere under `test/powershell`.

Fix #27975

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
Reported in #27975. Measured on a local Release build of `6ca24ccf0`, 200,000-line log,
median of 5 runs, both binaries built the same way:

| Scenario | Before | After | Change |
| --- | ---: | ---: | ---: |
| 1 clause, every line matches | 1144.0 ms | 305.3 ms | 3.7x |
| 24 clauses, past `[regex]::CacheSize` | 21764.1 ms | 858.8 ms | 25.3x |
| Allocation, 1 clause | 1008.6 MB | 250.3 MB | -75% |

The second row is a separate effect: because the old code went through the static cache,
which holds only `Regex.CacheSize` (15) patterns, a switch with more distinct clause patterns
than that recompiled every clause for every line. Allocation is the most stable signal — it is
identical at 1008.6 MB on both the unpatched local build and the shipped 7.6.5 release.

One design point worth a reviewer's attention, also raised on the issue: clause patterns are
now retained in a process-wide cache of up to 1000 entries rather than the static cache's 15,
and `[regex]::CacheSize` no longer influences `switch -regex`. That makes `switch` consistent
with the other regex operators, but it is a policy change rather than a pure optimization, so
I would rather flag it than have it found in review.

Verification: the new test file covers named and numbered groups, the exact `$matches` key
set, `$matches` left untouched on a non-match, default case-insensitivity, `-CaseSensitive`, a
`[regex]` instance as the clause condition under both switch modes, clause fallthrough, the
`InvalidRegularExpression` error id, `switch -regex -file`, and 24 distinct clause patterns
over repeated passes. It passes on both the patched and unpatched binary, since it asserts
behavior rather than speed. `test/powershell/Language` and `test/powershell/engine` (6764
tests) show no regressions against an unpatched baseline build of the same commit.

The `condition as Regex` fast path in the same method is deliberately left untouched, so this
does not interact with #8946.

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
