### PR TITLE
Protect the fallback temporary home directory by enforcing and checking its file mode on Unix platforms

### DIFF
--- a/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
+++ b/src/System.Management.Automation/CoreCLR/CorePsPlatform.cs
@@ -280,7 +280,17 @@ namespace System.Management.Automation
             try
             {
                 s_tempHome = Path.Combine(Path.GetTempPath(), StringUtil.Format(tempHomeFolderName, Environment.UserName));
-                Directory.CreateDirectory(s_tempHome);
+
+                // Create the temporary home directory with the user-only permission.
+                UnixFileMode userOnlyMode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+                var dirInfo = Directory.CreateDirectory(s_tempHome, userOnlyMode);
+                if (dirInfo.UnixFileMode != userOnlyMode)
+                {
+                    // The permission is not as expected, which indicates the directory may be pre-created by a different user.
+                    // Throw an exception and fail PowerShell in this case for security reason.
+                    throw new InvalidOperationException(
+                        StringUtil.Format(CoreClrStubResources.TempHomeDirectoryUnsafePermission, s_tempHome));
+                }
             }
             catch (UnauthorizedAccessException)
             {

--- a/src/System.Management.Automation/resources/CoreClrStubResources.resx
+++ b/src/System.Management.Automation/resources/CoreClrStubResources.resx
@@ -138,4 +138,8 @@
   <data name="UnknownErrorNumber" xml:space="preserve">
     <value>Unknown error "{0}".</value>
   </data>
+  <data name="TempHomeDirectoryUnsafePermission" xml:space="preserve">
+    <value>The temporary HOME directory '{0}' already exists but does not have the expected user-only permission. It may have been created by a different user, which is a potential security risk. PowerShell will not start until this directory is removed, its permission is corrected, or the 'HOME' environment variable is set.</value>
+    <comment>{StrContains="HOME"}</comment>
+  </data>
 </root>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Protect the home fallback directory by checking its Unix permission mode -- PowerShell always creates the temporary home directory with the user-only permission, so if its mode is not what we expect, then it indicates the directory may be tampered (e.g. a different local user created it) and we fail the startup for security reason.

### PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [ ] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [x] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [x] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [x] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
