### PR TITLE
[release/v7.4.20] Add the needed variable groups to the MSIX VPack pipeline to enforce using the production ADO feed

### DIFF
--- a/.pipelines/MSIXBundle-vPack-Official.yml
+++ b/.pipelines/MSIXBundle-vPack-Official.yml
@@ -51,6 +51,8 @@ variables:
   - group: certificate_logical_to_actual # used within signing task
   - group: MSIXSigningProfile
   - group: msixTools
+  - group: mscodehub-feed-read-general
+  - group: mscodehub-feed-read-akv
 
 resources:
   repositories:


### PR DESCRIPTION
Backport of #27896 to release/v7.4.20

<!--
DO NOT MODIFY THIS COMMENT. IT IS AUTO-GENERATED.
$$$originalprnumber:27896$$$
-->

Triggered by @daxian-dbw on behalf of @daxian-dbw

Original CL Label: CL-BuildPackaging

/cc @PowerShell/powershell-maintainers

## Impact

**REQUIRED**: Choose either Tooling Impact or Customer Impact (or both). At least one checkbox must be selected.

### Tooling Impact

- [x] Required tooling change
- [ ] Optional tooling change (include reasoning)

Adds the missing variable groups to the MSIX VPack pipeline so the insert-nuget-config-azfeed.yml template's "Switch to production Azure DevOps feed" step runs, granting permission to pull packages from upstream. Needed because the early-access .NET feed work changed the Coordinate Binary build to use a different internal feed, so downstream MSIX VPack builds now need authenticated access to pull packages.

### Customer Impact

- [ ] Customer reported
- [ ] Found internally

## Regression

**REQUIRED**: Check exactly one box.

- [x] Yes
- [ ] No

Introduced by the early-access .NET feed work (e.g., in v7.6.5), which changed the Coordinate Binary build to use a different internal feed, causing the MSIX VPack pipeline to fail without authenticated access to pull packages from upstream.

## Testing

Pipeline configuration change; verified original PR fixed the MSIX VPack pipeline failure on master/downstream builds.

## Risk

**REQUIRED**: Check exactly one box.

- [ ] High
- [x] Medium
- [ ] Low

Modifies release build pipeline configuration (variable groups/feed authentication) — build infra risk — but the change is narrowly scoped to restoring a working feed-authentication step and is necessary to unblock MSIX VPack builds on this release line.
