### PR TITLE
Centralize coordinated package pipeline stages

### DIFF
--- a/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
@@ -65,7 +65,7 @@ resources:
   - repository: PowerShellEngineeringSystem
     type: git
     name: PowerShellCore/PowerShell-Engineering-System
-    ref: refs/heads/pilot/powershell-coordinated-packages
+    ref: ac401b01fccbe26898de20a66bcde10ca019dcdd
 
 variables:
   - template: /.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml@self

--- a/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
+++ b/.pipelines/NonOfficial/PowerShell-Coordinated_Packages-NonOfficial.yml
@@ -62,6 +62,10 @@ resources:
     type: git
     name: OneBranch.Pipelines/GovernedTemplates
     ref: refs/heads/main
+  - repository: PowerShellEngineeringSystem
+    type: git
+    name: PowerShellCore/PowerShell-Engineering-System
+    ref: refs/heads/pilot/powershell-coordinated-packages
 
 variables:
   - template: /.pipelines/templates/variables/PowerShell-Coordinated_Packages-Variables.yml@self
@@ -112,7 +116,7 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
-    - template: /.pipelines/templates/stages/PowerShell-Coordinated_Packages-Stages.yml@self
+    - template: /templates/stages/powershell-coordinated-packages.yml@PowerShellEngineeringSystem
       parameters:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}

--- a/.pipelines/PowerShell-Coordinated_Packages-Official.yml
+++ b/.pipelines/PowerShell-Coordinated_Packages-Official.yml
@@ -62,6 +62,10 @@ resources:
     type: git
     name: OneBranch.Pipelines/GovernedTemplates
     ref: refs/heads/main
+  - repository: PowerShellEngineeringSystem
+    type: git
+    name: PowerShellCore/PowerShell-Engineering-System
+    ref: ac401b01fccbe26898de20a66bcde10ca019dcdd
 
 variables:
   - template: templates/variables/PowerShell-Coordinated_Packages-Variables.yml
@@ -112,7 +116,7 @@ extends:
       tsaOptionsFile: .config\tsaoptions.json
 
     stages:
-    - template: templates/stages/PowerShell-Coordinated_Packages-Stages.yml
+    - template: /templates/stages/powershell-coordinated-packages.yml@PowerShellEngineeringSystem
       parameters:
         RUN_WINDOWS: ${{ parameters.RUN_WINDOWS }}
         RUN_TEST_AND_RELEASE: ${{ parameters.RUN_TEST_AND_RELEASE }}
@@ -121,4 +125,3 @@ extends:
         DOTNET_SDK_VERSION: ${{ parameters.DOTNET_SDK_VERSION }}
         EarlyAccessFeed: ${{ parameters.EarlyAccessFeed }}
         IsEarlyAccess: ${{ parameters.IsEarlyAccess }}
-


### PR DESCRIPTION
## Summary

- consume the coordinated-package stage graph from the internal PowerShell Engineering System repository
- pin both Official and NonOfficial pipelines to an exact engineering-system commit
- preserve branch-owned product templates through nested `@self` references

## Validation

- both Official and NonOfficial definitions passed ADO YAML preview
- NonOfficial branch-reference run [715713](https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=715713) succeeded
- NonOfficial exact-pin run [715720](https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=715720) succeeded
- each successful run produced the same 88 artifact names as local-template baseline 715578
- Official run [715734](https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=715734) passed template expansion and the required `extends` check, but remains queued in the automated production-readiness check

## Dependency

The pinned template is in internal ADO PR [41524](https://dev.azure.com/mscodehub/PowerShellCore/_git/PowerShell-Engineering-System/pullrequest/41524). That PR must merge without rewriting the pinned commit, or this PR must be updated to the durable post-merge SHA before completion.

The unrelated NonOfficial macOS signature workaround used to establish a known-good test baseline is intentionally excluded from this branch.