### PR TITLE
Improve remote prompt handling for PSCredential and SecureString arrays

### DIFF
--- a/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
@@ -666,12 +666,33 @@ namespace System.Management.Automation.Internal.Host
 
         internal static bool IsSecuritySensitiveType(string typeName)
         {
-            if (typeName.Equals(nameof(PSCredential), StringComparison.OrdinalIgnoreCase))
+            // Normalize the wire-provided type name so array-typed sensitive fields are
+            // recognized in this type-name fallback (used when the Type cannot be resolved).
+            // Every array form decorates the element name with a trailing bracket group
+            // ("PSCredential[]", multidimensional "[,]"/"[,,]", non-zero-based "[*]", jagged
+            // "[][]"), and assembly-qualified names append ", <assembly>, Version=...". Both
+            // are strictly suffixes, so cutting at the first '[' or ',' recovers the element
+            // type name for any shape. This mirrors the IsArray element-type unwrap in
+            // RemoteHostCall.PerformSecurityChecksOnHostMessage; without it such prompts would
+            // silently degrade to a cleartext string input instead of failing secure. Compare
+            // against both the short Name and the namespace-qualified FullName so the check is
+            // robust to whichever type-name variant is sent. As a fail-secure backstop the
+            // match is deliberately conservative: a false match only refuses a prompt.
+            string effectiveName = typeName;
+            int suffixIndex = effectiveName.IndexOfAny(new char[] { '[', ',' });
+            if (suffixIndex >= 0)
+            {
+                effectiveName = effectiveName.Substring(0, suffixIndex);
+            }
+
+            if (effectiveName.Equals(nameof(PSCredential), StringComparison.OrdinalIgnoreCase) ||
+                effectiveName.Equals(typeof(PSCredential).FullName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }
 
-            if (typeName.Equals(nameof(SecureString), StringComparison.OrdinalIgnoreCase))
+            if (effectiveName.Equals(nameof(SecureString), StringComparison.OrdinalIgnoreCase) ||
+                effectiveName.Equals(typeof(SecureString).FullName, StringComparison.OrdinalIgnoreCase))
             {
                 return true;
             }

--- a/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
+++ b/src/System.Management.Automation/engine/hostifaces/InternalHostUserInterface.cs
@@ -666,18 +666,6 @@ namespace System.Management.Automation.Internal.Host
 
         internal static bool IsSecuritySensitiveType(string typeName)
         {
-            // Normalize the wire-provided type name so array-typed sensitive fields are
-            // recognized in this type-name fallback (used when the Type cannot be resolved).
-            // Every array form decorates the element name with a trailing bracket group
-            // ("PSCredential[]", multidimensional "[,]"/"[,,]", non-zero-based "[*]", jagged
-            // "[][]"), and assembly-qualified names append ", <assembly>, Version=...". Both
-            // are strictly suffixes, so cutting at the first '[' or ',' recovers the element
-            // type name for any shape. This mirrors the IsArray element-type unwrap in
-            // RemoteHostCall.PerformSecurityChecksOnHostMessage; without it such prompts would
-            // silently degrade to a cleartext string input instead of failing secure. Compare
-            // against both the short Name and the namespace-qualified FullName so the check is
-            // robust to whichever type-name variant is sent. As a fail-secure backstop the
-            // match is deliberately conservative: a false match only refuses a prompt.
             string effectiveName = typeName;
             int suffixIndex = effectiveName.IndexOfAny(new char[] { '[', ',' });
             if (suffixIndex >= 0)

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
@@ -379,12 +379,24 @@ namespace System.Management.Automation.Remoting
                         Type fieldType = InternalHostUserInterface.GetFieldType(fieldDesc);
                         if (fieldType != null)
                         {
-                            if (fieldType == typeof(PSCredential))
+                            // Unwrap the element type for array-typed sensitive fields so
+                            // that PSCredential[] and SecureString[] receive the same
+                            // client-side remoting protections (caption/message rewrite,
+                            // SecureString prerequisite warning) as their scalar forms.
+                            // The host's Prompt implementation walks any IList field and
+
+                            // invokes PromptForSingleItem with the element type if the field is an array (otherwise no type is specified),
+                            // which surfaces the typed credential dialog / secure-string
+                            // input per element. Without this unwrap those per-element
+                            // prompts run under attacker-controlled caption/message with
+                            // no remote-origin indication.
+                            Type effectiveType = fieldType.IsArray ? fieldType.GetElementType() : fieldType;
+                            if (effectiveType == typeof(PSCredential))
                             {
                                 havePSCredential = true;
                                 fieldDesc.ModifiedByRemotingProtocol = true;
                             }
-                            else if (fieldType == typeof(System.Security.SecureString))
+                            else if (effectiveType == typeof(System.Security.SecureString))
                             {
                                 prerequisiteCalls.Add(ConstructWarningMessageForSecureString(
                                     computerName, RemotingErrorIdStrings.RemoteHostPromptSecureStringPrompt));

--- a/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
+++ b/src/System.Management.Automation/engine/remoting/common/WireDataFormat/RemoteHost.cs
@@ -379,17 +379,6 @@ namespace System.Management.Automation.Remoting
                         Type fieldType = InternalHostUserInterface.GetFieldType(fieldDesc);
                         if (fieldType != null)
                         {
-                            // Unwrap the element type for array-typed sensitive fields so
-                            // that PSCredential[] and SecureString[] receive the same
-                            // client-side remoting protections (caption/message rewrite,
-                            // SecureString prerequisite warning) as their scalar forms.
-                            // The host's Prompt implementation walks any IList field and
-
-                            // invokes PromptForSingleItem with the element type if the field is an array (otherwise no type is specified),
-                            // which surfaces the typed credential dialog / secure-string
-                            // input per element. Without this unwrap those per-element
-                            // prompts run under attacker-controlled caption/message with
-                            // no remote-origin indication.
                             Type effectiveType = fieldType.IsArray ? fieldType.GetElementType() : fieldType;
                             if (effectiveType == typeof(PSCredential))
                             {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
This pull request improves handling of PSCredential and SecureString types in PowerShell remoting, including cases where these types are used in arrays or specified with assembly-qualified names. The changes ensure these types are consistently recognized and processed across a wider range of remoting scenarios
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->

## PR Checklist

- [x] [PR has a meaningful title](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
  - Use the present tense and imperative mood when describing your changes
- [x] [Summarized changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] [Make sure all `.h`, `.cpp`, `.cs`, `.ps1` and `.psm1` files have the correct copyright header](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
- [x] This PR is ready to merge. If this PR is a work in progress, please open this as a [Draft Pull Request and mark it as Ready to Review when it is ready to merge](https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests).
- **[Breaking changes](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#making-breaking-changes)**
  - [ ] None
  - **OR**
  - [ ] [Experimental feature(s) needed](https://github.com/MicrosoftDocs/PowerShell-Docs/blob/main/reference/7.5/Microsoft.PowerShell.Core/About/about_Experimental_Features.md)
    - [ ] Experimental feature name(s): <!-- Experimental feature name(s) here -->
- **User-facing changes**
  - [ ] Not Applicable
  - **OR**
  - [ ] [Documentation needed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#pull-request---submission)
    - [ ] Issue filed: <!-- Number/link of that issue here -->
- **Testing - New and feature**
  - [ ] N/A or can only be tested interactively
  - **OR**
  - [ ] [Make sure you've added a new test if existing tests do not effectively test the code changed](https://github.com/PowerShell/PowerShell/blob/master/.github/CONTRIBUTING.md#before-submitting)
